### PR TITLE
fix: out of bounds and double ref dec

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -684,7 +684,7 @@ namespace hdt
 				continue;
 
 			if (child->name.size() && !strncmp(child->name.data(), prefix->cstr(), prefix->size())) {
-				dst->DetachChildAt2(i++);
+				dst->DetachChildAt2(i);
 			} else {
 				doSkeletonClean(child, prefix);
 			}
@@ -838,7 +838,6 @@ namespace hdt
 									auto parent = removeObj->parent;
 									if (parent) {
 										parent->DetachChild2(removeObj);
-										removeObj->DecRefCount();
 									}
 								}
 								this->head.nodeUseCount.erase(findNode);


### PR DESCRIPTION
Bug 1 - line 687:
So there's a bug in doSkeletonClean where the loop goes backwards through the children array but when it finds a match and detaches a child it bumps i back up with i++ which totally breaks the reverse iteration.

Here's what happens if you walk through it with like three children A B C. The loop counts down and hits C at index 2, detaches it, then i++ pushes i back to 3. Now the array is only two elements long but on the next loop check it still thinks there's stuff to look at and tries to access index 2 on an array that only goes up to 1. That's an out of bounds read and depending on your luck it's either garbage data or a crash.

I haven't confirmed this bug, it just visually looks like a logic error. 

Bug 2 - line 841: 

The DetatchChild2 drops the ref count by -1. Doing DecRefCount dereferences freed memory, so it's a use-after-free bug.

The node was added by doSkeletonMerg, cloneNodeTree, AttachChild: https://github.com/DaymareOn/hdtSMP64/blob/dc7fe3c60f3c5b9bfb75ba0244fad8dbd3ee21dd/src/ActorManager.cpp#L631

I don't see anywhere the refCount is increased to need a second DecRefCount. 

That's actually what led to this recent bug fix: https://github.com/DaymareOn/hdtSMP64/blob/dc7fe3c60f3c5b9bfb75ba0244fad8dbd3ee21dd/src/ActorManager.cpp#L1345

Where we had to hold a reference to avoid the object from being destroyed and causing a crash.

I'm confident this is a bug, but Kernel Panic should review given it's his code. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skeleton cleanup operations and node detachment management during object lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->