### PR TITLE
feat: Improve default settings for our use-case

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -1272,7 +1272,7 @@ namespace hdt
 				if (skeleton->GetUserData() && skeleton->GetUserData()->GetObjectReference())
 				{
 					auto skeletonNpc = skyrim_cast<RE::TESNPC*>(skeleton->GetUserData()->GetObjectReference());
-					if (npc)
+					if (skeletonNpc)
 					{
 						char filePath[MAX_PATH];
 						if (TESNPC_GetFaceGeomPath(skeletonNpc, filePath))

--- a/src/WeatherManager.cpp
+++ b/src/WeatherManager.cpp
@@ -117,11 +117,7 @@ void hdt::WeatherCheck()
 				continue;
 			}
 
-	#ifdef SKYRIMVR
-			RE::TESWorldSpace* worldSpace = cell->GetRuntimeData().unk120;
-	#else
 			RE::TESWorldSpace* worldSpace = cell->GetRuntimeData().worldSpace;
-	#endif
 			if (!worldSpace) // Interior cell
 			{
 				//LOG("In interior cell. Waiting for 5 seconds");

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -150,6 +150,7 @@ namespace hdt
 				else if (reader.GetLocalName() == "useRealTime") 
 				{
 					SkyrimPhysicsWorld::get()->m_useRealTime = reader.readBool();
+				}
 #ifdef CUDA
 				else if (reader.GetLocalName() == "enableCuda")
 				{
@@ -164,7 +165,6 @@ namespace hdt
 					}
 				}
 #else
-				}
 				else if (reader.GetLocalName() == "enableCuda")
 				{
 					if (reader.readBool())

--- a/src/hdtSkyrimPhysicsWorld.cpp
+++ b/src/hdtSkyrimPhysicsWorld.cpp
@@ -10,7 +10,37 @@ namespace hdt
 		gDisableDeactivation = true;
 		setGravity(btVector3(0, 0, -9.8f * scaleSkyrim));
 
+		// https://github.com/bulletphysics/bullet3/blob/master/src/BulletDynamics/ConstraintSolver/btContactSolverInfo.h
+
 		getSolverInfo().m_friction = 0;
+
+		// This should be enabled by default, but just for clarity I put it here too
+		getSolverInfo().m_splitImpulse = true;
+
+		// Set a very low threshold so even micro-penetrations use Split Impulse
+		// Too low might cause weird visuals - default is -0.04f
+		getSolverInfo().m_splitImpulsePenetrationThreshold = -0.01f;
+
+		// Default ERP2 is 0.2
+		// From Bullet: error reduction for non-contact constraints
+		getSolverInfo().m_erp2 = 0.15f;
+
+		// constraint force mixing for contacts and non-contacts
+		// Adds "sponginess" to collisions to absorb the constant recalculations
+		// Default is 0
+		getSolverInfo().m_globalCfm = 0.001f;
+
+		// Ignore Bounciness (Restitution) on slow micro-collisions
+		// If objects are moving slower than this, they will not bounce at all.
+		// The default is 0.2f, but putting this here since it's very noteworthy!
+		getSolverInfo().m_restitutionVelocityThreshold = 0.2f;
+
+		// Default is = SOLVER_USE_WARMSTARTING | SOLVER_SIMD;
+		// But we don't even use warm starts since we delete the manifolds every frame
+		// SOLVER_SIMD nets a small performance uplift
+		// SOLVER_RANDMIZE_ORDER is also possible, but I clocked a pretty heavy performance hit. Maybe make it a config option
+		getSolverInfo().m_solverMode = SOLVER_SIMD;
+
 		m_averageInterval = m_timeTick;
 		m_accumulatedInterval = 0;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 #include "Hooks.h"
 #include "Events.h"
-#include "Hooks.h"
 #include "ActorManager.h"
 #include "hdtSkyrimPhysicsWorld.h"
 #include "PluginInterfaceImpl.h"
@@ -600,7 +599,7 @@ extern "C" DLLEXPORT constinit auto SKSEPlugin_Version = []()
 
 extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_skse)
 {
-// #ifndef NDEBUG
+#ifndef NDEBUG
 	auto start = std::chrono::high_resolution_clock::now();
 
 	while (!IsDebuggerPresent()) 
@@ -613,7 +612,7 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 			break;
 		}
 	}
-// #endif
+#endif
 
 	//
 	hdt::loadConfig();


### PR DESCRIPTION
These settings are better for our use case.

Bullet has a warmup period, and is largely designed for persistent manifolds. Because we reset the manifolds every cycle, the default settings lead to a lot of issues such as jitter. 

These few settings help alleviate the jitter, and smooth out the physics a bit. 

It may also be wise to increase the default iterations to around ~16