### PR TITLE
feat: add plugin support

### DIFF
--- a/hdtSMP64/PluginAPI.h
+++ b/hdtSMP64/PluginAPI.h
@@ -17,21 +17,22 @@
 * The PluginInterface pointer shall remain valid until shutdown.
 */
 
-class btDynamicsWorld;
+template<typename T> class btAlignedObjectArray;
+class btCollisionObject;
 
 namespace hdt
 {
 	//Sent right before the physics simulation begins updating
 	struct PreStepEvent
 	{
-		const btDynamicsWorld* world{ nullptr };
+		const btAlignedObjectArray<btCollisionObject*>& objects;
 		float timeStep{ 0.0f };
 	};
 
 	//Sent right after the physics simulation has finished updating
 	struct PostStepEvent
 	{
-		const btDynamicsWorld* world{ nullptr };
+		const btAlignedObjectArray<btCollisionObject*>& objects;
 		float timeStep{ 0.0f };
 	};
 
@@ -61,7 +62,7 @@ namespace hdt
 
 	public:
 		//Consider the interface to be unstable for now
-		constexpr static Version INTERFACE_VERSION{ 0, 1, 0 };
+		constexpr static Version INTERFACE_VERSION{ 0, 2, 0 };
 		
 		//Is this defined somewhere already? Should it be?
 		constexpr static Version BULLET_VERSION{ 3, 24, 0 };

--- a/hdtSMP64/PluginAPI.h
+++ b/hdtSMP64/PluginAPI.h
@@ -22,14 +22,17 @@ class btCollisionObject;
 
 namespace hdt
 {
-	//Sent right before the physics simulation begins updating
+	//Sent right before the physics simulation begins updating.
+	//Only forces and torques may be applied during this event.
+	//The collision objects must in every other regard be treated as read-only.
 	struct PreStepEvent
 	{
 		const btAlignedObjectArray<btCollisionObject*>& objects;
 		float timeStep{ 0.0f };
 	};
 
-	//Sent right after the physics simulation has finished updating
+	//Sent right after the physics simulation has finished updating.
+	//The collision objects must in every regard be treated as read-only.
 	struct PostStepEvent
 	{
 		const btAlignedObjectArray<btCollisionObject*>& objects;
@@ -61,10 +64,7 @@ namespace hdt
 		};
 
 	public:
-		//Consider the interface to be unstable for now
 		constexpr static Version INTERFACE_VERSION{ 0, 2, 0 };
-		
-		//Is this defined somewhere already? Should it be?
 		constexpr static Version BULLET_VERSION{ 3, 24, 0 };
 
 	public:

--- a/hdtSMP64/PluginAPI.h
+++ b/hdtSMP64/PluginAPI.h
@@ -1,0 +1,80 @@
+#pragma once
+#include "IEventListener.h"
+
+/*Plugins should register for messages from hdtSMP64 via SKSE during SKSE's PostLoad event.
+* When ready, hdtSMP64 will send a message of type MSG_STARTUP containing a PluginInterface* as data.
+* 
+* A plugin MUST verify compatibility with the interface version before calling any other functions.
+* The interface version is semantic, meaning that
+*	- any incompatible API change increments the MAJOR version
+*	- any backwards-compatible new feature increments the MINOR version
+*	- a PATCH update does not change anything in this API
+* 
+* A plugin MUST verify compatibility with the Bullet version if it intends to interact with any Bullet object.
+* Refer to Bullet documentation for information about their versioning scheme.
+* 
+* If compatible, the plugin may call other functions on the PluginInterface at any time.
+* The PluginInterface pointer shall remain valid until shutdown.
+*/
+
+class btDynamicsWorld;
+
+namespace hdt
+{
+	//Sent right before the physics simulation begins updating
+	struct PreStepEvent
+	{
+		const btDynamicsWorld* world{ nullptr };
+		float timeStep{ 0.0f };
+	};
+
+	//Sent right after the physics simulation has finished updating
+	struct PostStepEvent
+	{
+		const btDynamicsWorld* world{ nullptr };
+		float timeStep{ 0.0f };
+	};
+
+	using IPreStepListener = IEventListener<PreStepEvent>;
+	using IPostStepListener = IEventListener<PostStepEvent>;
+
+	class PluginInterface
+	{
+	public:
+		enum MessageType : unsigned long
+		{
+			MSG_STARTUP,
+		};
+
+		struct Version
+		{
+			int major;
+			int minor;
+			int patch;
+		};
+
+		struct VersionInfo
+		{
+			Version interfaceVersion;
+			Version bulletVersion;
+		};
+
+	public:
+		//Consider the interface to be unstable for now
+		constexpr static Version INTERFACE_VERSION{ 0, 1, 0 };
+		
+		//Is this defined somewhere already? Should it be?
+		constexpr static Version BULLET_VERSION{ 2, 89, 0 };
+
+	public:
+		virtual ~PluginInterface() = default;
+
+		virtual const VersionInfo& getVersionInfo() const = 0;
+
+		virtual void addListener(IPreStepListener*) = 0;
+		virtual void removeListener(IPreStepListener*) = 0;
+
+		virtual void addListener(IPostStepListener*) = 0;
+		virtual void removeListener(IPostStepListener*) = 0;
+	};
+}

--- a/hdtSMP64/PluginInterfaceImpl.cpp
+++ b/hdtSMP64/PluginInterfaceImpl.cpp
@@ -1,0 +1,58 @@
+#include "PluginInterfaceImpl.h"
+
+hdt::PluginInterfaceImpl hdt::g_pluginInterface;
+
+void hdt::PluginInterfaceImpl::addListener(IPreStepListener* l)
+{
+	if (l)
+	{
+		m_preStepDispatcher.addListener(l);
+	}
+}
+
+void hdt::PluginInterfaceImpl::removeListener(IPreStepListener* l)
+{
+	if (l)
+	{
+		m_preStepDispatcher.removeListener(l);
+	}
+}
+
+void hdt::PluginInterfaceImpl::addListener(IPostStepListener* l)
+{
+	if (l)
+	{
+		m_postStepDispatcher.addListener(l);
+	}
+}
+
+void hdt::PluginInterfaceImpl::removeListener(IPostStepListener* l)
+{
+	if (l)
+	{
+		m_postStepDispatcher.removeListener(l);
+	}
+}
+
+void hdt::PluginInterfaceImpl::onPostPostLoad()
+{
+	//Send ourselves to any plugin that registered during the PostLoad event
+	if (m_skseMessagingInterface)
+	{
+		m_skseMessagingInterface->Dispatch(m_sksePluginHandle, PluginInterface::MSG_STARTUP, static_cast<PluginInterface*>(this), 0, nullptr);
+	}
+}
+
+void hdt::PluginInterfaceImpl::init(const SKSEInterface* skse)
+{
+	//We need to have our SKSE plugin handle and the messaging interface in order to reach our plugins later
+	if (skse)
+	{
+		m_sksePluginHandle = skse->GetPluginHandle();
+		m_skseMessagingInterface = reinterpret_cast<SKSEMessagingInterface*>(skse->QueryInterface(kInterface_Messaging));
+	}
+	if (!m_skseMessagingInterface)
+	{
+		_WARNING("Failed to get a messaging interface. Plugins will not work.");
+	}
+}

--- a/hdtSMP64/PluginInterfaceImpl.h
+++ b/hdtSMP64/PluginInterfaceImpl.h
@@ -1,0 +1,43 @@
+#pragma once
+#include "skse64/PluginAPI.h"
+
+#include "EventDispatcherImpl.h"
+#include "PluginAPI.h"
+
+namespace hdt
+{
+	class PluginInterfaceImpl final : public PluginInterface
+	{
+	public:
+		PluginInterfaceImpl() = default;
+		~PluginInterfaceImpl() = default;
+
+		PluginInterfaceImpl(const PluginInterfaceImpl&) = delete;
+		PluginInterfaceImpl& operator=(const PluginInterfaceImpl&) = delete;
+
+		virtual const VersionInfo& getVersionInfo() const { return m_versionInfo; }
+
+		virtual void addListener(IPreStepListener* l) override;
+		virtual void removeListener(IPreStepListener* l) override;
+
+		virtual void addListener(IPostStepListener* l) override;
+		virtual void removeListener(IPostStepListener* l) override;
+
+		void onPostPostLoad();
+
+		void onPreStep(const PreStepEvent& e) { m_preStepDispatcher.dispatch(e); }
+		void onPostStep(const PostStepEvent& e) { m_postStepDispatcher.dispatch(e); }
+
+		void init(const SKSEInterface* skse);
+
+	private:
+		VersionInfo m_versionInfo{ INTERFACE_VERSION, BULLET_VERSION };
+		EventDispatcherImpl<PreStepEvent> m_preStepDispatcher;
+		EventDispatcherImpl<PostStepEvent> m_postStepDispatcher;
+
+		PluginHandle m_sksePluginHandle;
+		SKSEMessagingInterface* m_skseMessagingInterface;
+	};
+
+	extern PluginInterfaceImpl g_pluginInterface;
+}

--- a/hdtSMP64/hdtSMP64.vcxproj
+++ b/hdtSMP64/hdtSMP64.vcxproj
@@ -5824,6 +5824,7 @@ copy "$(SolutionDir)configs\configs.xml" "$(TargetDir)..\..\..\..\..\Faster HDT-
     <ClInclude Include="LinearMath\TaskScheduler\btThreadSupportInterface.h" />
     <ClInclude Include="Offsets.h" />
     <ClInclude Include="PluginAPI.h" />
+    <ClInclude Include="PluginInterfaceImpl.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="XmlInspector\CharactersReader.hpp" />
     <ClInclude Include="XmlInspector\CharactersWriter.hpp" />
@@ -6022,6 +6023,7 @@ copy "$(SolutionDir)configs\configs.xml" "$(TargetDir)..\..\..\..\..\Faster HDT-
     <ClCompile Include="LinearMath\TaskScheduler\btThreadSupportPosix.cpp" />
     <ClCompile Include="LinearMath\TaskScheduler\btThreadSupportWin32.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="PluginInterfaceImpl.cpp" />
     <ClCompile Include="XmlReader.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/hdtSMP64/hdtSMP64.vcxproj
+++ b/hdtSMP64/hdtSMP64.vcxproj
@@ -5823,6 +5823,7 @@ copy "$(SolutionDir)configs\configs.xml" "$(TargetDir)..\..\..\..\..\Faster HDT-
     <ClInclude Include="LinearMath\btVector3.h" />
     <ClInclude Include="LinearMath\TaskScheduler\btThreadSupportInterface.h" />
     <ClInclude Include="Offsets.h" />
+    <ClInclude Include="PluginAPI.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="XmlInspector\CharactersReader.hpp" />
     <ClInclude Include="XmlInspector\CharactersWriter.hpp" />

--- a/hdtSMP64/hdtSMP64.vcxproj.filters
+++ b/hdtSMP64/hdtSMP64.vcxproj.filters
@@ -856,6 +856,9 @@
     <ClInclude Include="hdtSerialization.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="PluginAPI.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="hdtSkinnedMesh\hdtAabb.cpp">

--- a/hdtSMP64/hdtSMP64.vcxproj.filters
+++ b/hdtSMP64/hdtSMP64.vcxproj.filters
@@ -859,6 +859,9 @@
     <ClInclude Include="PluginAPI.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="PluginInterfaceImpl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="hdtSkinnedMesh\hdtAabb.cpp">
@@ -1435,6 +1438,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="hdtSerialization.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PluginInterfaceImpl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/hdtSMP64/hdtSkyrimPhysicsWorld.cpp
+++ b/hdtSMP64/hdtSkyrimPhysicsWorld.cpp
@@ -1,6 +1,8 @@
 #include "hdtSkyrimPhysicsWorld.h"
 #include <ppl.h>
 #include "Offsets.h"
+#include "PluginInterfaceImpl.h"
+
 #include "skse64/GameMenus.h"
 
 namespace hdt
@@ -91,11 +93,17 @@ namespace hdt
 				const auto remainingTimeStep = std::min(m_accumulatedInterval, tick * m_maxSubSteps);
 
 				readTransform(remainingTimeStep);
+
+				g_pluginInterface.onPreStep({ this, remainingTimeStep});
+
 				updateActiveState();
 				auto offset = applyTranslationOffset();
 				stepSimulation(remainingTimeStep, 0/*=maxSubSteps, ignored*/, tick);
 				restoreTranslationOffset(offset);
 				m_accumulatedInterval = 0;
+
+				g_pluginInterface.onPostStep({ this, remainingTimeStep });
+
 				writeTransform();
 			}
 		}

