### PR TITLE
feat: Non-Hookean springs & many config options

### DIFF
--- a/hdtSMP64/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.h
+++ b/hdtSMP64/BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.h
@@ -94,6 +94,10 @@ public:
 	btScalar m_currentPosition;
 	int m_currentLimit;
 
+	// BM: Definitely a better way to do this, but yay dirty hacks for Skyrims.
+	btScalar m_nonHookeanDamping;
+	btScalar m_nonHookeanStiffness;
+
 	btRotationalLimitMotor2()
 	{
 		m_loLimit = 1.0f;
@@ -119,6 +123,9 @@ public:
 		m_currentLimitErrorHi = 0;
 		m_currentPosition = 0;
 		m_currentLimit = 0;
+
+		m_nonHookeanDamping = 0.f;
+		m_nonHookeanStiffness = 0.f;
 	}
 
 	btRotationalLimitMotor2(const btRotationalLimitMotor2& limot)
@@ -146,6 +153,9 @@ public:
 		m_currentLimitErrorHi = limot.m_currentLimitErrorHi;
 		m_currentPosition = limot.m_currentPosition;
 		m_currentLimit = limot.m_currentLimit;
+
+		m_nonHookeanDamping = limot.m_nonHookeanDamping;
+		m_nonHookeanStiffness = limot.m_nonHookeanStiffness;
 	}
 
 	bool isLimited()
@@ -187,6 +197,10 @@ public:
 	btVector3 m_currentLinearDiff;
 	int m_currentLimit[3];
 
+	// BM: Definitely a better way to do this, but yay dirty hacks for Skyrims.
+	btVector3 m_nonHookeanDamping;
+	btVector3 m_nonHookeanStiffness;
+
 	btTranslationalLimitMotor2()
 	{
 		m_lowerLimit.setValue(0.f, 0.f, 0.f);
@@ -216,6 +230,9 @@ public:
 			m_maxMotorForce[i] = btScalar(0.f);
 
 			m_currentLimit[i] = 0;
+
+			m_nonHookeanDamping[i] = btScalar(0.f);
+			m_nonHookeanStiffness[i] = btScalar(0.f);
 		}
 	}
 
@@ -248,6 +265,9 @@ public:
 			m_maxMotorForce[i] = other.m_maxMotorForce[i];
 
 			m_currentLimit[i] = other.m_currentLimit[i];
+
+			m_nonHookeanDamping[i] = other.m_nonHookeanDamping[i];
+			m_nonHookeanStiffness[i] = other.m_nonHookeanStiffness[i];
 		}
 	}
 
@@ -464,6 +484,8 @@ public:
 
 	void enableSpring(int index, bool onOff);
 	void setStiffness(int index, btScalar stiffness, bool limitIfNeeded = true);  // if limitIfNeeded is true the system will automatically limit the stiffness in necessary situations where otherwise the spring would move unrealistically too widely
+	void setNonHookeanDamping(int index, btScalar factor);                        // Increases spring damping by factor (using a power of 2 curve), the closer the current position is to equilibrium.
+	void setNonHookeanStiffness(int index, btScalar factor);                      // Increases spring stiffness the further position is from equilibrium, by this factor (power curve).
 	void setDamping(int index, btScalar damping, bool limitIfNeeded = true);      // if limitIfNeeded is true the system will automatically limit the damping in necessary situations where otherwise the spring would blow up
 	void setEquilibriumPoint();                                                   // set the current constraint position/orientation as an equilibrium point for all DOF
 	void setEquilibriumPoint(int index);                                          // set the current constraint position/orientation as an equilibrium point for given DOF

