### PR TITLE
fix: Corrects corruption to the head that'll eventually lead to a CTD

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -1384,7 +1384,8 @@ namespace hdt
 					// nodes children of the head node, so that they move properly when there's no physics.
 					// This case never happens to a lurker skeleton, thus we don't need to test.
 					RE::NiNode* npcHeadNode = findNode(head.npcFaceGeomNode.get(), "NPC Head [Head]");
-					if (npcHeadNode) {
+					if (npcHeadNode) 
+					{
 
 						RE::NiTransform invTransform = npcHeadNode->local.Invert();
 						auto& children = head.npcFaceGeomNode->GetChildren();

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -1384,17 +1384,19 @@ namespace hdt
 					// nodes children of the head node, so that they move properly when there's no physics.
 					// This case never happens to a lurker skeleton, thus we don't need to test.
 					RE::NiNode* npcHeadNode = findNode(head.npcFaceGeomNode.get(), "NPC Head [Head]");
-					if (npcHeadNode)
-					{
+					if (npcHeadNode) {
+
 						RE::NiTransform invTransform = npcHeadNode->local.Invert();
 						auto& children = head.npcFaceGeomNode->GetChildren();
-						for (uint16_t i = 0; i < children.size(); ++i)
+
+						for (int32_t i = static_cast<int32_t>(children.size()) - 1; i >= 0; --i) 
 						{
 							auto child = castNiNode(children[i].get());
 
-							// This case never happens to a lurker skeleton, thus we don't need to test.
-							if (child && !findNode(npc.get(), child->name))
+							if (child && !findNode(npc.get(), child->name)) 
 							{
+								// hold a reference so DetachChildAt2 doesn't destroy the node
+								RE::NiPointer<RE::NiNode> ref(child);
 								child->local = invTransform * child->local;
 								head.npcFaceGeomNode->DetachChildAt2(i);
 								npcHeadNode->AttachChild(child, false);


### PR DESCRIPTION
Fixes the FaceGenCrash mentioned in discord. I also corrected a potential forward iteration removal bug although I highly doubt this bug ever actually occurred in-game.

Also removed the "// This case never happens to a lurker skeleton, thus we don't need to test." comment since it was already mentioned a few lines above. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when processing face-geometry operations by preventing potential node destruction during attachment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->