### PR TITLE
fix: we don't set the PC skeleton as active if it is in 1st person view

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/configs/configs.xml
+++ b/configs/configs.xml
@@ -42,6 +42,9 @@
             calculate the maximumActiveSkeletons. Increasing sample size will flatten outliers but can slow adjustment responsiveness.
 						Default is 5. -->
     <sampleSize>5</sampleSize>
+    <!-- disable1stPersonViewPhysics: if set to true, the physics of the PC won't be calculated when in 1st person view, to save performance.
+            Default is false. -->
+    <disable1stPersonViewPhysics>false</disable1stPersonViewPhysics>
     <!-- enableCuda: experimental GPU collision algorithm. Try this if you have a slow CPU and fast GPU -->
     <enableCuda>true</enableCuda>
   </smp>

--- a/hdtSMP64/ActorManager.cpp
+++ b/hdtSMP64/ActorManager.cpp
@@ -196,7 +196,7 @@ namespace hdt
 				i.skeleton = nullptr;
 			}
 			else if (i.hasPhysics && i.updateAttachedState(playerCell, activeSkeletons >= maxActiveSkeletons))
-					activeSkeletons++;
+				activeSkeletons++;
 		}
 
 		m_skeletons.erase(
@@ -752,8 +752,12 @@ namespace hdt
 		{
 			if (isPlayerCharacter())
 			{
-				isActive = true;
-				state = SkeletonState::e_ActiveIsPlayer;
+				// We don't set the PC skeleton as active if it is in 1st person view, to avoid calculating physics uselessly.
+				if (!isFirstPersonSkeleton(skeleton))
+				{
+					isActive = true;
+					state = SkeletonState::e_ActiveIsPlayer;
+				}
 			}
 			else if (isInPlayerView())
 			{

--- a/hdtSMP64/ActorManager.cpp
+++ b/hdtSMP64/ActorManager.cpp
@@ -752,8 +752,10 @@ namespace hdt
 		{
 			if (isPlayerCharacter())
 			{
-				// We don't set the PC skeleton as active if it is in 1st person view, to avoid calculating physics uselessly.
-				if (!isFirstPersonSkeleton(skeleton))
+				// That setting defines whether we don't set the PC skeleton as active
+				// when it is in 1st person view, to avoid calculating physics uselessly.
+				if (!(instance()->m_disable1stPersonViewPhysics // disabling?
+					&& PlayerCamera::GetSingleton()->cameraState == PlayerCamera::GetSingleton()->cameraStates[0])) // 1st person view
 				{
 					isActive = true;
 					state = SkeletonState::e_ActiveIsPlayer;

--- a/hdtSMP64/ActorManager.h
+++ b/hdtSMP64/ActorManager.h
@@ -197,6 +197,10 @@ namespace hdt
 		float m_maxDistance2 = 1e8f; // The maxDistance value needs to be transformed to be useful, this is the useful value.
 		float m_maxAngle = 45.0f;
 		float m_cosMaxAngle2 = 0.5f; // The maxAngle value needs to be transformed to be useful, this is the useful value.
+
+		// @brief Depending on this setting, we avoid to calculate the physics of the PC when it is in 1st person view.
+		bool m_disable1stPersonViewPhysics = false;
+
 	private:
 		void setSkeletonsActive();
 	};

--- a/hdtSMP64/config.cpp
+++ b/hdtSMP64/config.cpp
@@ -96,6 +96,13 @@ namespace hdt
 					if (device >= 0 && device < CudaInterface::instance()->deviceCount())
 						CudaInterface::currentDevice = device;
 				}
+#else
+				else if (reader.GetLocalName() == "enableCuda")
+				{
+					if (reader.readBool())
+						_MESSAGE("CUDA isn't built into this version.");
+				}
+				else if (reader.GetLocalName() == "cudaDevice") {}
 #endif
 				else if (reader.GetLocalName() == "maximumAngle")
 				{

--- a/hdtSMP64/config.cpp
+++ b/hdtSMP64/config.cpp
@@ -123,6 +123,8 @@ namespace hdt
 				}
 				else if (reader.GetLocalName() == "sampleSize")
 					ActorManager::instance()->m_sampleSize = std::max(reader.readInt(), 1);
+				else if (reader.GetLocalName() == "disable1stPersonViewPhysics")
+					ActorManager::instance()->m_disable1stPersonViewPhysics = reader.readBool();
 				else
 				{
 					_WARNING("Unknown config : %s", reader.GetLocalName());


### PR DESCRIPTION
to avoid calculating physics uselessly.