--- a/hdtSMP64/hdtSkyrimSystem.cpp
+++ b/hdtSMP64/hdtSkyrimSystem.cpp
@@ -1290,6 +1290,52 @@ namespace hdt
 			{
 				auto name = m_reader->GetName();
 				if (parseFrameType(name, dest.frameType, dest.frame));
+				else if (name == "enableLinearSprings")
+					dest.enableLinearSprings = m_reader->readBool();
+				else if (name == "enableAngularSprings")
+					dest.enableAngularSprings = m_reader->readBool();
+				else if (name == "linearStiffnessLimited")
+					dest.linearStiffnessLimited = m_reader->readBool();
+				else if (name == "angularStiffnessLimited")
+					dest.angularStiffnessLimited = m_reader->readBool();
+
+				else if (name == "springDampingLimited")
+					dest.springDampingLimited = m_reader->readBool();
+				else if (name == "linearNonHookeanDamping")
+					dest.linearNonHookeanDamping = m_reader->readVector3();
+				else if (name == "angularNonHookeanDamping")
+					dest.angularNonHookeanDamping = m_reader->readVector3();
+				else if (name == "linearNonHookeanStiffness")
+					dest.linearNonHookeanStiffness = m_reader->readVector3();
+				else if (name == "angularNonHookeanStiffness")
+					dest.angularNonHookeanStiffness = m_reader->readVector3();
+
+				else if (name == "linearMotors")
+					dest.linearMotors = m_reader->readBool();
+				else if (name == "angularMotors")
+					dest.angularMotors = m_reader->readBool();
+				else if (name == "linearServoMotors")
+					dest.linearServoMotors = m_reader->readBool();
+				else if (name == "angularServoMotors")
+					dest.angularServoMotors = m_reader->readBool();
+				else if (name == "linearTargetVelocity")
+					dest.linearTargetVelocity = m_reader->readVector3();
+				else if (name == "angularTargetVelocity")
+					dest.angularTargetVelocity = m_reader->readVector3();
+				else if (name == "linearMaxMotorForce")
+					dest.linearMaxMotorForce = m_reader->readVector3();
+				else if (name == "angularMaxMotorForce")
+					dest.angularMaxMotorForce = m_reader->readVector3();
+
+				else if (name == "stopERP")
+					dest.stopERP = m_reader->readFloat();
+				else if (name == "stopCFM")
+					dest.stopCFM = m_reader->readFloat();
+				else if (name == "motorERP")
+					dest.motorERP = m_reader->readFloat();
+				else if (name == "motorCFM")
+					dest.motorCFM = m_reader->readFloat();
+
 				else if (name == "useLinearReferenceFrameA")
 					dest.useLinearReferenceFrameA = m_reader->readBool();
 				else if (name == "linearLowerLimit")
@@ -1475,12 +1521,37 @@ namespace hdt
 		constraint->setAngularUpperLimit(cinfo.angularUpperLimit);
 		for (int i = 0; i < 3; ++i)
 		{
-			constraint->setStiffness(i, cinfo.linearStiffness[i]);
-			constraint->setStiffness(i + 3, cinfo.angularStiffness[i]);
-			constraint->setDamping(i, cinfo.linearDamping[i]);
-			constraint->setDamping(i + 3, cinfo.angularDamping[i]);
+			constraint->setStiffness(i, cinfo.linearStiffness[i], cinfo.linearStiffnessLimited);
+			constraint->setStiffness(i + 3, cinfo.angularStiffness[i], cinfo.angularStiffnessLimited);
+			constraint->setDamping(i, cinfo.linearDamping[i], cinfo.springDampingLimited);
+			constraint->setDamping(i + 3, cinfo.angularDamping[i], cinfo.springDampingLimited);
 			constraint->setEquilibriumPoint(i, cinfo.linearEquilibrium[i]);
 			constraint->setEquilibriumPoint(i + 3, cinfo.angularEquilibrium[i]);
+
+			constraint->setNonHookeanDamping(i, cinfo.linearNonHookeanDamping[i]);
+			constraint->setNonHookeanDamping(i + 3, cinfo.angularNonHookeanDamping[i]);
+			constraint->setNonHookeanStiffness(i, cinfo.linearNonHookeanStiffness[i]);
+			constraint->setNonHookeanStiffness(i + 3, cinfo.angularNonHookeanStiffness[i]);
+
+			constraint->enableSpring(i, cinfo.enableLinearSprings);
+			constraint->enableSpring(i + 3, cinfo.enableAngularSprings);
+
+			constraint->enableMotor(i, cinfo.linearMotors);
+			constraint->enableMotor(i + 3, cinfo.angularMotors);
+			constraint->setServo(i, cinfo.linearServoMotors);
+			constraint->setServo(i + 3, cinfo.angularServoMotors);
+			// TODO: Test if servo motors go to [0, 0, 0], or whatever equilibrium is.  Provide option to set server motor target.  Hard coded to equilibrium right now.
+			constraint->setServoTarget(i, cinfo.linearEquilibrium[i]);
+			constraint->setServoTarget(i + 3, cinfo.angularEquilibrium[i]);
+			constraint->setTargetVelocity(i, cinfo.linearTargetVelocity[i]);
+			constraint->setTargetVelocity(i + 3, cinfo.angularTargetVelocity[i]);
+			constraint->setMaxMotorForce(i, cinfo.linearMaxMotorForce[i]);
+			constraint->setMaxMotorForce(i + 3, cinfo.angularMaxMotorForce[i]);
+
+			constraint->setParam(BT_CONSTRAINT_ERP, cinfo.motorERP, i);
+			constraint->setParam(BT_CONSTRAINT_CFM, cinfo.motorCFM, i);
+			constraint->setParam(BT_CONSTRAINT_STOP_ERP, cinfo.stopERP, i);
+			constraint->setParam(BT_CONSTRAINT_STOP_CFM, cinfo.stopCFM, i);
 		}
 		constraint->getTranslationalLimitMotor()->m_bounce = cinfo.linearBounce;
 		constraint->getRotationalLimitMotor(0)->m_bounce = cinfo.angularBounce[0];

--- a/hdtSMP64/hdtSkyrimSystem.h
+++ b/hdtSMP64/hdtSkyrimSystem.h
@@ -123,6 +123,28 @@ namespace hdt
 			btVector3 angularEquilibrium = btVector3(0, 0, 0);
 			btVector3 linearBounce = btVector3(0, 0, 0);
 			btVector3 angularBounce = btVector3(0, 0, 0);
+			bool enableLinearSprings = true;
+			bool enableAngularSprings = true;
+			bool linearStiffnessLimited = true;
+			bool angularStiffnessLimited = true;
+			bool springDampingLimited = true;
+			bool linearMotors = false;
+			bool angularMotors = false;
+			// TODO: Test if servo motors go to [0, 0, 0], or whatever equilibrium is.  Provide option to set server motor target.  Hard coded to equilibrium right now.
+			bool linearServoMotors = false;
+			bool angularServoMotors = false;
+			btVector3 linearNonHookeanDamping = btVector3(0, 0, 0);
+			btVector3 angularNonHookeanDamping = btVector3(0, 0, 0);
+			btVector3 linearNonHookeanStiffness = btVector3(0, 0, 0);
+			btVector3 angularNonHookeanStiffness = btVector3(0, 0, 0);
+			btVector3 linearTargetVelocity = btVector3(0, 0, 0);
+			btVector3 angularTargetVelocity = btVector3(0, 0, 0);
+			btVector3 linearMaxMotorForce = btVector3(0, 0, 0);
+			btVector3 angularMaxMotorForce = btVector3(0, 0, 0);
+			btScalar motorERP = 0.2f;
+			btScalar motorCFM = 0;
+			btScalar stopERP = 0.2f;
+			btScalar stopCFM = 0;
 		};
 
 		std::unordered_map<IDStr, GenericConstraintTemplate> m_genericConstraintTemplates;


### PR DESCRIPTION
Below options add to generic constraints.  All defaults as per Bullet library defaults (no change to existing files / configs).  If you want any of these features you must configure them in your constraints.

Of note, enableLinearSprings can be used per-constraint to bypass the spring algorithm entirely, increasing performance for things that just don't need to be springy.

And of much more note, setting *StiffnessLimited = false will remove the artificial damping of 6dofSpring2 constraints, allowing them to obey Hooke's Law (and also break it, but nobody's perfect).

enableLinearSprings
enableAngularSprings
linearStiffnessLimited
angularStiffnessLimited
springDampingLimited
linearMotors
angularMotors
linearServoMotors
angularServoMotors
linearNonHookeanDamping
angularNonHookeanDamping
linearNonHookeanStiffness
angularNonHookeanStiffness
linearTargetVelocity
angularTargetVelocity
linearMaxMotorForce
angularMaxMotorForce
motorERP
motorCFM
stopERP
stopCFM