### PR TITLE
refactor: remove the obsolete angularOnly tag

### DIFF
--- a/hdtSMP64/hdtSkyrimSystem.cpp
+++ b/hdtSMP64/hdtSkyrimSystem.cpp
@@ -1530,8 +1530,6 @@ namespace hdt
 			{
 				auto name = m_reader->GetName();
 				if (parseFrameType(name, dest.frameType, dest.frame));
-				else if (name == "angularOnly")
-					dest.angularOnly = m_reader->readBool();
 				else if (name == "swingSpan1" || name == "coneLimit" || name == "limitZ")
 					dest.swingSpan1 = std::max(m_reader->readFloat(), 0.f);
 				else if (name == "swingSpan2" || name == "planeLimit" || name == "limitY")
@@ -1633,7 +1631,6 @@ namespace hdt
 		Ref<ConeTwistConstraint> constraint = new ConeTwistConstraint(bodyA, bodyB, frameA, frameB);
 		constraint->setLimit(cinfo.swingSpan1, cinfo.swingSpan2, cinfo.twistSpan, cinfo.limitSoftness, cinfo.biasFactor,
 		                     cinfo.relaxationFactor);
-		constraint->setAngularOnly(cinfo.angularOnly);
 
 		return constraint;
 	}

--- a/hdtSMP64/hdtSkyrimSystem.h
+++ b/hdtSMP64/hdtSkyrimSystem.h
@@ -142,7 +142,6 @@ namespace hdt
 		{
 			btTransform frame = btTransform::getIdentity();
 			FrameType frameType = FrameInB;
-			bool angularOnly = false;
 			float swingSpan1 = 0;
 			float swingSpan2 = 0;
 			float twistSpan = 0;


### PR DESCRIPTION
This information use was obsoleted by Bullet when they obsoleted their "obsolete constraint solver".
It was passed by FSMP to the bullet engine, but was never used by it.