### PR TITLE
fix: fix multi-threading problems

### DIFF
--- a/hdtSMP64/ActorManager.cpp
+++ b/hdtSMP64/ActorManager.cpp
@@ -116,7 +116,7 @@ namespace hdt
 			if (!b1) continue;
 			for (auto& b2 : dst->getBones()) {
 				if (!b2) continue;
-				if (_match_name(b1->m_name, b2->m_name)) {
+				if (util::_match_name(b1->m_name, b2->m_name)) {
 					b2->m_rig.setWorldTransform(b1->m_rig.getWorldTransform());
 					b2->m_rig.setAngularVelocity(b1->m_rig.getAngularVelocity());
 					b2->m_rig.setLinearVelocity(b1->m_rig.getLinearVelocity());
@@ -124,19 +124,6 @@ namespace hdt
 				}
 			}
 		}
-	}
-
-	bool ActorManager::_match_name(hdt::IDStr& a, hdt::IDStr& b) {
-		if (!a || !b) return false;
-		return _deprefix(a->cstr()) == _deprefix(b->cstr());
-	}
-
-	std::string ActorManager::_deprefix(std::string str_with_prefix) {
-		std::string str_no_prefix = str_with_prefix;
-		if (str_with_prefix.find("hdtSSEPhysics_AutoRename_") == 0) {
-			str_no_prefix = str_with_prefix.substr(str_with_prefix.find(' ') + 1);
-		}
-		return str_no_prefix;
 	}
 
 	std::pair<ActorManager::Armor*, ActorManager::Skeleton*> ActorManager::findArmor(UInt32 on_actor_formID, UInt32 on_item_formID, std::string old_physics_file_path)

--- a/hdtSMP64/ActorManager.h
+++ b/hdtSMP64/ActorManager.h
@@ -185,10 +185,6 @@ namespace hdt
 
 		void transferCurrentPosesBetweenSystems(hdt::SkyrimSystem* src, hdt::SkyrimSystem* dst);
 
-		static bool _match_name(hdt::IDStr& a, hdt::IDStr& b);
-
-		static std::string _deprefix(std::string str_with_prefix);
-
 		// @brief We loop through the skeletons to find those which owner is on_actor_formID;
 		// for those, if on_item_formID is defined, then we look for the worn armor with that formID;
 		// then if the old_physics_file_path is set, we check that the armor has this path;
@@ -228,4 +224,17 @@ namespace hdt
 		void setSkeletonsActive();
 		std::vector<Skeleton>& getSkeletons();
 	};
+
+	namespace util {
+		inline static std::string _deprefix(std::string str_with_prefix) {
+			return str_with_prefix.find("hdtSSEPhysics_AutoRename_") == 0
+				? str_with_prefix.substr(str_with_prefix.find(' ') + 1)
+				: str_with_prefix;
+		}
+
+		inline static bool _match_name(IDStr& a, IDStr& b) {
+			if (!a || !b) return false;
+			return _deprefix(a->cstr()) == _deprefix(b->cstr());
+		}
+	}
 }

--- a/hdtSMP64/ActorManager.h
+++ b/hdtSMP64/ActorManager.h
@@ -141,6 +141,8 @@ namespace hdt
 			static NiNode* cloneNodeTree(NiNode* src, IString* prefix, std::unordered_map<IDStr, IDStr>& map);
 			static void renameTree(NiNode* root, IString* prefix, std::unordered_map<IDStr, IDStr>& map);
 
+			// FIXME we expose through a public fonction the address to a vector, in a multi-thread environment.
+			// If one thread modifies the vector, while another iterates on it, this might lead to a CTD.
 			std::vector<Armor>& getArmors() { return armors; }
 
 			// @brief This is the squared distance between the skeleton and the camera.
@@ -159,9 +161,9 @@ namespace hdt
 
 		bool m_shutdown = false;
 		std::recursive_mutex m_lock;
+		// FIXME we expose publically the address to a vector, in a multi-thread environment.
+		// If one thread modifies the vector, while another iterates on it, this might lead to a CTD.
 		std::vector<Skeleton> m_skeletons;
-
-
 
 		Skeleton& getSkeletonData(NiNode* skeleton);
 
@@ -187,6 +189,8 @@ namespace hdt
 #ifdef ANNIVERSARY_EDITION
 		bool skeletonNeedsParts(NiNode* skeleton);
 #endif