--- a/hdtSMP64/hdtSkyrimPhysicsWorld.cpp
+++ b/hdtSMP64/hdtSkyrimPhysicsWorld.cpp
@@ -94,7 +94,7 @@ namespace hdt
 
 				readTransform(remainingTimeStep);
 
-				g_pluginInterface.onPreStep({ this, remainingTimeStep});
+				g_pluginInterface.onPreStep({ getCollisionObjectArray(), remainingTimeStep });
 
 				updateActiveState();
 				auto offset = applyTranslationOffset();
@@ -102,7 +102,7 @@ namespace hdt
 				restoreTranslationOffset(offset);
 				m_accumulatedInterval = 0;
 
-				g_pluginInterface.onPostStep({ this, remainingTimeStep });
+				g_pluginInterface.onPostStep({ getCollisionObjectArray(), remainingTimeStep });
 
 				writeTransform();
 			}

--- a/hdtSMP64/main.cpp
+++ b/hdtSMP64/main.cpp
@@ -567,6 +567,8 @@ extern "C" {
 			_FATALERROR("Couldn't create codegen buffer. This is fatal. Skipping remainder of init process.");
 			return false;
 		}
+
+		hdt::g_PluginHandle = skse->GetPluginHandle();
 #endif // ANNIVERSARY_EDITION
 
 		hdt::g_frameEventDispatcher.addListener(hdt::ActorManager::instance());

