### PR TITLE
refactor: Remove redundant code in GroupConstraintSolver and SkinnedMeshWorld

### DIFF
--- a/src/hdtSkinnedMesh/hdtGroupConstraintSolver.cpp
+++ b/src/hdtSkinnedMesh/hdtGroupConstraintSolver.cpp
@@ -4,42 +4,42 @@
 #include <LinearMath/btCpuFeatureUtility.h>
 #include <random>
 
-#if defined (BT_ALLOW_SSE4)
-#include <intrin.h>
+#if defined(BT_ALLOW_SSE4)
+#	include <intrin.h>
 
-#define USE_FMA					1
-#define USE_FMA3_INSTEAD_FMA4	1
-#define USE_SSE4_DOT			1
+#	define USE_FMA 1
+#	define USE_FMA3_INSTEAD_FMA4 1
+#	define USE_SSE4_DOT 1
 
-#define SSE4_DP(a, b)			_mm_dp_ps(a, b, 0x7f)
-#define SSE4_DP_FP(a, b)		_mm_cvtss_f32(_mm_dp_ps(a, b, 0x7f))
+#	define SSE4_DP(a, b) _mm_dp_ps(a, b, 0x7f)
+#	define SSE4_DP_FP(a, b) _mm_cvtss_f32(_mm_dp_ps(a, b, 0x7f))
 
-#if USE_SSE4_DOT
-#define DOT_PRODUCT(a, b)		SSE4_DP(a, b)
-#else
-#define DOT_PRODUCT(a, b)		btSimdDot3(a, b)
-#endif
+#	if USE_SSE4_DOT
+#		define DOT_PRODUCT(a, b) SSE4_DP(a, b)
+#	else
+#		define DOT_PRODUCT(a, b) btSimdDot3(a, b)
+#	endif
 
-#if USE_FMA
-#if USE_FMA3_INSTEAD_FMA4
+#	if USE_FMA
+#		if USE_FMA3_INSTEAD_FMA4
 // a*b + c
-#define FMADD(a, b, c)		_mm_fmadd_ps(a, b, c)
-#define FMADD256(a, b, c)		_mm256_fmadd_ps(a, b, c)
+#			define FMADD(a, b, c) _mm_fmadd_ps(a, b, c)
+#			define FMADD256(a, b, c) _mm256_fmadd_ps(a, b, c)
 // -(a*b) + c
-#define FMNADD(a, b, c)		_mm_fnmadd_ps(a, b, c)
-#define FMNADD256(a, b, c)		_mm256_fnmadd_ps(a, b, c)
-#else // USE_FMA3
+#			define FMNADD(a, b, c) _mm_fnmadd_ps(a, b, c)
+#			define FMNADD256(a, b, c) _mm256_fnmadd_ps(a, b, c)
+#		else  // USE_FMA3
 // a*b + c
-#define FMADD(a, b, c)		_mm_macc_ps(a, b, c)
+#			define FMADD(a, b, c) _mm_macc_ps(a, b, c)
 // -(a*b) + c
-#define FMNADD(a, b, c)		_mm_nmacc_ps(a, b, c)
-#endif
-#else // USE_FMA
+#			define FMNADD(a, b, c) _mm_nmacc_ps(a, b, c)
+#		endif
+#	else  // USE_FMA
 // c + a*b
-#define FMADD(a, b, c)		_mm_add_ps(c, _mm_mul_ps(a, b))
+#		define FMADD(a, b, c) _mm_add_ps(c, _mm_mul_ps(a, b))
 // c - a*b
-#define FMNADD(a, b, c)		_mm_sub_ps(c, _mm_mul_ps(a, b))
-#endif
+#		define FMNADD(a, b, c) _mm_sub_ps(c, _mm_mul_ps(a, b))
+#	endif
 #endif
 
 namespace hdt
@@ -82,7 +82,7 @@ namespace hdt
 		//const __m128 deltaVel2Dotn = _mm_add_ps(DOT_PRODUCT(c.m_contactNormal2.mVec128, body2.internalGetDeltaLinearVelocity().mVec128), DOT_PRODUCT(c.m_relpos2CrossNormal.mVec128, body2.internalGetDeltaAngularVelocity().mVec128));
 		//deltaImpulse = FMNADD(deltaVel1Dotn, tmp, deltaImpulse);
 		//deltaImpulse = FMNADD(deltaVel2Dotn, tmp, deltaImpulse);