+		// FIXME we expose through a public fonction the address to a vector, in a multi-thread environment.
+		// If one thread modifies the vector, while another iterates on it, this might lead to a CTD.
 		std::vector<Skeleton>& getSkeletons();//Altered by Dynamic HDT
 
 		bool m_skinNPCFaceParts = true;

--- a/hdtSMP64/DynamicHDT.cpp
+++ b/hdtSMP64/DynamicHDT.cpp
@@ -18,32 +18,3 @@ std::string hdt::util::UInt32toString(UInt32 formID)
 	sprintf_s(buffer, "%08X", formID);
 	return std::string(buffer);
 }
-
-std::string _deprefix(std::string str_with_prefix) {
-	std::string str_no_prefix = str_with_prefix;
-	if (str_with_prefix.find("hdtSSEPhysics_AutoRename_") == 0) {
-		str_no_prefix = str_with_prefix.substr(str_with_prefix.find(' ') + 1);
-	}
-	return str_no_prefix;
-}
-
-bool _match_name(hdt::IDStr& a, hdt::IDStr& b) {
-	if (!a || !b)return false;
-	return _deprefix(a->cstr()) == _deprefix(b->cstr());
-}
-
-void hdt::util::transferCurrentPosesBetweenSystems(hdt::SkyrimSystem* src, hdt::SkyrimSystem* dst)
-{
-	for (auto& b1 : src->getBones()) {
-		if (!b1)continue;
-		for (auto& b2 : dst->getBones()) {
-			if (!b2)continue;
-			if (_match_name(b1->m_name, b2->m_name)) {
-				b2->m_rig.setWorldTransform(b1->m_rig.getWorldTransform());
-				b2->m_rig.setAngularVelocity(b1->m_rig.getAngularVelocity());
-				b2->m_rig.setLinearVelocity(b1->m_rig.getLinearVelocity());
-				break;
-			}
-		}
-	}
-}

--- a/hdtSMP64/DynamicHDT.h
+++ b/hdtSMP64/DynamicHDT.h
@@ -27,7 +27,5 @@ namespace hdt {
 		UInt32 splitArmorAddonFormID(std::string nodeName);
 
 		std::string UInt32toString(UInt32 formID);
-
-		void transferCurrentPosesBetweenSystems(hdt::SkyrimSystem* src, hdt::SkyrimSystem* dst);
 	}
 }

--- a/hdtSMP64/dhdtOverrideManager.cpp
+++ b/hdtSMP64/dhdtOverrideManager.cpp
@@ -90,7 +90,7 @@ void hdt::Override::OverrideManager::Deserialize(std::stringstream& data_stream)
 				std::string orig_physics_file, override_physics_file;
 				data_stream >> orig_physics_file >> override_physics_file;
 				//this->registerOverride(actor_formID, orig_physics_file, override_physics_file);
-				hdt::papyrus::impl::SwapPhysicsFileImpl(actor_formID, orig_physics_file, override_physics_file, true, false);
+				ActorManager::instance()->swapPhysicsFile(actor_formID, orig_physics_file, override_physics_file);
 			}
 		}
 	}

