### PR TITLE
fix: manage all the headparts, in the AE specific code

### DIFF
--- a/hdtSMP64/Hooks.cpp
+++ b/hdtSMP64/Hooks.cpp
@@ -60,9 +60,9 @@ namespace hdt
 				if (actor)
 				{
 					TESNPC* actorBase = DYNAMIC_CAST(actor->baseForm, TESForm, TESNPC);
-					for (int i = 0; i < actorBase->numHeadParts; i++)
+					for (int i = 0; i < BGSHeadPart::kNumTypes; i++)
 					{
-						BGSHeadPart* headPart = actorBase->headparts[i];
+						BGSHeadPart* headPart = actorBase->GetCurrentHeadPartByType(i);
 						ProcessHeadPart(headPart, a_skeleton);
 					}
 					if (a_skeleton->m_owner && a_skeleton->m_owner->formID == 0x14)


### PR DESCRIPTION
In 1.5.x, the internal skyrim function SkinAllGeometry internally called the SkinSingleGeometry internal skyrim function when required.

In 1.6.x, this doesn't happen, so we need to call SkinSingleGeometry ourselves. The algorithm proposed by igloomod (thanks :) ) processes one headpart by headpart type, this headpart being the first found, and supposed to be the current headpart for this type.

There was a bug in this algorithm, introduced in 60dbb0818ae61b3fce73342622ca761783907322, which consisted in managing only the n first types, n being the number of headparts. I think this resulted in some missing headparts, in particular visible in bug reports about new races.

This bug has been first fixed in 530bb71098b3bc95d8a9baa60f303b34f182da26 by processing all the headparts.

In 1.6.353, although this fixes the invisibility bug, it made more prevalent the missing headparts bugs, this being particularly visible in the vampire bug.

In 1.6.640, the invisibility bug has been reintroduced despite that bugfix.

This commit is a bugfix consisting in processing one headpart by headpart type, for every headpart type. This fixes the missing headparts bug / vampire bug in my tests.

Certains tests where the invisibility bug happened are solved by this fix (create a nord, make it a vampire, bring him into farengar's room, use 1.45+1.6.640, the nord becomes invisible in farengar's room). With this commit, he isn't invisible anymore.
I do not pretend this fixes all other invisibility bugs.