-		tmp = _mm_add_ps(c.m_appliedImpulse, deltaImpulse); // sum
+		tmp = _mm_add_ps(c.m_appliedImpulse, deltaImpulse);  // sum
 		auto appliedImpulse = _mm_max_ps(_mm_min_ps(tmp, upperLimit), lowerLimit);
 		deltaImpulse = _mm_sub_ps(appliedImpulse, c.m_appliedImpulse);
 		c.m_appliedImpulse = appliedImpulse;
@@ -155,223 +155,6 @@ namespace hdt
 		return deltaImpulse.m128_f32[0] / c.m_jacDiagABInv;
 	}
 
-	SolverBodyMt::SolverBodyMt()
-	{
-	}
-
-	SolverBodyMt::~SolverBodyMt()
-	{
-	}
-
-	SolverTask::SolverTask(SolverBodyMt* A, SolverBodyMt* B)
-		: m_bodyA(A), m_bodyB(B)
-	{
-		if (A > B) std::swap(A, B);
-		m_lockOrderA = A;
-		m_lockOrderB = B;
-	}
-
-	NonContactSolverTask::NonContactSolverTask(SolverBodyMt* A, SolverBodyMt* B, btSolverConstraint** begin,
-		btSolverConstraint** end, btSingleConstraintRowSolver s)
-		: SolverTask(A, B), m_begin(begin), m_end(end), m_solver(s)
-	{
-		std::random_device rng;
-		std::mt19937 urng(rng());
-		std::shuffle(m_begin, m_end, urng);
-	}
-
-	void NonContactSolverTask::solve()
-	{
-		HDT_LOCK_GUARD(la, *m_lockOrderA);
-		HDT_LOCK_GUARD(lb, *m_lockOrderB);
-
-		for (auto i = m_begin; i < m_end; ++i)
-			m_solver(*m_bodyA->m_body, *m_bodyB->m_body, **i);
-	}
-
-	ContactSolverTask::ContactSolverTask(SolverBodyMt* A, SolverBodyMt* B, btSolverConstraint* c,
-		btSolverConstraint* f0, btSolverConstraint* f1, btSingleConstraintRowSolver sl,
-		btSingleConstraintRowSolver s)
-		: SolverTask(A, B), m_contact(c), m_friction0(f0), m_friction1(f1), m_solver(s), m_solverLowerLimit(sl)
-	{
-	}
-
-	void ContactSolverTask::solve()
-	{
-		HDT_LOCK_GUARD(la, *m_lockOrderA);
-		HDT_LOCK_GUARD(lb, *m_lockOrderB);
-
-		m_solverLowerLimit(*m_bodyA->m_body, *m_bodyB->m_body, *m_contact);
-		float totalImpulse = m_contact->m_appliedImpulse;
-
-		if (totalImpulse > 0)
-		{
-			if (m_friction0)
-			{
-				m_friction0->m_lowerLimit = -(m_friction0->m_friction * totalImpulse);
-				m_friction0->m_upperLimit = m_friction0->m_friction * totalImpulse;
-				m_solver(*m_bodyA->m_body, *m_bodyB->m_body, *m_friction0);
-			}
-
-			if (m_friction1)
-			{
-				m_friction1->m_lowerLimit = -(m_friction1->m_friction * totalImpulse);
-				m_friction1->m_upperLimit = m_friction1->m_friction * totalImpulse;
-				m_solver(*m_bodyA->m_body, *m_bodyB->m_body, *m_friction1);
-			}
-		}
-	}
-
-	ObsoleteSolverTask::ObsoleteSolverTask(SolverBodyMt* A, SolverBodyMt* B, btTypedConstraint* c, float t)
-		: SolverTask(A, B), m_timeStep(t), m_constraint(c)
-	{
-	}
-
-	void ObsoleteSolverTask::solve()
-	{
-		HDT_LOCK_GUARD(la, *m_lockOrderA);
-		HDT_LOCK_GUARD(lb, *m_lockOrderB);
-		m_constraint->solveConstraintObsolete(*m_bodyA->m_body, *m_bodyB->m_body, m_timeStep);
-	}
-
-	btScalar GroupConstraintSolver::solveGroupCacheFriendlySetup(btCollisionObject** bodies, int numBodies,
-		btPersistentManifold** manifoldPtr, int numManifolds,
-		btTypedConstraint** constraints, int numConstraints,
-		const btContactSolverInfo& infoGlobal,
-		btIDebugDraw* debugDrawer)
-	{
-		auto ret = Base::solveGroupCacheFriendlySetup(bodies, numBodies, manifoldPtr, numManifolds, constraints,
-			numConstraints, infoGlobal, debugDrawer);
-
-		concurrency::parallel_for_each(m_groups.begin(), m_groups.end(), [&](ConstraintGroup* i)
-		{
-			i->setup(&m_tmpSolverBodyPool, infoGlobal);
-			i->iteration(bodies, numBodies, infoGlobal);
-		});
-
-		// init solver body
-		for (int j = 0; j < numConstraints; j++)
-		{
-			if (constraints[j]->isEnabled())
-			{
-				getOrInitSolverBody(constraints[j]->getRigidBodyA(), infoGlobal.m_timeStep);
-				getOrInitSolverBody(constraints[j]->getRigidBodyB(), infoGlobal.m_timeStep);
-			}
-		}
-
-		// init mt bodies
-		m_bodiesMt.resize(m_tmpSolverBodyPool.size());
-		for (int i = 0; i < m_bodiesMt.size(); ++i)
-			m_bodiesMt[i].m_body = &m_tmpSolverBodyPool[i];
-
-		// add tasks;
-		if (m_tmpSolverNonContactConstraintPool.size())
-		{
-			{
-				auto begin = &m_tmpSolverNonContactConstraintPool[0];
-				auto end = begin + m_tmpSolverNonContactConstraintPool.size();
-				m_nonContactConstraintRowPtrs.reserve(m_tmpSolverNonContactConstraintPool.size());
-				for (auto i = begin; i < end; ++i)
-					m_nonContactConstraintRowPtrs.push_back(i);
-
-				std::sort(m_nonContactConstraintRowPtrs.begin(), m_nonContactConstraintRowPtrs.end(),
-					[](btSolverConstraint* a, btSolverConstraint* b)
-					{
-						return ((static_cast<uint64_t>(a->m_solverBodyIdA) << 32) | a->m_solverBodyIdB) < ((
-							static_cast<uint64_t>(b->m_solverBodyIdA) << 32) | b->m_solverBodyIdB);
-					});
-			}
-
-			SolverBodyMt* lastA = nullptr;
-			SolverBodyMt* lastB = nullptr;
-			btSolverConstraint** lastBegin = m_nonContactConstraintRowPtrs.data();
-			for (int i = 0; i < m_nonContactConstraintRowPtrs.size(); ++i)
-			{
-				auto curr = &m_nonContactConstraintRowPtrs[i];
-				auto c = m_nonContactConstraintRowPtrs[i];
-				auto a = &m_bodiesMt[c->m_solverBodyIdA];
-				auto b = &m_bodiesMt[c->m_solverBodyIdB];
-				if (lastA != a || lastB != b)
-				{
-					if (lastA && lastB)
-					{
-						auto task = std::static_pointer_cast<SolverTask>(
-							std::make_shared<NonContactSolverTask>(lastA, lastB, lastBegin, curr,
-								getActiveConstraintRowSolverGeneric()));
-						m_tasks.push_back(task);
-						m_nonContactTasks.push_back(task);
-					}
-					lastA = a;
-					lastB = b;
-					lastBegin = curr;
-				}
-			}
-
-			if (lastA && lastB)
-			{
-				auto task = std::static_pointer_cast<SolverTask>(std::make_shared<NonContactSolverTask>(
-					lastA, lastB, lastBegin,
-					m_nonContactConstraintRowPtrs.data() + m_nonContactConstraintRowPtrs.size(),
-					getActiveConstraintRowSolverGeneric()));
-				m_tasks.push_back(task);
-				m_nonContactTasks.push_back(task);
-			}
-		}
-
-		for (int j = 0; j < numConstraints; j++)
-		{
-			if (constraints[j]->isEnabled())
-			{
-				btTypedConstraint::btConstraintInfo1 info1;
-				constraints[j]->getInfo1(&info1);
-				if (!info1.m_numConstraintRows && !info1.nub)
-				{
-					int bodyAid = getOrInitSolverBody(constraints[j]->getRigidBodyA(), infoGlobal.m_timeStep);
-					int bodyBid = getOrInitSolverBody(constraints[j]->getRigidBodyB(), infoGlobal.m_timeStep);
-					auto bodyA = &m_bodiesMt[bodyAid];
-					auto bodyB = &m_bodiesMt[bodyBid];
-					auto task = std::static_pointer_cast<SolverTask>(
-						std::make_shared<ObsoleteSolverTask>(bodyA, bodyB, constraints[j], infoGlobal.m_timeStep));
-					m_tasks.push_back(task);
-					m_nonContactTasks.push_back(task);
-				}
-			}
-		}
-
-		for (int i = 0; i < m_tmpSolverContactConstraintPool.size(); ++i)
-		{
-			int multiplier = (infoGlobal.m_solverMode & SOLVER_USE_2_FRICTION_DIRECTIONS) ? 2 : 1;
-			auto c = &m_tmpSolverContactConstraintPool[i];
-			auto a = &m_bodiesMt[c->m_solverBodyIdA];
-			auto b = &m_bodiesMt[c->m_solverBodyIdB];
-			auto f0 = &m_tmpSolverContactFrictionConstraintPool[i * multiplier];
-			auto f1 = infoGlobal.m_solverMode & SOLVER_USE_2_FRICTION_DIRECTIONS
-				? &m_tmpSolverContactFrictionConstraintPool[i * multiplier + 1]
-				: nullptr;
-			auto task = std::static_pointer_cast<SolverTask>(std::make_shared<ContactSolverTask>(
-				a, b, c, f0, f1, getActiveConstraintRowSolverLowerLimit(), getActiveConstraintRowSolverGeneric()));
-			m_tasks.push_back(task);
-			m_contactTasks.push_back(task);
-		}
-
-		std::random_device rng;
-		std::mt19937 urng(rng());
-		std::shuffle(m_tasks.begin(), m_tasks.end(), urng);
-		return ret;
-	}
-
-	btScalar GroupConstraintSolver::solveGroupCacheFriendlyFinish(btCollisionObject** bodies, int numBodies,
-		const btContactSolverInfo& infoGlobal)
-	{
-		auto ret = Base::solveGroupCacheFriendlyFinish(bodies, numBodies, infoGlobal);
-		m_tasks.clear();
-		m_contactTasks.clear();
-		m_nonContactTasks.clear();
-		m_bodiesMt.clear();
-		m_nonContactConstraintRowPtrs.clear();
-		return ret;
-	}
-
 	btSingleConstraintRowSolver GroupConstraintSolver::getResolveSingleConstraintRowGenericAVX()
 	{
 		return gResolveSingleConstraintRowGeneric_avx256;
@@ -380,40 +163,5 @@ namespace hdt
 	btSingleConstraintRowSolver GroupConstraintSolver::getResolveSingleConstraintRowLowerLimitAVX()
 	{
 		return gResolveSingleConstraintRowLowerLimit_avx256;
-	}
-
-	GroupConstraintSolver::GroupConstraintSolver()
-	{
-		int cpuFeatures = btCpuFeatureUtility::getCpuFeatures();
-		if ((cpuFeatures & btCpuFeatureUtility::CPU_FEATURE_FMA3) && (cpuFeatures & btCpuFeatureUtility::
-			CPU_FEATURE_SSE4_1))
-		{
-			m_resolveSingleConstraintRowGeneric = gResolveSingleConstraintRowGeneric_avx256;
-			m_resolveSingleConstraintRowLowerLimit = gResolveSingleConstraintRowLowerLimit_avx256;
-		}
-	}
-
-	btScalar GroupConstraintSolver::solveSingleIteration(int iteration, [[maybe_unused]] btCollisionObject** bodies, [[maybe_unused]] int numBodies, [[maybe_unused]] btPersistentManifold** manifoldPtr, [[maybe_unused]] int numManifolds, [[maybe_unused]]  btTypedConstraint** constraints, [[maybe_unused]] int numConstraints, const btContactSolverInfo& infoGlobal, [[maybe_unused]] btIDebugDraw* debugDrawer)
-	{
-		int maxIterations = m_maxOverrideNumSolverIterations > infoGlobal.m_numIterations
-			? m_maxOverrideNumSolverIterations
-			: infoGlobal.m_numIterations;
-		if (iteration <= (maxIterations * 3 + 3) / 4)
-		{
-			concurrency::parallel_for_each(m_tasks.begin(), m_tasks.end(),
-			                               [](const SolverTaskPtr& task) { task->solve(); });
-		}
-		else
-		{
-			std::random_device rng;
-			std::mt19937 urng(rng());
-			std::shuffle(m_nonContactTasks.begin(), m_nonContactTasks.end(), urng);
-			std::shuffle(m_contactTasks.begin(), m_contactTasks.end(), urng);
-			concurrency::parallel_for_each(m_nonContactTasks.begin(), m_nonContactTasks.end(),
-			                               [](const SolverTaskPtr& task) { task->solve(); });
-			concurrency::parallel_for_each(m_contactTasks.begin(), m_contactTasks.end(),
-			                               [](const SolverTaskPtr& task) { task->solve(); });
-		}
-		return FLT_MAX;
 	}
 }

