### PR TITLE
fix: fix scaling egression introduced in fb32e328b847794a81d4d278b5df…

### DIFF
--- a/hdtSMP64/hdtSkinnedMesh/hdtGeneric6DofConstraint.cpp
+++ b/hdtSMP64/hdtSkinnedMesh/hdtGeneric6DofConstraint.cpp
@@ -38,11 +38,8 @@ namespace hdt
 		auto factor3 = factor2 * factor;
 		auto factor5 = factor3 * factor2;
 
-		auto frameA = getFrameOffsetA();
-		auto frameB = getFrameOffsetB();
-
-		frameA.setOrigin(frameA.getOrigin() * factorA);
-		frameB.setOrigin(frameB.getOrigin() * factorB);
+		getFrameOffsetA().setOrigin(getFrameOffsetA().getOrigin() * factorA);
+		getFrameOffsetB().setOrigin(getFrameOffsetB().getOrigin() * factorB);
 		m_linearLimits.m_equilibriumPoint *= factor;
 		// target k = ma / x(kg/s^2)
 		m_linearLimits.m_springStiffness *= factor3;


### PR DESCRIPTION
…0f327ae96b64

Bug about generic scale constraints introduced in the 1.25 version.
Was visible when setting player at high scale (10): some clothes animation
would not scale gracefully.