--- a/hdtSMP64/dhdtPapyrusFunctions.h
+++ b/hdtSMP64/dhdtPapyrusFunctions.h
@@ -21,15 +21,6 @@ namespace hdt {
 
 		BSFixedString QueryCurrentPhysicsFile(StaticFunctionTag* base, Actor* on_actor, TESObjectARMA* on_item, bool verbose_log);
 
-		namespace impl {
-			bool ReloadPhysicsFileImpl(UInt32 on_actor_formID, UInt32 on_item_formID, std::string physics_file_path, bool persist, bool verbose_log);
-
-			bool SwapPhysicsFileImpl(UInt32 on_actor_formID, std::string old_physics_file_path, std::string new_physics_file_path, bool persist, bool verbose_log);
-
-			std::string QueryCurrentPhysicsFileImpl(UInt32 on_actor_formID, UInt32 on_item_formID, bool verbose_log);
-		}
-
-
 		//UInt32 FindOrCreateAnonymousSystem(StaticFunctionTag* base, TESObjectARMA* system_model, bool verbose_log);
 
 		//UInt32 AttachAnonymousSystem(StaticFunctionTag* base, Actor* on_actor, UInt32 system_handle, bool verbose_log);

--- a/hdtSMP64/hdtSkinnedMesh/hdtSkinnedMeshSystem.cpp
+++ b/hdtSMP64/hdtSkinnedMesh/hdtSkinnedMeshSystem.cpp
@@ -14,9 +14,6 @@ namespace hdt
 
 	void SkinnedMeshSystem::readTransform(float timeStep)
 	{
-		if (this->block_resetting)
-			return;
-
 		for (int i = 0; i < m_bones.size(); ++i)
 			m_bones[i]->readTransform(timeStep);
 

--- a/hdtSMP64/hdtSkinnedMesh/hdtSkinnedMeshSystem.h
+++ b/hdtSMP64/hdtSkinnedMesh/hdtSkinnedMeshSystem.h
@@ -30,7 +30,6 @@ namespace hdt
 		std::vector<std::shared_ptr<btCollisionShape>> m_shapeRefs;
 		SkinnedMeshWorld* m_world = nullptr;
 
-		bool block_resetting = false;
 		std::vector<Ref<SkinnedMeshBone>>& getBones() { return m_bones; };
 
 	protected:

--- a/hdtSMP64/hdtSkyrimPhysicsWorld.cpp
+++ b/hdtSMP64/hdtSkyrimPhysicsWorld.cpp
@@ -109,13 +109,6 @@ namespace hdt
 		m_averageProcessingTime = (m_averageProcessingTime + lastProcessingTime) * 0.5;
 	}
 
-	void SkyrimPhysicsWorld::suspendSimulationUntilFinished(std::function<void(void)> process)
-	{
-		this->m_isStasis = true;
-		process();
-		this->m_isStasis = false;
-	}
-
 	btVector3 SkyrimPhysicsWorld::applyTranslationOffset()
 	{
 		btVector3 center;
@@ -271,11 +264,11 @@ namespace hdt
 
 		float interval = *(float*)(RelocationManager::s_baseAddr + offset::GameStepTimer_SlowTime);
 
-		if (interval > FLT_EPSILON && !m_suspended && !m_isStasis && !m_systems.empty())
+		if (interval > FLT_EPSILON && !m_suspended && !m_systems.empty())
 		{
 			doUpdate(interval);
 		}
-		else if (m_isStasis || (m_suspended && !m_loading))
+		else if (m_suspended && !m_loading)
 		{
 			writeTransform();
 		}

--- a/hdtSMP64/hdtSkyrimPhysicsWorld.h
+++ b/hdtSMP64/hdtSkyrimPhysicsWorld.h
@@ -53,9 +53,6 @@ namespace hdt
 			}
 		}
 
-		void suspendSimulationUntilFinished(std::function<void(void)> process);
-		std::atomic_bool m_isStasis = false;
-
 		btVector3 applyTranslationOffset();
 		void restoreTranslationOffset(const btVector3&);
 

--- a/hdtSMP64/hdtSkyrimSystem.cpp
+++ b/hdtSMP64/hdtSkyrimSystem.cpp
@@ -64,8 +64,7 @@ namespace hdt
 
 		if (timeStep <= RESET_PHYSICS)
 		{
-			if (!this->block_resetting)
-				updateTransformUpDown(m_skeleton, true);
+			updateTransformUpDown(m_skeleton, true);
 			m_lastRootRotation = convertNi(m_skeleton->m_worldTransform.rot);
 		}
 		else if (m_skeleton->m_parent == (*g_thePlayer)->GetNiNode())

--- a/hdtSMP64/main.cpp
+++ b/hdtSMP64/main.cpp
@@ -264,6 +264,8 @@ namespace hdt
 			{ActorManager::SkeletonState::e_ActiveIsPlayer, "Is player character"},
 			{ActorManager::SkeletonState::e_ActiveNearPlayer, "Is near player"} };
 
+		// FIXME not protected by a lock, might CTD during loops on skeletons, and armors.
+		// A copy of m_skeletons might be enough to protect against this risk.
 		auto skeletons = ActorManager::instance()->getSkeletons();
 		std::vector<int>order(skeletons.size());
 		std::iota(order.begin(), order.end(), 0);
@@ -429,6 +431,8 @@ namespace hdt
 			return true;
 		}
 
+		// FIXME not protected by a lock, might CTD during loops on skeletons, and armors.
+		// A copy of m_skeletons might be enough to protect against this risk.
 		auto skeletons = ActorManager::instance()->getSkeletons();
 
 		size_t activeSkeletons = 0;


### PR DESCRIPTION
Make access to ActorManager::m_skeletons and ActorManager::Skeleton::m_armors thread-safe.
CTDs might have happened when using 'smp' commands and Dynamic HDT.
