### PR TITLE
fix(VR): ctd from bone limit fix

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -1182,7 +1182,47 @@ namespace hdt
 									if (rootFadeNode) {
 										logger::debug("NPC facegeometry root fadeNode found.");
 										logBrokenNifOnce(filePath, rootFadeNode);
-										// Detect VR NiStream isolation bug: unresolved bone refs left as raw pointers
+										// VR: NiSkinInstance::LinkObject fails to resolve internal bone refs,
+										// storing the bone name as a raw char* instead of a resolved NiNode*.
+										// Bone NiNodes are self-contained in the face geometry NIF, so resolve
+										// them now by name lookup against the loaded tree.
+										// Must run before NiStream_deconstructor while the tree is live.
+										if (REL::Module::IsVR()) {
+											auto& ch = rootFadeNode->GetChildren();
+											for (std::uint32_t ci = 0; ci < ch.size(); ++ci) {
+												auto faceChild = ch[ci].get();
+												if (!faceChild || !isValidNiObject(faceChild))
+													continue;
+												auto faceGeo = faceChild->AsGeometry();
+												if (!faceGeo)
+													continue;
+												const auto& grd = faceGeo->GetGeometryRuntimeData();
+												if (!grd.skinInstance || !grd.skinInstance->skinData)
+													continue;
+												std::uint32_t vrResolved = 0, vrFailed = 0;
+												for (std::uint32_t bi = 0; bi < grd.skinInstance->skinData->bones; ++bi) {
+													auto bone = grd.skinInstance->bones[bi];
+													if (!bone || isValidNiObject(bone))
+														continue;
+													// char* case: bone pointer is canonical but its bytes are not a valid vtable.
+													// Guard against truly non-canonical addresses before reading as a string.
+													if (reinterpret_cast<uintptr_t>(bone) > kCanonicalUserSpaceMax)
+														continue;
+													const char* name = reinterpret_cast<const char*>(bone);
+													auto result = findNode(rootFadeNode, RE::BSFixedString(name));
+													grd.skinInstance->bones[bi] = result;
+													if (result)
+														++vrResolved;
+													else {
+														++vrFailed;
+														logger::warn("VR bone fix '{}': bone[{}] '{}' not found in NIF tree.", faceGeo->name.c_str(), bi, name);
+													}
+												}
+												if (vrResolved || vrFailed)
+													logger::info("VR bone fix '{}': resolved {}/{} unresolved bone refs in '{}'.", faceGeo->name.c_str(), vrResolved, vrResolved + vrFailed, filePath);
+											}
+										}
+										// Detect remaining unresolvable bone refs (non-null, non-canonical pointers).
 										bool brokenBoneRefs = false;
 										auto& faceCh = rootFadeNode->GetChildren();
 										for (std::uint32_t ci = 0; ci < faceCh.size() && !brokenBoneRefs; ++ci) {
@@ -1207,8 +1247,8 @@ namespace hdt
 										}
 										if (brokenBoneRefs) {
 											logger::warn(
-												"processGeometry: NPC facegeometry '{}' has VR NiStream unresolved "
-												"bone refs. Skipping facegeometry-based bone lookup to avoid crashes.",
+												"processGeometry: NPC facegeometry '{}' has remaining unresolvable "
+												"bone refs after VR fix pass. Skipping facegeometry-based bone lookup to avoid crashes.",
 												filePath);
 											head.npcFaceGeomNodeBroken = true;
 										} else
@@ -1291,10 +1331,7 @@ namespace hdt
 					// Facegen data doesn't have any tree structure to the skeleton. We need to make any new
 					// nodes children of the head node, so that they move properly when there's no physics.
 					// This case never happens to a lurker skeleton, thus we don't need to test.
-					// In VR, isolated NiStream nodes have broken vtable entries at higher slots;
-					// directly attaching originals to the live skeleton crashes the game update loop.
-					// doSkeletonMerge below uses cloneNodeTree (fresh valid copies), so skip direct attach in VR.
-					RE::NiNode* npcHeadNode = !REL::Module::IsVR() ? findNode(head.npcFaceGeomNode.get(), "NPC Head [Head]") : nullptr;
+					RE::NiNode* npcHeadNode = findNode(head.npcFaceGeomNode.get(), "NPC Head [Head]");
 					if (npcHeadNode) {
 						RE::NiTransform invTransform = npcHeadNode->local.Invert();
 						auto& children = head.npcFaceGeomNode->GetChildren();
@@ -1340,7 +1377,7 @@ namespace hdt
 
 		if (hasRenames) {
 			for (auto& entry : head.renameMap) {
-				if ((this->head.headParts.back().origPartRootNode && findObject(this->head.headParts.back().origPartRootNode.get(), entry.first->cstr())) || (!REL::Module::IsVR() && this->head.npcFaceGeomNode && findObject(this->head.npcFaceGeomNode.get(), entry.first->cstr()))) {
+				if ((this->head.headParts.back().origPartRootNode && findObject(this->head.headParts.back().origPartRootNode.get(), entry.first->cstr())) || (this->head.npcFaceGeomNode && findObject(this->head.npcFaceGeomNode.get(), entry.first->cstr()))) {
 					auto findNode = this->head.nodeUseCount.find(entry.first);
 					if (findNode != this->head.nodeUseCount.end()) {
 						findNode->second += 1;

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -703,8 +703,42 @@ namespace hdt
 		return "";
 	}
 
+	// Logs a warning once per NIF path when VR NiStream Type B stubs are found.
+	// Uses a static set to avoid duplicate warnings for the same NIF across frames.
+	static void logBrokenNifOnce(const char* nifPath, RE::NiAVObject* root)
+	{
+		if (!REL::Module::IsVR() || !nifPath || !root)
+			return;
+		static std::unordered_set<std::string> warned;
+		if (warned.count(nifPath))
+			return;
+		std::vector<RE::NiAVObject*> stack = { root };
+		while (!stack.empty()) {
+			auto obj = stack.back();
+			stack.pop_back();
+			if (!obj || !isValidNiObject(obj))
+				continue;
+			if (isVRNiStreamStub(obj)) {
+				warned.insert(nifPath);
+				logger::warn(
+					"[VR NiStream] NIF '{}' contains SE-format blocks VR cannot fully instantiate "
+					"(Type B stubs, broken vtable[43]). Run through Cathedral Assets Optimizer (CAO) for Skyrim VR.",
+					nifPath);
+				return;
+			}
+			auto node = obj->AsNode();
+			if (node)
+				for (auto& c : node->GetChildren())
+					if (c)
+						stack.push_back(c.get());
+		}
+	}
+
 	void ActorManager::Skeleton::addArmor(RE::NiNode* armorModel)
 	{
+		if (armorModel)
+			logBrokenNifOnce(armorModel->name.c_str(), armorModel);
+
 		IDType id = armors.size() ? armors.back().id + 1 : 0;
 		auto prefix = armorPrefix(id);
 		// FIXME we probably could simplify this by using findNode as surely we don't merge Armors with lurkers skeleton?
@@ -1125,7 +1159,7 @@ namespace hdt
 			}
 		} else {
 			logger::debug("No facegen extra model data available, loading original facegeometry.");
-			if (!head.npcFaceGeomNode) {
+			if (!head.npcFaceGeomNode && !head.npcFaceGeomNodeBroken) {
 				if (skeleton->GetUserData() && skeleton->GetUserData()->GetObjectReference()) {
 					auto skeletonNpc = skyrim_cast<RE::TESNPC*>(skeleton->GetUserData()->GetObjectReference());
 					if (skeletonNpc) {
@@ -1147,7 +1181,38 @@ namespace hdt
 									auto rootFadeNode = niStream->topObjects[0]->AsFadeNode();
 									if (rootFadeNode) {
 										logger::debug("NPC facegeometry root fadeNode found.");
-										head.npcFaceGeomNode = hdt::make_nismart(rootFadeNode);
+										logBrokenNifOnce(filePath, rootFadeNode);
+										// Detect VR NiStream isolation bug: unresolved bone refs left as raw pointers
+										bool brokenBoneRefs = false;
+										auto& faceCh = rootFadeNode->GetChildren();
+										for (std::uint32_t ci = 0; ci < faceCh.size() && !brokenBoneRefs; ++ci) {
+											auto faceChild = faceCh[ci].get();
+											if (!faceChild)
+												continue;
+											if (!isValidNiObject(faceChild)) {
+												brokenBoneRefs = true;
+												break;
+											}
+											auto faceGeo = faceChild->AsGeometry();
+											if (!faceGeo)
+												continue;
+											const auto& fgrd = faceGeo->GetGeometryRuntimeData();
+											if (!fgrd.skinInstance || !fgrd.skinInstance->skinData)
+												continue;
+											for (std::uint32_t bi = 0; bi < fgrd.skinInstance->skinData->bones && !brokenBoneRefs; ++bi) {
+												auto fBone = fgrd.skinInstance->bones[bi];
+												if (fBone && !isValidNiObject(fBone))
+													brokenBoneRefs = true;
+											}
+										}
+										if (brokenBoneRefs) {
+											logger::warn(
+												"processGeometry: NPC facegeometry '{}' has VR NiStream unresolved "
+												"bone refs. Skipping facegeometry-based bone lookup to avoid crashes.",
+												filePath);
+											head.npcFaceGeomNodeBroken = true;
+										} else
+											head.npcFaceGeomNode = hdt::make_nismart(rootFadeNode);
 									} else
 										logger::debug("NPC facegeometry root wasn't fadeNode as expected.");
 								}
@@ -1189,9 +1254,23 @@ namespace hdt
 
 			if (!*boneName.c_str()) {
 				if (origGeom) {
-					boneName = origGeom->GetGeometryRuntimeData().skinInstance->bones[boneIdx]->name;
+					const auto& rd = origGeom->GetGeometryRuntimeData();
+					if (rd.skinInstance && rd.skinInstance->skinData && boneIdx < rd.skinInstance->skinData->bones) {
+						auto bone = rd.skinInstance->bones[boneIdx];
+						if (isValidNiObject(bone))
+							boneName = bone->name;
+						else if (bone)
+							logger::warn("processGeometry: origGeom '{}' bone[{}] at {:p} is not a valid NiObject (VR NiStream unresolved bone ref)", geometry->name.c_str(), boneIdx, static_cast<void*>(bone));
+					}
 				} else if (origNiGeom) {
-					boneName = origNiGeom->GetRuntimeData().spSkinInstance->bones[boneIdx]->name;
+					const auto& spSkin = origNiGeom->GetRuntimeData().spSkinInstance;
+					if (spSkin && spSkin->skinData && boneIdx < spSkin->skinData->bones) {
+						auto bone = spSkin->bones[boneIdx];
+						if (isValidNiObject(bone))
+							boneName = bone->name;
+						else if (bone)
+							logger::warn("processGeometry: origNiGeom bone[{}] at {:p} is not a valid NiObject (VR NiStream unresolved bone ref)", boneIdx, static_cast<void*>(bone));
+					}
 				}
 			}
 
@@ -1212,7 +1291,10 @@ namespace hdt
 					// Facegen data doesn't have any tree structure to the skeleton. We need to make any new
 					// nodes children of the head node, so that they move properly when there's no physics.
 					// This case never happens to a lurker skeleton, thus we don't need to test.
-					RE::NiNode* npcHeadNode = findNode(head.npcFaceGeomNode.get(), "NPC Head [Head]");
+					// In VR, isolated NiStream nodes have broken vtable entries at higher slots;
+					// directly attaching originals to the live skeleton crashes the game update loop.
+					// doSkeletonMerge below uses cloneNodeTree (fresh valid copies), so skip direct attach in VR.
+					RE::NiNode* npcHeadNode = !REL::Module::IsVR() ? findNode(head.npcFaceGeomNode.get(), "NPC Head [Head]") : nullptr;
 					if (npcHeadNode) {
 						RE::NiTransform invTransform = npcHeadNode->local.Invert();
 						auto& children = head.npcFaceGeomNode->GetChildren();
@@ -1258,7 +1340,7 @@ namespace hdt
 
 		if (hasRenames) {
 			for (auto& entry : head.renameMap) {
-				if ((this->head.headParts.back().origPartRootNode && findObject(this->head.headParts.back().origPartRootNode.get(), entry.first->cstr())) || (this->head.npcFaceGeomNode && findObject(this->head.npcFaceGeomNode.get(), entry.first->cstr()))) {
+				if ((this->head.headParts.back().origPartRootNode && findObject(this->head.headParts.back().origPartRootNode.get(), entry.first->cstr())) || (!REL::Module::IsVR() && this->head.npcFaceGeomNode && findObject(this->head.npcFaceGeomNode.get(), entry.first->cstr()))) {
 					auto findNode = this->head.nodeUseCount.find(entry.first);
 					if (findNode != this->head.nodeUseCount.end()) {
 						findNode->second += 1;

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -709,7 +709,9 @@ namespace hdt
 	{
 		if (!REL::Module::IsVR() || !nifPath || !root)
 			return;
+		static std::mutex warnedMutex;
 		static std::unordered_set<std::string> warned;
+		std::lock_guard lock(warnedMutex);
 		if (warned.count(nifPath))
 			return;
 		std::vector<RE::NiAVObject*> stack = { root };

--- a/src/ActorManager.h
+++ b/src/ActorManager.h
@@ -79,6 +79,7 @@ namespace hdt
 			RE::BSTSmartPointer<IString> prefix;
 			RE::NiPointer<RE::BSFaceGenNiNode> headNode;
 			RE::NiPointer<RE::BSFadeNode> npcFaceGeomNode;
+			bool npcFaceGeomNodeBroken = false;  // true if isolated NiStream load produced broken VR bone refs
 			std::vector<HeadPart> headParts;
 			std::unordered_map<IDStr, IDStr> renameMap;
 			std::unordered_map<IDStr, uint8_t> nodeUseCount;

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -22,7 +22,8 @@ namespace Hooks
 
 			//
 			REL::Relocation<uintptr_t> BSFaceGenNiNode__vtbl{ RE::VTABLE_BSFaceGenNiNode[0] };
-			BSFaceGenNiNode__vtbl.write_vfunc(0x3E, SkinAllGeometry__Hook);
+			// VR adds SKYRIM_REL_VR_VIRTUAL FixSkinInstances at slot 0x3E, pushing SkinAllGeometry to 0x3F
+			BSFaceGenNiNode__vtbl.write_vfunc(REL::Module::IsVR() ? 0x3F : 0x3E, SkinAllGeometry__Hook);
 
 			//
 			_SkinSingleGeometry = trampoline.write_call<5>(SkinSingleGeometryCode1.address(), SkinSingleGeometry__Hook);

--- a/src/NetImmerseUtils.h
+++ b/src/NetImmerseUtils.h
@@ -2,6 +2,39 @@
 
 namespace hdt
 {
+
+	// Returns true if obj looks like a valid NiObject safe to call virtuals on.
+	// VR's NiStream can leave bones[] slots as null or as raw char* pointers for
+	// unresolved bone references. A char* used as a pointer has its first 8 bytes
+	// interpreted as a vtable — those bytes are ASCII text, giving a non-canonical
+	// address (> 0x7FFFFFFFFFFF) that faults on access. We also guard against null
+	// vtable slots (stub objects from unknown NIF block types).
+	// NiObject vtable layout: [0]=~NiRefObject, [1]=DeleteThis, [2]=GetRTTI, [3]=AsNode
+	static constexpr uintptr_t kCanonicalUserSpaceMax = 0x00007FFFFFFFFFFFull;
+	static inline bool isValidNiObject(const RE::NiAVObject* obj)
+	{
+		if (!obj)
+			return false;
+		if (reinterpret_cast<uintptr_t>(obj) > kCanonicalUserSpaceMax)
+			return false;
+		auto vtbl = *reinterpret_cast<void* const* const*>(obj);
+		if (!vtbl || reinterpret_cast<uintptr_t>(vtbl) > kCanonicalUserSpaceMax)
+			return false;
+		return vtbl[3] != nullptr;  // slot 3 = AsNode
+	}
+
+	// Returns true if obj is a VR NiStream stub: passes isValidNiObject but has a
+	// null or non-canonical function pointer at vtable slot 43 (GetObjectByName, offset
+	// 0x158). VR creates these for SE-specific NIF block types it can't fully instantiate.
+	static inline bool isVRNiStreamStub(const RE::NiAVObject* obj)
+	{
+		if (!isValidNiObject(obj))
+			return false;
+		auto vtbl = *reinterpret_cast<const uintptr_t* const*>(obj);
+		auto slot43 = vtbl[0x158 / sizeof(uintptr_t)];
+		return slot43 == 0 || slot43 > kCanonicalUserSpaceMax;
+	}
+
 	static inline void setNiNodeName(RE::NiNode* node, const char* name)
 	{
 		node->name = name;
@@ -9,7 +42,12 @@ namespace hdt
 
 	static inline RE::NiNode* castNiNode(RE::NiAVObject* obj)
 	{
-		return obj ? obj->AsNode() : nullptr;
+		if (!isValidNiObject(obj)) {
+			if (obj)
+				logger::warn("castNiNode: skipping object at {:p} with invalid vtable (VR NiStream stub or unresolved bone ref)", static_cast<const void*>(obj));
+			return nullptr;
+		}
+		return obj->AsNode();
 	}
 
 	inline RE::BSTriShape* castBSTriShape(RE::NiAVObject* obj)

--- a/src/NetImmerseUtils.h
+++ b/src/NetImmerseUtils.h
@@ -24,15 +24,17 @@ namespace hdt
 	}
 
 	// Returns true if obj is a VR NiStream stub: passes isValidNiObject but has a
-	// null or non-canonical function pointer at vtable slot 43 (GetObjectByName, offset
-	// 0x158). VR creates these for SE-specific NIF block types it can't fully instantiate.
+	// null or non-canonical function pointer at vtable slot 0x2B (GetObjectByName in VR,
+	// offset 0x158). VR uses slot 0x2B because ApplyLocalTransformToWorld is inserted at
+	// slot 26, shifting all SKYRIM_REL_VR_VIRTUAL entries by +1 relative to SE's 0x2A.
+	// VR creates these stubs for SE-specific NIF block types it can't fully instantiate.
 	static inline bool isVRNiStreamStub(const RE::NiAVObject* obj)
 	{
 		if (!isValidNiObject(obj))
 			return false;
 		auto vtbl = *reinterpret_cast<const uintptr_t* const*>(obj);
-		auto slot43 = vtbl[0x158 / sizeof(uintptr_t)];
-		return slot43 == 0 || slot43 > kCanonicalUserSpaceMax;
+		auto slotGetObjectByName = vtbl[0x158 / sizeof(uintptr_t)];  // 0x158 = slot 0x2B (VR)
+		return slotGetObjectByName == 0 || slotGetObjectByName > kCanonicalUserSpaceMax;
 	}
 
 	static inline void setNiNodeName(RE::NiNode* node, const char* name)


### PR DESCRIPTION
# VR NiStream Bone Resolution Problem

## Background: What Was the sksevr Bug?

In the sksevr-based DLL (pre-CommonLib refactor), `GetObjectByName` was called via the NiAVObject
vtable using the SE slot index (0x2A). VR has an extra virtual function `ApplyLocalTransformToWorld`
inserted at slot 26, shifting all subsequent slots by one — so `GetObjectByName` in VR is at slot
0x2B, not 0x2A. Calling the wrong slot returned null or garbage, meaning:

- `origGeom` (the face geometry object found by name in the loaded NIF) was **always null** in VR
- `npcHeadNode` ("NPC Head [Head]" found in the NIF) was **always null** in VR
- The child-reparenting block (applying inverse head transform before `doSkeletonMerge`) was **always skipped** in VR

### Practical User-Visible Effects in sksevr VR

- **Bones 0–7**: Covered by FMD (BSFaceGenModelExtraData) → worked correctly
- **Bones 8+** (modded NPCs, complex hair, HairFemaleNord01 etc.): bone name lookup from `origGeom`
  was skipped → empty boneName → not skinned to live skeleton → those physics elements were
  static/missing from simulation
- **Head-relative transforms**: `npcHeadNode` reparenting skipped → merged face geometry nodes
  may have slightly wrong world-space positioning → face physics elements could be offset or
  rotated wrong relative to the NPC head
- **Result**: Silently degraded/partial face physics in VR. No crash, but incomplete behavior,
  particularly for modded NPCs with more complex face bones.

### Why CommonLib Crashed

CommonLib correctly dispatches `GetObjectByName` to VR slot 0x2B via `SKYRIM_REL_VR_VIRTUAL`.
This means `origGeom` IS found in VR. When the code then accesses `origGeom->skinInstance->bones[i]`,
those bone pointers are null or raw `char*` strings (bone names), because VR's `NiSkinInstance::LinkObject`
cannot resolve external bone references when the NIF is loaded in isolation — the skeleton NiNodes
are not in the same NiStream.

Commit `fdaeb6d` added `isValidNiObject()` guards to handle these gracefully. The `!REL::Module::IsVR()`
guard on `npcHeadNode` was overly conservative and has since been removed, since the `isValidNiObject`/
`castNiNode` checks provide sufficient protection.

---

## The Core NiStream Problem

When the face geometry NIF is loaded in **isolation** (without the full skeleton context), bone references
in `NiSkinInstance` cannot be resolved. In the NIF format, bone references are stored as **object
indices** into the NiStream's object list. The actual skeleton NiNode objects (`"NPC Head [Head]"`,
`"NPC L Clavicle"`, etc.) are **not embedded in the face geometry NIF** — they live in the head
skeleton NIF (`headhuman.nif`, `skeletonhuman.nif`, etc.).

When VR's `NiSkinInstance::LinkObject` runs during the isolated load:
- It looks up each bone by index in the stream's object list
- Those bone NiNode objects are not present in this stream
- SE's NiStream stores null for unresolved refs
- VR's NiStream appears to store the **bone name string pointer** as a fallback (hence the
  `char* "G Hair14"` crash pattern)

---

## Can We Solve This at Runtime?

### Option 1: Post-Load Manual Bone Resolution (In-Process)

After `NiStream::Load1` returns, iterate `skinInstance->bones[]` for each loaded geometry and
manually resolve null/char* slots by name-matching against a provided NiNode tree (e.g., the
live skeleton `npc` or `npcFaceGeomNode`'s own hierarchy).

**Algorithm sketch:**
```
for each BSGeometry geo in loadedNIF:
    for i in 0..skinData->bones:
        if bones[i] is null or char*:
            name = (char*) bones[i]  // VR stores name as fallback
            if name is null:
                // SE: look up by NiSkinData::BoneData index — name not available
                // No reliable way to recover without NiSkinData::BoneData->name field
            bones[i] = findNode(availableTree, name)
```

**Problems:**
- For null bones (SE behavior): the name is not available from the pointer alone; would need to
  read the corresponding `NiSkinData::BoneData` to get a name — `NiSkinData` IS in the NIF and
  does contain per-bone transform data, but **not bone names** (names are in the NiSkinInstance
  bone pointers themselves after resolution)
- For char* bones (VR behavior): the name IS recoverable from the pointer, and resolution
  against the live skeleton would work — but this requires the target NiNode tree to be available
  at load time, which it is (we have `npc` / the live skeleton)
- This would be a **VR-specific post-processing step** on the loaded NIF before use

**Feasibility**: Moderate. VR's char* fallback makes names recoverable. SE's null fallback does not.

### Option 2: Provide the Skeleton NiStream During Load (NiStream Merging)

Load the face geometry NIF and the head skeleton NIF **into the same NiStream** (or load the
skeleton first, then add the face geometry into that stream's object context). This is how the
game normally loads skinned NIFs — the game's own streaming infrastructure resolves bone refs
against the already-loaded skeleton nodes.

**Problems:**
- `NiStream` does not natively support "load this NIF with bone refs resolved against an
  existing live NiNode tree" — the game's normal path goes through `BSResourceNiBinaryStream`
  with the full scene graph available, not isolated loads
- Implementing this would require injecting NiNode pointers into the stream before `LinkObject`
  runs, which requires either patching `NiStream::LinkObject` or hooking the object resolution
  mechanism — both are complex

### Option 3: Read Bone Names from NIF Binary Directly

Parse the NIF binary manually (or use an existing NIF parser) to extract the bone name strings
from the `NiStringExtraData` or node name fields **before** calling `NiStream::Load1`, then
map them by index. After load, fill in the unresolved `bones[]` slots using the pre-parsed names.

**Problems:**
- Requires a NIF parser (niflib, or hand-rolled) to read the block structure
- The bone-to-index mapping in NIF's `NiSkinInstance` uses the NiStream object index, which
  requires understanding the full NIF object list order
- Adds significant complexity

### Option 4: Cathedral Assets Optimizer (CAO) — Pre-Processing

CAO can repackage NIF files to be VR-compatible. This is the **standard community solution**.
It does not fix the NiStream isolation issue per se, but by ensuring all NIF blocks use
VR-native types (rather than SE-specific extensions), VR's NiStream can fully instantiate all
objects without creating stubs.

**However**: The NiStream bone isolation problem (external bone refs not resolved in isolated load)
is **not a CAO-fixable issue** — it is inherent to loading a skinned NIF without the skeleton
context, regardless of game version. CAO helps with *stub objects* (SE-specific NIF block types
VR can't instantiate), not with *external bone reference resolution*.

---

## Recommended Approach

### For the Stub Object Problem (SE-specific NIF block types → VR stubs)
**Use CAO.** This is the correct, user-facing solution. The `logBrokenNifOnce` warning in the
code already tells users to run CAO. Nothing to fix in the plugin.

### For the External Bone Reference Problem (null/char* bones in isolated NiStream load)
The current code already handles this correctly:
- `isValidNiObject()` guards in `processGeometry` skip null and char* bone pointers gracefully
- `brokenBoneRefs` detection catches genuine corruption (non-null, non-canonical pointers beyond char* names)
- VR's char* fallback means bone names ARE recoverable if we want to implement Option 1

**If we want to actually resolve the bones** (making origGeom's bone name lookup fully functional
in VR), we could implement a targeted post-load fix for VR:

```cpp
// After NiStream::Load1, for VR only: resolve char* bone refs by name
// against npcFaceGeomNode's own NiNode tree (the bones that ARE in the NIF)
if (REL::Module::IsVR() && rootFadeNode) {
    for each BSGeometry geo in rootFadeNode subtree:
        auto& si = geo->GetGeometryRuntimeData().skinInstance;
        if (!si) continue;
        for (uint32_t i = 0; i < si->skinData->bones; ++i) {
            auto bone = si->bones[i];
            if (bone && !isValidNiObject(bone)) {
                // VR stored the name as char* — recover it
                const char* name = reinterpret_cast<const char*>(bone);
                si->bones[i] = findNode(rootFadeNode, RE::BSFixedString(name));
            }
            // null bones: cannot recover name, leave null (handled gracefully)
        }
}
```

This would make VR bone name lookup from `origGeom` fully functional for VR's char* fallback
case, restoring parity with SE behavior for face physics bones.

**Caveat**: Requires verifying that the char* pointer from VR's NiStream actually points to a
valid null-terminated string in a stable memory region (not freed after load). Given it appeared
in crash logs as a readable string, this seems likely but should be validated.

---

## Summary Table

| Approach | Fixes Stubs | Fixes Bone Refs | Complexity | Recommended |
|---|---|---|---|---|
| CAO pre-processing | ✓ | ✗ | User action | ✓ Yes, for stubs |
| Current isValidNiObject guards | ✓ (catches) | ✓ (graceful skip) | Done | ✓ Keep |
| VR char* post-load resolution | ✗ | ✓ (partial) | Low-Medium | Consider |
| NiStream merging | ✗ | ✓ (full) | High | Not worth it |
| Manual NIF binary parse | ✗ | ✓ (full) | High | Not worth it |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved crashes and stability issues when loading NPC face geometry in VR.
  * Prevented broken VR bone references from causing rendering failures or hangs.

* **Improvements**
  * Better detection and graceful handling of problematic VR geometry to avoid crashes.
  * Enhanced logging and diagnostics for VR rendering and NPC appearance issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->