--- a/hdtSMP64/main.cpp
+++ b/hdtSMP64/main.cpp
@@ -12,6 +12,7 @@
 #include "Hooks.h"
 #include "Offsets.h"
 #include "HookEvents.h"
+#include "PluginInterfaceImpl.h"
 
 #include <numeric>
 
@@ -578,6 +579,8 @@ extern "C" {
 
 		hdt::hookAll();
 
+		hdt::g_pluginInterface.init(skse);
+
 		const auto messageInterface = reinterpret_cast<SKSEMessagingInterface*>(skse->QueryInterface(kInterface_Messaging));
 		if (messageInterface)
 		{
@@ -630,6 +633,12 @@ extern "C" {
 							data << ifs.rdbuf();
 							hdt::Override::OverrideManager::GetSingleton()->Deserialize(data);
 						}
+					}
+
+					//Send our public interface to registered plugins
+					if (msg && msg->type == SKSEMessagingInterface::kMessage_PostPostLoad)
+					{
+						hdt::g_pluginInterface.onPostPostLoad();
 					}
 				});
 		}


### PR DESCRIPTION
Allows third-party SKSE plugins to interact with the physics world.

The system works by sending a public interface via SKSE at startup. Any other SKSE plugin may use this interface to register listeners for physics update events. On receiving such an event, the plugin may access and interact with the physics world.