### PR TITLE
ci: add pre-commit.ci support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,12 @@ repos:
     hooks:
       - id: codespell
         args: [--ignore-words-list, "ue,nd,fo,hin,inout,numer,gool,fre,oord,accessort,toi,isse"]
+
+ci:
+    autofix_commit_msg: |
+        style: 🎨 apply pre-commit.ci formatting
+
+        Automated formatting by clang-format, prettier, and other hooks.
+        See https://pre-commit.ci for details.
+    autofix_prs: true
+    autoupdate_commit_msg: "build(deps): update pre-commit hooks"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit CI configuration to enable automatic code formatting and hook updates with standardized commit messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->