### PR TITLE
ci: harden workflow and expand build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,33 @@ on:
   push:
     branches:
       - master
-      - test
+      - dev
       - testbuild
+  workflow_dispatch:
   pull_request:
     branches:
       - master
-      - test
+      - dev
       - testbuild
+    paths:
+      - "**.cpp"
+      - "**.h"
+      - "**.hpp"
+      - "CMakeLists.txt"
+      - "CMakePresets.json"
+      - "vcpkg.json"
+      - "vcpkg-configuration.json"
+      - ".gitmodules"
+      - "extern/**"
+      - "cmake/**"
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   prepare:
@@ -39,15 +59,40 @@ jobs:
     needs: prepare
     runs-on: windows-2022
     strategy:
+      fail-fast: false
       # Use a matrix to run all presets at the same time
       matrix:
-        preset: [vs2022-windows-nocuda-avx2, vs2022-windows-nocuda-avx512]
+        include:
+          - preset: vs2022-windows-nocuda
+            cuda: false
+          - preset: vs2022-windows-nocuda-avx
+            cuda: false
+          - preset: vs2022-windows-nocuda-avx2
+            cuda: false
+          - preset: vs2022-windows-nocuda-avx512
+            cuda: false
+          - preset: vs2022-windows-cuda
+            cuda: true
+          - preset: vs2022-windows-cuda-avx
+            cuda: true
+          - preset: vs2022-windows-cuda-avx2
+            cuda: true
+          - preset: vs2022-windows-cuda-avx512
+            cuda: true
 
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
           submodules: recursive # This handles the 'git submodule update --init --recursive' automatically
+
+      - name: Install CUDA Toolkit
+        if: matrix.cuda
+        uses: Jimver/cuda-toolkit@v0.2.30
+        with:
+          cuda: "12.6.3"
+          method: network
+          sub-packages: '["nvcc", "cudart"]'
 
       - name: Inject version into CMake
         shell: pwsh
@@ -63,7 +108,7 @@ jobs:
             build/vcpkg_installed
             ~\AppData\Local\vcpkg\archives
           # Adding the preset name to the key ensures the presets don't overwrite each other's cache
-          key: vcpkg-${{ runner.os }}-${{ github.ref_name }}-${{ matrix.preset }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ github.ref_name }}-${{ matrix.preset }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/ports/**') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ github.ref_name }}-${{ matrix.preset }}-
 
@@ -101,6 +146,7 @@ jobs:
 
   release:
     needs: [prepare, build]
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -194,45 +240,9 @@ jobs:
           prerelease: ${{ github.ref_name != 'master' }}
 
       - name: Cleanup old releases
-        uses: actions/github-script@v7
+        uses: dev-drprasad/delete-older-releases@v0.3.4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { data: releases } = await github.rest.repos.listReleases({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-
-            const isMasterBranch = !context.ref.includes('-');
-            const branchName = context.ref.replace('refs/heads/', ''); // Only works for branches other than master
-
-            const filteredReleases = releases.filter(r => {
-            return isMasterBranch 
-              ? /^v[0-9.]+$/.test(r.tag_name)
-              : r.tag_name.includes(branchName);
-            });
-
-            // We keep the last 10 and delete the others
-            const toDelete = filteredReleases.slice(10);
-            for (const release of toDelete) {
-              console.log(`Deleting release ${release.tag_name} (ID: ${release.id})`);
-
-              // 1. Delete the release
-              await github.rest.repos.deleteRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: release.id,
-              });
-
-              // 2. Delete the associated tag
-              try {
-                await github.rest.git.deleteRef({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  ref: `tags/${release.tag_name}`,
-                });
-                console.log(`Successfully deleted tag ${release.tag_name}`);
-              } catch (e) {
-                console.log(`Could not delete tag ${release.tag_name} (maybe already gone)`);
-              }
-            }
+          keep_latest: 10
+          delete_tag_pattern: ${{ github.ref_name == 'master' && '^v[0-9.]+$' || github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Rename `test` branch trigger to `dev`
- Add workflow_dispatch trigger
- Add PR path filters to skip non-code changes
- Add permissions: contents: read (least privilege)
- Add concurrency to cancel superseded runs
- Add fail-fast: false for independent matrix results
- Expand matrix from 2 to 8 presets (all nocuda/cuda variants); install CUDA Toolkit conditionally
- Fix vcpkg cache key to include cmake/ports/**
- Skip release job on pull_request events