### PR TITLE
fix: make ActorManager members threadsafe

### DIFF
--- a/hdtSMP64/ActorManager.h
+++ b/hdtSMP64/ActorManager.h
@@ -179,11 +179,11 @@ namespace hdt
 		// @brief On this event, we decide which skeletons will be active for physics this frame.
 		void onEvent(const FrameEvent& e) override;
 
+		void onEvent(const MenuOpenCloseEvent&);
 		void onEvent(const ShutdownEvent&) override;
 		void onEvent(const SkinSingleHeadGeometryEvent&) override;
 		void onEvent(const SkinAllHeadGeometryEvent&) override;
 
-		void reloadMeshes();
 #ifdef ANNIVERSARY_EDITION
 		bool skeletonNeedsParts(NiNode* skeleton);
 #endif
@@ -197,5 +197,7 @@ namespace hdt
 		float m_maxDistance2 = 1e8f; // The maxDistance value needs to be transformed to be useful, this is the useful value.
 		float m_maxAngle = 45.0f;
 		float m_cosMaxAngle2 = 0.5f; // The maxAngle value needs to be transformed to be useful, this is the useful value.
+	private:
+		void setSkeletonsActive();
 	};
 }

--- a/hdtSMP64/main.cpp
+++ b/hdtSMP64/main.cpp
@@ -43,18 +43,14 @@ namespace hdt
 			if (evn && evn->opening && (!strcmp(evn->menuName.data, "Loading Menu") || !strcmp(
 				evn->menuName.data, "RaceSex Menu")))
 			{
-#ifdef _DEBUG
 				_DMESSAGE("loading menu/racesexmenu detected, scheduling physics reset on world un-suspend");
-#endif // _DEBUG
 				SkyrimPhysicsWorld::get()->suspend(true);
 			}
 
 			if (evn && !evn->opening && !strcmp(evn->menuName.data, "RaceSex Menu"))
 			{
-#ifdef _DEBUG
 				_DMESSAGE("racemenu closed, reloading meshes");
-#endif // _DEBUG
-				ActorManager::instance()->reloadMeshes();
+				ActorManager::instance()->onEvent(*evn);
 			}
 
 			return kEvent_Continue;
@@ -361,7 +357,8 @@ namespace hdt
 			Console_Print("running full smp reset");
 			hdt::loadConfig();
 			SkyrimPhysicsWorld::get()->resetTransformsToOriginal();
-			ActorManager::instance()->reloadMeshes();
+			const MenuOpenCloseEvent e { false };
+			ActorManager::instance()->onEvent(e);
 			SkyrimPhysicsWorld::get()->resetSystems();
 			return true;
 		}


### PR DESCRIPTION
ActorManager:reloadMeshes was modifying the ActorManager members (like the
Skeleton->head->headparts list) without protecting these modifications with
ActorManager.m_lock.
Problems might have happened in 2 cases: 'smp reset' and when closing
the RaceSex menu.