### PR TITLE
CTD Fixes, Weapon Support, Better Serialization, Quality of Life

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ skse64
 skse64_common
 xbyak
 tracy
+*.vcxproj
+*.vcxproj
+*.filters

--- a/hdtSMP64/DynamicHDT.cpp
+++ b/hdtSMP64/DynamicHDT.cpp
@@ -22,16 +22,14 @@ std::string hdt::util::UInt32toString(UInt32 formID)
 void hdt::util::transferCurrentPosesBetweenSystems(hdt::SkyrimSystem* src, hdt::SkyrimSystem* dst)
 {
 	for (auto& b1 : src->getBones()) {
-		for (auto& b2 : dst->getBones()) {
-			if (b1->m_name && b1->m_name == b2->m_name) {
-				if (b2->m_rig.isStaticOrKinematicObject())break;
-				if (b1->m_rig.isStaticOrKinematicObject())break;
 
+		for (auto& b2 : dst->getBones()) {
+
+			if (b1->m_name && b1->m_name == b2->m_name) {
 				b2->m_rig.setWorldTransform(b1->m_rig.getWorldTransform());
 				b2->m_rig.setAngularVelocity(b1->m_rig.getAngularVelocity());
 				b2->m_rig.setLinearVelocity(b1->m_rig.getLinearVelocity());
-				b2->m_localToRig = b1->m_localToRig;
-				b2->m_rigToLocal = b1->m_rigToLocal;
+
 				break;
 			}
 		}

--- a/hdtSMP64/dhdtOverrideManager.cpp
+++ b/hdtSMP64/dhdtOverrideManager.cpp
@@ -21,61 +21,6 @@ bool checkPapyrusExtension() {
 	return true;
 }
 
-void hdt::Override::OverrideManager::saveOverrideData(std::string save_name)
-{
-	if (!g_hasPapyrusExtension)return;
-
-	Console_Print("[DynamicHDT] -- Saving override data to \"%s\".", (OVERRIDE_SAVE_PATH + save_name + ".dhdt").c_str());
-	std::ofstream ofs(OVERRIDE_SAVE_PATH + save_name + ".dhdt", std::ios::out);
-	if (!ofs) {
-		Console_Print("[DynamicHDT] Warning! -- Failed writing override file. File \"%s\" is not accessable.", (OVERRIDE_SAVE_PATH + save_name + ".dhdt").c_str());
-		return;
-	}
-	for (auto& e : m_ActorPhysicsFileSwapList) {
-		char buff[16];
-		sprintf_s(buff, "%08X", e.first);
-		ofs << std::hex << buff << " " <<std::dec<< e.second.size() << std::endl;
-		for (auto& e1 : e.second) {
-			if (e1.second.empty())continue;
-			ofs << e1.first << "\t" << e1.second << std::endl;
-		}
-	}
-	ofs.close();
-}
-
-void hdt::Override::OverrideManager::loadOverrideData(std::string save_name)
-{
-
-	if (!checkPapyrusExtension())return;
-
-	save_name = save_name.substr(0, save_name.find_last_of("."));
-
-	std::ifstream ifs(OVERRIDE_SAVE_PATH + save_name + ".dhdt", std::ios::in | std::ios::_Nocreate);
-	if (!ifs) {
-		Console_Print("[DynamicHDT] Warning! -- Failed reading override file. File \"%s\" doesn't exist or is not accessable.", (OVERRIDE_SAVE_PATH + save_name + ".dhdt").c_str());
-		return;
-	}
-	try {
-		while (!ifs.eof()) {
-			UInt32 actor_formID, override_size = 0;
-			ifs >> std::hex >> actor_formID >> override_size;
-			for (int i = 0; i < override_size; ++i) {
-				std::string orig_physics_file, override_physics_file;
-				ifs >> orig_physics_file >> override_physics_file;
-				this->registerOverride(actor_formID, orig_physics_file, override_physics_file);
-			}
-		}
-	}catch (std::exception& e) {
-
-			Console_Print("[DynamicHDT] ERROR! -- Failed parsing override data.");
-
-			Console_Print("[DynamicHDT] Error(): %s\nWhat():\n\t%s", typeid(e).name(), e.what());
-
-			return;
-	}
-	ifs.close();
-}
-
 std::string hdt::Override::OverrideManager::queryOverrideData()
 {
 	std::string console_print("[DynamicHDT] -- Querying existing override data...\n");
@@ -113,4 +58,45 @@ std::string hdt::Override::OverrideManager::checkOverride(UInt32 actor_formID, s
 		}
 	}
 	return std::string();
+}
+
+std::stringstream hdt::Override::OverrideManager::Serialize()
+{
+	std::stringstream data_stream;
+	if (!g_hasPapyrusExtension)return data_stream;
+
+	for (auto& e : m_ActorPhysicsFileSwapList) {
+		char buff[16];
+		sprintf_s(buff, "%08X", e.first);
+		data_stream << std::hex << buff << " " << std::dec << e.second.size() << std::endl;
+		for (auto& e1 : e.second) {
+			if (e1.second.empty())continue;
+			data_stream << e1.first << "\t" << e1.second << std::endl;
+		}
+	}
+	return data_stream;
+}
+
+void hdt::Override::OverrideManager::Deserialize(std::stringstream& data_stream)
+{
+	if (!checkPapyrusExtension())return;
+	try {
+		while (!data_stream.eof()) {
+			UInt32 actor_formID, override_size = 0;
+			data_stream >> std::hex >> actor_formID >> override_size;
+			for (int i = 0; i < override_size; ++i) {
+				std::string orig_physics_file, override_physics_file;
+				data_stream >> orig_physics_file >> override_physics_file;
+				this->registerOverride(actor_formID, orig_physics_file, override_physics_file);
+			}
+		}
+	}
+	catch (std::exception& e) {
+
+		Console_Print("[DynamicHDT] ERROR! -- Failed parsing override data.");
+
+		Console_Print("[DynamicHDT] Error(): %s\nWhat():\n\t%s", typeid(e).name(), e.what());
+
+		return;
+	}
 }

--- a/hdtSMP64/dhdtOverrideManager.h
+++ b/hdtSMP64/dhdtOverrideManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "DynamicHDT.h"
 #include <fstream>
+#include <hdtSerialization.h>
 
 extern bool g_hasPapyrusExtension;
 
@@ -8,16 +9,21 @@ namespace hdt {
 	namespace Override {
 
 		//The formID of the armoraddon in ArmorAttachEvent cannot be acquired, which makes it impossible to check override by the formID upon attaching armoraddon.
-		class OverrideManager{
+		class OverrideManager:public Serializer<void>{
 		public:
-			OverrideManager() = default;
 			~OverrideManager() {};
 
+			//Override virtual methods inherited from Serializer
+			UInt32 FormatVersion() override { return 1; };
+
+			UInt32 StorageName() override { return 'APFW'; };
+
+			std::stringstream Serialize() override;
+
+			void Deserialize(std::stringstream&) override;
+			//Inherit End
+
 			static OverrideManager* GetSingleton();
-
-			void saveOverrideData(std::string save_name);
-
-			void loadOverrideData(std::string save_name);
 
 			std::string queryOverrideData();
 
@@ -26,6 +32,7 @@ namespace hdt {
 			std::string checkOverride(UInt32 actor_formID, std::string old_file_path);
 
 		protected:
+			OverrideManager() = default;
 			std::unordered_map<UInt32, std::unordered_map<std::string, std::string>> m_ActorPhysicsFileSwapList;
 		};
 	}

--- a/hdtSMP64/dhdtPapyrusFunctions.cpp
+++ b/hdtSMP64/dhdtPapyrusFunctions.cpp
@@ -31,7 +31,7 @@ bool hdt::papyrus::ReloadPhysicsFile(StaticFunctionTag* base, Actor* on_actor, T
 			Console_Print("[DynamicHDT] -- Couldn't parse parameters: on_actor(ptr: %016X), on_item(ptr: %016X).", reinterpret_cast<UInt64>(on_actor), reinterpret_cast<UInt64>(on_item));
 		return false;
 	}
-
+	
 	const auto& AM = hdt::ActorManager::instance();
 
 	auto& skeletons = AM->getSkeletons();
@@ -87,16 +87,25 @@ bool hdt::papyrus::ReloadPhysicsFile(StaticFunctionTag* base, Actor* on_actor, T
 
 					SkyrimPhysicsWorld::get()->suspendSimulationUntilFinished([&]() {
 
-						system = SkyrimSystemCreator().updateSystem(armor.m_physics, skeleton.npc, armor.armorWorn, armor.physicsFile, std::move(renameMap));
+						if (armor.hasPhysics())
+							system = SkyrimSystemCreator().updateSystem(armor.m_physics, skeleton.npc, armor.armorWorn, armor.physicsFile, std::move(renameMap));
+						else
+							system = SkyrimSystemCreator().createSystem(skeleton.npc, armor.armorWorn, armor.physicsFile, std::move(renameMap));
 
-						system->block_resetting = true;
+						if (!system) {
+							if(armor.hasPhysics())
+								armor.clearPhysics();
+						}
+						else {
+							system->block_resetting = true;
 
-						util::transferCurrentPosesBetweenSystems(armor.m_physics, system);
+							if (armor.hasPhysics())
+								util::transferCurrentPosesBetweenSystems(armor.m_physics, system);
 
-						armor.setPhysics(system, true);
+							armor.setPhysics(system, true);
 
-						system->block_resetting = false;
-
+							system->block_resetting = false;
+						}
 						}
 					);
 
@@ -189,16 +198,25 @@ bool hdt::papyrus::SwapPhysicsFile(StaticFunctionTag* base, Actor* on_actor, BSF
 
 					SkyrimPhysicsWorld::get()->suspendSimulationUntilFinished([&]() {
 
-						system = SkyrimSystemCreator().updateSystem(armor.m_physics, skeleton.npc, armor.armorWorn, armor.physicsFile, std::move(renameMap));
+						if (armor.hasPhysics())
+							system = SkyrimSystemCreator().updateSystem(armor.m_physics, skeleton.npc, armor.armorWorn, armor.physicsFile, std::move(renameMap));
+						else
+							system = SkyrimSystemCreator().createSystem(skeleton.npc, armor.armorWorn, armor.physicsFile, std::move(renameMap));
 
-						system->block_resetting = true;
+						if (!system) {
+							if (armor.hasPhysics())
+								armor.clearPhysics();
+						}
+						else {
+							system->block_resetting = true;
 
-						util::transferCurrentPosesBetweenSystems(armor.m_physics, system);
+							if(armor.hasPhysics())
+								util::transferCurrentPosesBetweenSystems(armor.m_physics, system);
 
-						armor.setPhysics(system, true);
+							armor.setPhysics(system, true);
 
-						system->block_resetting = false;
-
+							system->block_resetting = false;
+						}
 						}
 					);
 
@@ -292,6 +310,36 @@ BSFixedString hdt::papyrus::QueryCurrentPhysicsFile(StaticFunctionTag* base, Act
 		);
 
 	return physics_file_path.c_str();
+}
+
+UInt32 hdt::papyrus::FindOrCreateAnonymousSystem(StaticFunctionTag* base, TESObjectARMA* system_model, bool verbose_log)
+{
+	
+	return UInt32();
+}
+
+UInt32 hdt::papyrus::AttachAnonymousSystem(StaticFunctionTag* base, Actor* on_actor, UInt32 system_handle, bool verbose_log)
+{
+	if (!on_actor || !system_handle) {
+		if (verbose_log)
+			Console_Print("[DynamicHDT] -- Couldn't parse parameters: on_actor(ptr: %016X), system_handle(%08X).", reinterpret_cast<UInt64>(on_actor), system_handle);
+		return false;
+	}
+
+
+
+	return UInt32();
+}
+
+UInt32 hdt::papyrus::DetachAnonymousSystem(StaticFunctionTag* base, Actor* on_actor, UInt32 system_handle, bool verbose_log)
+{
+	if (!on_actor || !system_handle) {
+		if (verbose_log)
+			Console_Print("[DynamicHDT] -- Couldn't parse parameters: on_actor(ptr: %016X), system_handle(%08X).", reinterpret_cast<UInt64>(on_actor), system_handle);
+		return false;
+	}
+
+	return UInt32();
 }
 
 

--- a/hdtSMP64/dhdtPapyrusFunctions.h
+++ b/hdtSMP64/dhdtPapyrusFunctions.h
@@ -16,6 +16,12 @@ namespace hdt {
 		bool SwapPhysicsFile(StaticFunctionTag* base, Actor* on_actor, BSFixedString old_physics_file_path, BSFixedString new_physics_file_path, bool persist, bool verbose_log);
 
 		BSFixedString QueryCurrentPhysicsFile(StaticFunctionTag* base, Actor* on_actor, TESObjectARMA* on_item, bool verbose_log);
+
+		UInt32 FindOrCreateAnonymousSystem(StaticFunctionTag* base, TESObjectARMA* system_model, bool verbose_log);
+
+		UInt32 AttachAnonymousSystem(StaticFunctionTag* base, Actor* on_actor, UInt32 system_handle, bool verbose_log);
+
+		UInt32 DetachAnonymousSystem(StaticFunctionTag* base, Actor* on_actor, UInt32 system_handle, bool verbose_log);
 	}
 
 }

--- a/hdtSMP64/hdtSMP64.vcxproj
+++ b/hdtSMP64/hdtSMP64.vcxproj
@@ -2912,6 +2912,7 @@ copy "$(TargetDir)hdtSMP64.pdb" "$(TargetDir)..\..\..\..\..\Faster HDT-SMP\$(Con
     <ClInclude Include="hdtConvertNi.h" />
     <ClInclude Include="hdtDefaultBBP.h" />
     <ClInclude Include="hdtForceUpdateList.h" />
+    <ClInclude Include="hdtSerialization.h" />
     <ClInclude Include="hdtSkinnedMesh\hdtAABB.h" />
     <ClInclude Include="hdtSkinnedMesh\hdtBone.h" />
     <ClInclude Include="hdtSkinnedMesh\hdtBoneScaleConstraint.h" />
@@ -3150,6 +3151,7 @@ copy "$(TargetDir)hdtSMP64.pdb" "$(TargetDir)..\..\..\..\..\Faster HDT-SMP\$(Con
     <ClCompile Include="hdtConvertNi.cpp" />
     <ClCompile Include="hdtDefaultBBP.cpp" />
     <ClCompile Include="hdtForceUpdateList.cpp" />
+    <ClCompile Include="hdtSerialization.cpp" />
     <ClCompile Include="hdtSkinnedMesh\hdtAabb.cpp" />
     <ClCompile Include="hdtSkinnedMesh\hdtBoneScaleConstraint.cpp" />
     <ClCompile Include="hdtSkinnedMesh\hdtCollider.cpp" />

--- a/hdtSMP64/hdtSerialization.cpp
+++ b/hdtSMP64/hdtSerialization.cpp
@@ -1,0 +1,5 @@
+#include "hdtSerialization.h"
+
+namespace hdt {
+	std::vector<SerializerBase*> g_SerializerList;
+}

--- a/hdtSMP64/hdtSerialization.h
+++ b/hdtSMP64/hdtSerialization.h
@@ -1,0 +1,88 @@
+#pragma once
+#include <string>
+#include <sstream>
+#include <vector>
+#include <iostream>
+#include <skse64/Serialization.h>
+
+namespace hdt {
+	class SerializerBase;
+
+	extern PluginHandle g_PluginHandle;
+
+	extern std::vector<SerializerBase*> g_SerializerList;
+
+	class SerializerBase {
+	public:
+		SerializerBase() {};
+		~SerializerBase() {};
+		virtual UInt32 StorageName() = 0;
+		virtual UInt32 FormatVersion() = 0;
+
+		virtual void SaveData(SKSESerializationInterface*) = 0;
+
+		virtual void ReadData(SKSESerializationInterface*, UInt32) = 0;
+
+		static inline std::vector<SerializerBase*>& GetSerializerList() { return g_SerializerList; };
+
+		static void Save(SKSESerializationInterface* intfc) {
+			for (auto data_block : g_SerializerList) {
+				data_block->SaveData(intfc);
+			}
+		};
+
+		static void Load(SKSESerializationInterface* intfc) {
+			UInt32 type, version, length;
+			while (intfc->GetNextRecordInfo(&type, &version, &length)) {
+				auto record = std::find_if(g_SerializerList.begin(), g_SerializerList.end(), [type, version](SerializerBase* a_srlzr) {
+					return type == a_srlzr->StorageName() && version == a_srlzr->FormatVersion();
+					}
+				);
+				if (record == g_SerializerList.end())continue;
+
+				(*record)->ReadData(intfc, length);
+			}
+		};
+	};
+
+	template<class _Storage_t = void, class _Stream_t = std::stringstream>
+	class Serializer :public SerializerBase {
+	public:
+		Serializer() {
+			g_SerializerList.push_back(this);
+		};
+
+		~Serializer() {};
+
+		virtual _Stream_t Serialize() = 0;
+		virtual _Storage_t Deserialize(_Stream_t&) = 0;
+
+		void SaveData(SKSESerializationInterface*) override;
+
+		void ReadData(SKSESerializationInterface*, UInt32) override;
+
+	protected:
+		static inline std::string _toString(_Stream_t& _stream) {
+			return _stream.rdbuf()->str();
+		};
+	};
+	
+	template<class _Storage_t, class _Stream_t>
+	inline void Serializer<_Storage_t, _Stream_t>::SaveData(SKSESerializationInterface* intfc)
+	{
+		_Stream_t s_data_block = this->Serialize();
+		intfc->OpenRecord(this->StorageName(), this->FormatVersion());
+		intfc->WriteRecordData(_toString(s_data_block).c_str(), _toString(s_data_block).length());
+	}
+
+	template<class _Storage_t, class _Stream_t>
+	inline void Serializer<_Storage_t, _Stream_t>::ReadData(SKSESerializationInterface* intfc, UInt32 length)
+	{
+		char* data_block = nullptr;
+		intfc->ReadRecordData(data_block, length);
+
+		std::string s_data(data_block, length);
+		_Stream_t _stream; _stream << s_data;
+		this->Deserialize(_stream);
+	}
+}

--- a/hdtSMP64/hdtSkyrimBone.cpp
+++ b/hdtSMP64/hdtSkyrimBone.cpp
@@ -111,14 +111,16 @@ namespace hdt
 		m_node->m_worldTransform = m_node->m_worldTransform;
 
 		if (m_forceUpdateType == 1) {
-			NiAVObject::ControllerUpdateContext ctx{ 0,0 };
-			m_node->UpdateDownwardPass(&ctx, 0x0);
+			updateTransformUpDown(m_node, false);
 		}
 		else if (m_forceUpdateType == 2) {
-			for (int j = 0; j < m_node->m_children.m_size; j++) {
+			for (int j = 0; j < m_node->m_children.m_size; ++j) {
 				auto m_weapon_node = m_node->m_children.m_data[j];
-				NiAVObject::ControllerUpdateContext ctx{ 0,0 };
-				m_weapon_node->UpdateDownwardPass(&ctx, 0x0);
+				//Why when re-equipping things some nodes turn into nullptr?
+				//Equipment skeleton renamed weapon bones which were romoved when the equipment was disattahced.
+				if (!m_weapon_node)continue;
+				m_weapon_node->m_worldTransform = m_node->m_worldTransform;
+				updateTransformUpDown(m_weapon_node,false);
 			}
 		}
 
@@ -131,4 +133,15 @@ namespace hdt
 
 		//updateTransformUpDown(m_node->GetAsNiNode());
 	}
+
+
+	//void SkyrimBone::debugPrint(std::string name) {
+	//	if (this->m_name == name && SkyrimPhysicsWorld::get()->isSuspended() == false) {
+	//		auto tf0 = m_rig.getWorldTransform().getOrigin();
+	//		auto tf = (convertNi(m_skeleton->m_worldTransform).inverse() * convertNi(m_node->m_worldTransform)).getOrigin();
+	//		auto tf1 = (convertNi(m_node->m_parent->m_parent->m_worldTransform).inverse() * convertNi(m_node->m_worldTransform)).getOrigin();
+
+	//		Console_Print("wrote transforms bone %s [%.3f, %.3f, %.3f] | [%.3f, %.3f, %.3f] | [%.3f, %.3f, %.3f], %d, Kinematic: %s", m_node->m_name, tf0.x(), tf0.y(), tf0.z(), tf.x(), tf.y(), tf.z(), tf1.x(), tf1.y(), tf1.z(), clock(), m_rig.isStaticOrKinematicObject() ? "true" : "false");
+	//	}
+	//}
 }


### PR DESCRIPTION
1) Fixed the issue that Papyrus Functions would cause CTD when replacing or replacing with Empty Systems.
2) Support for Weapon nodes.
3) Fixed potential weapon node related CTDs.
4) Data serialization now bases SKSE's serialization method.
5) Smoothened pose transition between systems when calling papyrus functions.