--- a/src/hdtSkinnedMesh/hdtGroupConstraintSolver.h
+++ b/src/hdtSkinnedMesh/hdtGroupConstraintSolver.h
@@ -1,123 +1,15 @@
 #pragma once
 
-#include <BulletDynamics/ConstraintSolver/btNNCGConstraintSolver.h>
-#include <BulletDynamics/ConstraintSolver/btSequentialImpulseConstraintSolverMt.h>
-#include <BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.h>
-#include <BulletDynamics/MLCPSolvers/btMLCPSolver.h>
 #include "hdtSkinnedMeshSystem.h"
-
-#include <mutex>
 
 namespace hdt
 {
-	struct SolverBodyMt
+	class GroupConstraintSolver
 	{
 	public:
-		SolverBodyMt();
-		~SolverBodyMt();
-
-		btSolverBody* m_body;
-
-		void lock() { m_lock.lock(); }
-		void unlock() { m_lock.unlock(); }
-
-		SolverBodyMt(const SolverBodyMt& rhs) : m_body(rhs.m_body)
-		{
-		}
-
-		SolverBodyMt& operator=(const SolverBodyMt& rhs) { m_body = rhs.m_body; }
-
-	private:
-		SpinLock m_lock;
-	};
-
-	class SolverTask
-	{
-	public:
-		SolverTask(SolverBodyMt* A, SolverBodyMt* B);
-
-		virtual ~SolverTask()
-		{
-		}
-
-		virtual void solve() = 0;
-
-	protected:
-		SolverBodyMt* m_bodyA;
-		SolverBodyMt* m_bodyB;
-		SolverBodyMt* m_lockOrderA;
-		SolverBodyMt* m_lockOrderB;
-	};
-
-	typedef std::shared_ptr<SolverTask> SolverTaskPtr;
-
-	class NonContactSolverTask : public SolverTask
-	{
-	public:
-
-		NonContactSolverTask(SolverBodyMt* A, SolverBodyMt* B, btSolverConstraint** begin, btSolverConstraint** end,
-		                     btSingleConstraintRowSolver s);
-		void solve() override;
-
-	protected:
-		btSolverConstraint** m_begin;
-		btSolverConstraint** m_end;
-		btSingleConstraintRowSolver m_solver;
-	};
-
-	class ObsoleteSolverTask : public SolverTask
-	{
-	public:
-
-		ObsoleteSolverTask(SolverBodyMt* A, SolverBodyMt* B, btTypedConstraint* c, float t);
-		void solve() override;
-
-	protected:
-		float m_timeStep;
-		btTypedConstraint* m_constraint;
-	};
-
-	class ContactSolverTask : public SolverTask
-	{
-	public:
-		ContactSolverTask(SolverBodyMt* A, SolverBodyMt* B, btSolverConstraint* c, btSolverConstraint* f0,
-		                  btSolverConstraint* f1, btSingleConstraintRowSolver sl, btSingleConstraintRowSolver s);
-		void solve() override;
-	protected:
-		btSolverConstraint* m_contact;
-		btSolverConstraint* m_friction0;
-		btSolverConstraint* m_friction1;
-
-		btSingleConstraintRowSolver m_solver;
-		btSingleConstraintRowSolver m_solverLowerLimit;
-	};
-
-	class GroupConstraintSolver : public btSequentialImpulseConstraintSolverMt
-	{
-		typedef btSequentialImpulseConstraintSolverMt Base;
-	public:
-		GroupConstraintSolver();
-
-		btScalar solveSingleIteration(int iteration, btCollisionObject** bodies, int numBodies,
-		                              btPersistentManifold** manifoldPtr, int numManifolds,
-		                              btTypedConstraint** constraints, int numConstraints,
-		                              const btContactSolverInfo& infoGlobal, btIDebugDraw* debugDrawer) override;
-		btScalar solveGroupCacheFriendlySetup(btCollisionObject** bodies, int numBodies,
-		                                      btPersistentManifold** manifoldPtr, int numManifolds,
-		                                      btTypedConstraint** constraints, int numConstraints,
-		                                      const btContactSolverInfo& infoGlobal,
-		                                      btIDebugDraw* debugDrawer) override;
-		btScalar solveGroupCacheFriendlyFinish(btCollisionObject** bodies, int numBodies,
-		                                       const btContactSolverInfo& infoGlobal) override;
-
 		static btSingleConstraintRowSolver getResolveSingleConstraintRowGenericAVX();
 		static btSingleConstraintRowSolver getResolveSingleConstraintRowLowerLimitAVX();
 
 		std::vector<ConstraintGroup*> m_groups;
-		std::vector<SolverBodyMt> m_bodiesMt;
-		std::vector<btSolverConstraint*> m_nonContactConstraintRowPtrs;
-		std::vector<SolverTaskPtr> m_tasks;
-		std::vector<SolverTaskPtr> m_contactTasks;
-		std::vector<SolverTaskPtr> m_nonContactTasks;
 	};
 }

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -1,16 +1,16 @@
-#include <random>
 #include "hdtSkinnedMeshWorld.h"
