### PR TITLE
fix: optimize updateAabb

### DIFF
--- a/src/hdtSkinnedMesh/hdtCollider.cpp
+++ b/src/hdtSkinnedMesh/hdtCollider.cpp
@@ -3,7 +3,6 @@
 
 namespace hdt
 {
-	static const _CRT_ALIGN(16) U8 interleaveBits[16] = { 0, 1, 8, 9, 64, 65, 72, 73 };
 
 	void ColliderTree::insertCollider(const std::vector<U32>& keys, const Collider& c)
 	{
@@ -19,30 +18,71 @@ namespace hdt
 		p->colliders.push_back(c);
 	}
 
+	// finds overlapping pairs between two collider trees
 	void ColliderTree::checkCollisionL(ColliderTree* r, std::vector<std::pair<ColliderTree*, ColliderTree*>>& ret)
 	{
-		if (isKinematic && r->isKinematic)
-			return;
+		enum Mode : uint8_t
+		{
+			L,  // still splitting a, b is along for the ride
+			R   // a is a leaf, now drilling into b's subtree
+		};
+		struct Entry
+		{
+			ColliderTree* a;
+			ColliderTree* b;
+			Mode mode;
+		};
+		// thread_local so we don't re-alloc every call. This gets hammered
+		thread_local std::vector<Entry> stack;
+		stack.clear();
+		stack.push_back({ this, r, L });
+		while (!stack.empty()) {
+			auto e = stack.back();
+			stack.pop_back();
 
-		if (!aabbAll.collideWith(r->aabbAll))
-			return;
+			if (e.a->isKinematic && e.b->isKinematic)
+				continue;
 
-		if (numCollider && aabbMe.collideWith(r->aabbAll)) {
-			if (aabbMe.collideWith(r->aabbMe))
-				ret.push_back(std::make_pair(this, r));
+			if (e.mode == L) {
+				if (!e.a->aabbAll.collideWith(e.b->aabbAll))
+					continue;
 
-			auto begin = r->children.data();
-			auto end = begin + (isKinematic ? r->dynChild : r->children.size());
-			for (auto i = begin; i < end; ++i)
-				checkCollisionR(i, ret);
+				// a is a leaf — switch to R-mode and walk down b
+				if (e.a->numCollider && e.a->aabbMe.collideWith(e.b->aabbAll)) {
+					if (e.a->aabbMe.collideWith(e.b->aabbMe))
+						ret.push_back(std::make_pair(e.a, e.b));
+
+					auto begin = e.b->children.data();
+					// skip b's kinematic children if a is kinematic (would get culled above anyway)
+					auto end = begin + (e.a->isKinematic ? e.b->dynChild : e.b->children.size());
+					for (auto i = begin; i < end; ++i)
+						stack.push_back({ e.a, i, R });
+				}
+
+				// keep splitting a — same kinematic shortcut
+				auto begin = e.a->children.data();
+				auto end = begin + (e.b->isKinematic ? e.a->dynChild : e.a->children.size());
+				for (auto i = begin; i < end; ++i)
+					stack.push_back({ i, e.b, L });
+			} else {
+				// a is always a leaf here (L only pushes R when numCollider is set)
+				// numCollider check is technically redundant but whatever, it's cheap
+				if (!e.a->numCollider)
+					continue;
+				if (!e.a->aabbMe.collideWith(e.b->aabbAll))
+					continue;
+				if (e.a->aabbMe.collideWith(e.b->aabbMe))
+					ret.push_back(std::make_pair(e.a, e.b));
+
+				auto begin = e.b->children.data();
+				auto end = begin + (e.a->isKinematic ? e.b->dynChild : e.b->children.size());
+				for (auto i = begin; i < end; ++i)
+					stack.push_back({ e.a, i, R });
+			}
 		}
-
-		auto begin = children.data();
-		auto end = begin + (r->isKinematic ? dynChild : children.size());
-		for (auto i = begin; i < end; ++i)
-			i->checkCollisionL(r, ret);
 	}
 
+	// dead code. checkCollisionL inlines R logic now. kept for API
 	void ColliderTree::checkCollisionR(ColliderTree* r, std::vector<std::pair<ColliderTree*, ColliderTree*>>& ret)
 	{
 		if (isKinematic && r->isKinematic)
@@ -110,24 +150,54 @@ namespace hdt
 
 	void ColliderTree::updateAabb()
 	{
-		if (numCollider) {
-			auto aabbEnd = this->aabb + numCollider;
-			for (auto i = this->aabb + 1; i < aabbEnd; ++i)
-				this->aabb->merge(*i);
-			aabbMe = *this->aabb;
-		}
+		struct Frame
+		{
+			ColliderTree* node;
+			size_t childIdx;
+		};
+		thread_local std::vector<Frame> stack;
+		stack.clear();
+		stack.push_back({ this, 0 });
+
+		while (!stack.empty()) {
+			auto& f = stack.back();
+			if (f.childIdx < f.node->children.size()) {
+				auto* child = &f.node->children[f.childIdx++];
+				stack.push_back({ child, 0 });
+				continue;
+			}
+
+			auto* node = f.node;
+			stack.pop_back();
+
+			// old code merged into aabb[0] directly which nuked collider 0's actual bbox,
+			// making it always pass narrow-phase checks. accumulate in registers instead
+			if (node->numCollider) {
+				__m128 mn = node->aabb[0].m_min;
+				__m128 mx = node->aabb[0].m_max;
+				auto* aabbPtr = node->aabb + 1;
+				auto* aabbEnd = node->aabb + node->numCollider;
+				for (; aabbPtr < aabbEnd; ++aabbPtr) {
+					mn = _mm_min_ps(mn, aabbPtr->m_min);
+					mx = _mm_max_ps(mx, aabbPtr->m_max);
+				}
+				node->aabbMe.m_min = mn;
+				node->aabbMe.m_max = mx;
+			}
 #ifdef CUDA
-		else {
-			aabbMe.invalidate();
-		}
+			else {
+				node->aabbMe.invalidate();
+			}
 #endif
 
-		aabbAll = aabbMe;
-		for (auto& i : children) {
-			// FIXME PROFILING Lots of time is used here, because this is called a lot.
-			i.updateAabb();
-
-			aabbAll.merge(i.aabbAll);
+			__m128 allMin = node->aabbMe.m_min;
+			__m128 allMax = node->aabbMe.m_max;
+			for (auto& child : node->children) {
+				allMin = _mm_min_ps(allMin, child.aabbAll.m_min);
+				allMax = _mm_max_ps(allMax, child.aabbAll.m_max);
+			}
+			node->aabbAll.m_min = allMin;
+			node->aabbAll.m_max = allMax;
 		}
 	}
 
@@ -164,33 +234,68 @@ namespace hdt
 		}
 	}
 
+	// same deal as checkCollisionL - iterative, early return still works since we just bail out of the loop
 	bool ColliderTree::collapseCollideL(ColliderTree* r)
 	{
-		if (isKinematic && r->isKinematic)
-			return false;
+		enum Mode : uint8_t
+		{
+			L,
+			R
+		};
+		struct Entry
+		{
+			ColliderTree* a;
+			ColliderTree* b;
+			Mode mode;
+		};
+		thread_local std::vector<Entry> stack;
+		stack.clear();
+		stack.push_back({ this, r, L });
 
-		if (!aabbAll.collideWith(r->aabbAll))
-			return false;
+		while (!stack.empty()) {
+			auto e = stack.back();
+			stack.pop_back();
 
-		if (numCollider && aabbMe.collideWith(r->aabbAll)) {
-			if (aabbMe.collideWith(r->aabbMe))
-				return true;
+			if (e.a->isKinematic && e.b->isKinematic)
+				continue;
 
-			auto begin = r->children.data();
-			auto end = begin + (isKinematic ? r->dynChild : r->children.size());
-			for (auto i = begin; i < end; ++i)
-				if (collapseCollideR(i))
+			if (e.mode == L) {
+				if (!e.a->aabbAll.collideWith(e.b->aabbAll))
+					continue;
+
+				if (e.a->numCollider && e.a->aabbMe.collideWith(e.b->aabbAll)) {
+					if (e.a->aabbMe.collideWith(e.b->aabbMe))
+						return true;
+
+					auto begin = e.b->children.data();
+					auto end = begin + (e.a->isKinematic ? e.b->dynChild : e.b->children.size());
+					for (auto i = begin; i < end; ++i)
+						stack.push_back({ e.a, i, R });
+				}
+
+				auto begin = e.a->children.data();
+				auto end = begin + (e.b->isKinematic ? e.a->dynChild : e.a->children.size());
+				for (auto i = begin; i < end; ++i)
+					stack.push_back({ i, e.b, L });
+			} else {
+				if (!e.a->numCollider)
+					continue;
+				if (!e.a->aabbMe.collideWith(e.b->aabbAll))
+					continue;
+
+				if (e.a->aabbMe.collideWith(e.b->aabbMe))
 					return true;
-		}
 
-		auto begin = children.data();
-		auto end = begin + (r->isKinematic ? dynChild : children.size());
-		for (auto i = begin; i < end; ++i)
-			if (i->collapseCollideL(r))
-				return true;
+				auto begin = e.b->children.data();
+				auto end = begin + (e.a->isKinematic ? e.b->dynChild : e.b->children.size());
+				for (auto i = begin; i < end; ++i)
+					stack.push_back({ e.a, i, R });
+			}
+		}
 		return false;
 	}
 
+	// dead code.. collapseCollideL inlines R logic now. kept for API
 	bool ColliderTree::collapseCollideR(ColliderTree* r)
 	{
 		if (isKinematic && r->isKinematic)


### PR DESCRIPTION
Was debugging our collision passes (narrow, wide, etc) and noticed a weird amount of collisions were making it through the narrow phase

Turns out updateAabb was merging all collider bounding boxes into aabb[0], which meant collider 0 always had the full union AABB. So it passed every narrow-phase check unconditionally - free false positives for every node. fixed by accumulating into registers and only writing to aabbMe

Also:

- Removed some of the recussion in hdtCollider too since the CPU was freaking out over it.
- Removed interleaveBits, it's dead code
- Using thread_local for reduction in allocation rates (Was hot on my profiler)
- Added some comments to make it easier for another dev to pickup and understand

These other optimizations were from trying to optimize the CPU. 

This can be optimized a bit further but I doubt it'd make a difference. Some of the design choices here were more about readability over micro-optimizations. 

While it looks simple, actually failing on a narrow pass rather than just unconditionally dumping everything to the next phase is a significant performance enhancement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal collision detection system structure for improved code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->