-#include "hdtSkinnedMeshAlgorithm.h"
+#include "hdtBoneScaleConstraint.h"
 #include "hdtDispatcher.h"
 #include "hdtSimulationIslandManager.h"
-#include "hdtBoneScaleConstraint.h"
-#include "hdtSkyrimSystem.h"
+#include "hdtSkinnedMeshAlgorithm.h"
 #include "hdtSkyrimPhysicsWorld.h"
+#include "hdtSkyrimSystem.h"
+#include <random>
 
 namespace hdt
 {
-	SkinnedMeshWorld::SkinnedMeshWorld()
-		: btDiscreteDynamicsWorldMt(nullptr, nullptr, m_solverPool, &m_constraintSolver, nullptr)
+	SkinnedMeshWorld::SkinnedMeshWorld() :
+		btDiscreteDynamicsWorldMt(nullptr, nullptr, new btConstraintSolverPoolMt(BT_MAX_THREAD_COUNT), nullptr, nullptr)
 	{
 		btSetTaskScheduler(btGetPPLTaskScheduler());
 
@@ -23,7 +23,7 @@ namespace hdt
 
 		auto broadphase = new btDbvtBroadphase();
 		m_broadphasePairCache = broadphase;
-		m_solverPool = new btConstraintSolverPoolMt(BT_MAX_THREAD_COUNT);
+		m_solverPool = static_cast<btConstraintSolverPoolMt*>(m_constraintSolver);
 
 		//m_islandManager->~btSimulationIslandManager();
 		//new (m_islandManager) SimulationIslandManager();
@@ -31,8 +31,7 @@ namespace hdt
 
 	SkinnedMeshWorld::~SkinnedMeshWorld()
 	{
-		for (auto system : m_systems)
-		{
+		for (auto system : m_systems) {
 			for (int i = 0; i < system->m_meshes.size(); ++i)
 				removeCollisionObject(system->m_meshes[i].get());
 
@@ -52,20 +51,17 @@ namespace hdt
 
 	void SkinnedMeshWorld::addSkinnedMeshSystem(SkinnedMeshSystem* system)
 	{
-		if (std::find(m_systems.begin(), m_systems.end(), system) != m_systems.end())
-		{
+		if (std::find(m_systems.begin(), m_systems.end(), system) != m_systems.end()) {
 			return;
 		}
 
 		m_systems.push_back(hdt::make_smart(system));
 
-		for (int i = 0; i < system->m_meshes.size(); ++i)
-		{
+		for (int i = 0; i < system->m_meshes.size(); ++i) {
 			addCollisionObject(system->m_meshes[i].get(), 1, 1);
 		}
-		
-		for (int i = 0; i < system->m_bones.size(); ++i)
-		{
+
+		for (int i = 0; i < system->m_bones.size(); ++i) {
 			system->m_bones[i]->m_rig.setActivationState(DISABLE_DEACTIVATION);
 			addRigidBody(&system->m_bones[i]->m_rig, 0, 0);
 		}
@@ -112,8 +108,7 @@ namespace hdt
 		if (hdt::SkyrimPhysicsWorld::get()->m_enableWind)
 			applyWind();
 
-		while (remainingTimeStep > fixedTimeStep)
-		{
+		while (remainingTimeStep > fixedTimeStep) {
 			internalSingleStepSimulation(fixedTimeStep);
 			remainingTimeStep -= fixedTimeStep;
 		}
@@ -140,13 +135,10 @@ namespace hdt
 
 	void SkinnedMeshWorld::applyGravity()
 	{
-		for (auto& i : m_systems)
-		{
-			for (auto& j : i->m_bones)
-			{
+		for (auto& i : m_systems) {
+			for (auto& j : i->m_bones) {
 				auto body = &j->m_rig;
-				if (!body->isStaticOrKinematicObject() && !(body->getFlags() & BT_DISABLE_WORLD_GRAVITY))
-				{
+				if (!body->isStaticOrKinematicObject() && !(body->getFlags() & BT_DISABLE_WORLD_GRAVITY)) {
 					body->setGravity(m_gravity * j->m_gravityFactor);
 				}
 			}
@@ -157,18 +149,15 @@ namespace hdt
 
 	void SkinnedMeshWorld::applyWind()
 	{
-		for (auto& i : m_systems)
-		{
+		for (auto& i : m_systems) {
 			auto system = static_cast<SkyrimSystem*>(i.get());
-			if (btFuzzyZero(system->m_windFactor)) // skip any systems that aren't affected by wind
+			if (btFuzzyZero(system->m_windFactor))  // skip any systems that aren't affected by wind
 				continue;
-			for (auto& j : i->m_bones)
-			{
+			for (auto& j : i->m_bones) {
 				auto body = &j->m_rig;
-				if (!body->isStaticOrKinematicObject()
-					&& (rand() % 5)) // apply randomly 80% of the time to desync wind across npcs
+				if (!body->isStaticOrKinematicObject() && (rand() % 5))  // apply randomly 80% of the time to desync wind across npcs
 				{
-					body->applyCentralForce(m_windSpeed *j->m_windFactor * system->m_windFactor);
+					body->applyCentralForce(m_windSpeed * j->m_windFactor * system->m_windFactor);
 				}
 			}
 		}
@@ -176,17 +165,13 @@ namespace hdt
 
 	void SkinnedMeshWorld::predictUnconstraintMotion(btScalar timeStep)
 	{
-		for (int i = 0; i < m_nonStaticRigidBodies.size(); i++)
-		{
+		for (int i = 0; i < m_nonStaticRigidBodies.size(); i++) {
 			btRigidBody* body = m_nonStaticRigidBodies[i];
-			if (!body->isStaticOrKinematicObject())
-			{
+			if (!body->isStaticOrKinematicObject()) {
 				// not realistic, just an approximate
 				body->applyDamping(timeStep);
 				body->predictIntegratedTransform(timeStep, body->getInterpolationWorldTransform());
-			}
-			else
-			{
+			} else {
 				body->predictIntegratedTransform(timeStep, body->getInterpolationWorldTransform());
 			}
 		}
@@ -194,11 +179,9 @@ namespace hdt
 
 	void SkinnedMeshWorld::integrateTransforms(btScalar timeStep)
 	{
-		for (int i = 0; i < m_collisionObjects.size(); ++i)
-		{
+		for (int i = 0; i < m_collisionObjects.size(); ++i) {
 			auto body = m_collisionObjects[i];
-			if (body->isKinematicObject())
-			{
+			if (body->isKinematicObject()) {
 				btTransformUtil::integrateTransform(
 					body->getWorldTransform(),
 					body->getInterpolationLinearVelocity(),
@@ -211,8 +194,7 @@ namespace hdt
 
 		btVector3 limitMin(-1e+9f, -1e+9f, -1e+9f);
 		btVector3 limitMax(1e+9f, 1e+9f, 1e+9f);
-		for (int i = 0; i < m_nonStaticRigidBodies.size(); i++)
-		{
+		for (int i = 0; i < m_nonStaticRigidBodies.size(); i++) {
 			btRigidBody* body = m_nonStaticRigidBodies[i];
 			auto lv = body->getLinearVelocity();
 			lv.setMax(limitMin);
@@ -231,24 +213,19 @@ namespace hdt
 	void SkinnedMeshWorld::solveConstraints(btContactSolverInfo& solverInfo)
 	{
 		BT_PROFILE("solveConstraints");
-		if (!m_collisionObjects.size()) return;
+		if (!m_collisionObjects.size())
+			return;
 
 		m_solverPool->prepareSolve(getCollisionWorld()->getNumCollisionObjects(),
-		                                getCollisionWorld()->getDispatcher()->getNumManifolds());
-
-		m_constraintSolver.m_groups.clear();
-		for (auto& i : m_systems)
-			for (auto& j : i->m_constraintGroups)
-				m_constraintSolver.m_groups.push_back(j.get());
+			getCollisionWorld()->getDispatcher()->getNumManifolds());
 
 		btPersistentManifold** manifold = m_dispatcher1->getInternalManifoldPointer();
 		int maxNumManifolds = m_dispatcher1->getNumManifolds();
 		m_solverPool->solveGroup(&m_collisionObjects[0], m_collisionObjects.size(), manifold, maxNumManifolds,
-		                              &m_constraints[0], m_constraints.size(), solverInfo, m_debugDrawer,
-		                              m_dispatcher1);
+			&m_constraints[0], m_constraints.size(), solverInfo, m_debugDrawer,
+			m_dispatcher1);
 
 		m_solverPool->allSolved(solverInfo, m_debugDrawer);
 		static_cast<CollisionDispatcher*>(m_dispatcher1)->clearAllManifold();
-		m_constraintSolver.m_groups.clear();
 	}
 }

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.h>
+
 #include "hdtGroupConstraintSolver.h"
 
 namespace hdt
@@ -7,7 +9,6 @@ namespace hdt
 	class SkinnedMeshWorld : protected btDiscreteDynamicsWorldMt
 	{
 	public:
-
 		SkinnedMeshWorld();
 		~SkinnedMeshWorld();
 
@@ -15,13 +16,12 @@ namespace hdt
 		virtual void removeSkinnedMeshSystem(SkinnedMeshSystem* system);
 
 		int stepSimulation(btScalar remainingTimeStep, int maxSubSteps = 1,
-		                   btScalar fixedTimeStep = btScalar(1.) / btScalar(60.)) override;
+			btScalar fixedTimeStep = btScalar(1.) / btScalar(60.)) override;
 
 		btVector3& getWind() { return m_windSpeed; }
 		const btVector3& getWind() const { return m_windSpeed; }
 
 	protected:
-
 		void resetTransformsToOriginal()
 		{
 			for (int i = 0; i < m_systems.size(); ++i) m_systems[i]->resetTransformsToOriginal();
@@ -32,7 +32,10 @@ namespace hdt
 			for (int i = 0; i < m_systems.size(); ++i) m_systems[i]->readTransform(timeStep);
 		}
 
-		void writeTransform() { for (int i = 0; i < m_systems.size(); ++i) m_systems[i]->writeTransform(); }
+		void writeTransform()
+		{
+			for (int i = 0; i < m_systems.size(); ++i) m_systems[i]->writeTransform();
+		}
 
 		void applyGravity() override;
 		void applyWind();
@@ -44,13 +47,11 @@ namespace hdt
 
 		std::vector<RE::BSTSmartPointer<SkinnedMeshSystem>> m_systems;
 
-		btVector3 m_windSpeed; // world windspeed
+		btVector3 m_windSpeed;  // world windspeed
 
 	private:
-
 		std::vector<SkinnedMeshBody*> _bodies;
 		std::vector<SkinnedMeshShape*> _shapes;
 		btConstraintSolverPoolMt* m_solverPool;
-		GroupConstraintSolver m_constraintSolver;
 	};
 }


### PR DESCRIPTION
I removed some redundant/dead code that did nothing but confuse. The system uses Bullet's btConstraintSolverPoolMt. hdtGroupConstraintSolver serves no purpose. I also auto-formatted the code. 

hdtSkinnedMeshWorld.cpp is where this "used" to be used at some point: https://github.com/DaymareOn/hdtSMP64/blob/25edf7ea28db4e8b72f82f38997ec8db80cfaad0/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp#L246

But as you can see it was replaced by btConstraintSolverPoolMt. So it was just dead code, wasting CPU cycles and confusing people like myself.. It's populating the solver, but never calling solveGroup, which is obviously critical. 

Furthermore there was undefined behavior with passing that m_constraintSolver/m_solverPool in the constructor: https://github.com/DaymareOn/hdtSMP64/blob/25edf7ea28db4e8b72f82f38997ec8db80cfaad0/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp#L13

So that's solved now too. 