### PR TITLE
fix: Fixed the broken physics issue known as the 'slot 32' bug

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -604,6 +604,11 @@ namespace hdt
 
 	void ActorManager::Skeleton::doSkeletonMerge(RE::NiNode* dst, RE::NiNode* src, IString* prefix, std::unordered_map<IDStr, IDStr>& map)
 	{
+		doSkeletonMerge(dst, src, prefix, map, dst);
+	}
+
+	void ActorManager::Skeleton::doSkeletonMerge(RE::NiNode* dst, RE::NiNode* src, IString* prefix, std::unordered_map<IDStr, IDStr>& map, RE::NiNode* dstRoot)
+	{
 		const auto& children = src->GetChildren();
 
 		for (uint16_t i = 0; i < children.size(); ++i) {
@@ -624,9 +629,9 @@ namespace hdt
 			}
 
 			// TODO check it's not a lurker skeleton
-			auto dstChild = findNode(dst, srcChild->name);
+			auto dstChild = findNode(dstRoot, srcChild->name);
 			if (dstChild) {
-				doSkeletonMerge(dstChild, srcChild, prefix, map);
+				doSkeletonMerge(dstChild, srcChild, prefix, map, dstRoot);
 			} else {
 				dst->AttachChild(cloneNodeTree(srcChild, prefix, map), false);
 			}

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -617,7 +617,7 @@ namespace hdt
 				continue;
 
 			if (!srcChild->name.size()) {
-				doSkeletonMerge(dst, srcChild, prefix, map);
+				doSkeletonMerge(dst, srcChild, prefix, map, dstRoot);
 				continue;
 			}
 

--- a/src/ActorManager.h
+++ b/src/ActorManager.h
@@ -163,6 +163,7 @@ namespace hdt
 		private:
 			bool isActiveInScene() const;
 			bool checkPhysics();
+			static void doSkeletonMerge(RE::NiNode* dst, RE::NiNode* src, IString* prefix, std::unordered_map<IDStr, IDStr>& map, RE::NiNode* dstRoot);
 
 			bool isActive = false;
 			float currentWindFactor = 0.f;


### PR DESCRIPTION
Super simple fix for the popular "slot 32" bug. 

Users commonly connect this bug with cbpc and smp. Known as the slot 32 bug. When you enter a game with certain smp armors, the breasts for example wont have physics until you re-equip the armor. 

The cause of the bug is due to Skyrim's lazy loaded skeleton node system. The fix is to use the FlattedTreeNode to properly fetch the node, which prompts skyrim to actually load it rather than purely using the tree cache. If we used a child of said node, it would be limited to only cache lookups. 

Since we always use the main parent node, we can just pass it directly to doSkeletonMerge. No need to traverse the hierarchy to find the proper tree node manually. 

Tested in-game and what not already... 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced skeleton-merge behavior to consistently honor an explicit destination root, improving node resolution and lookup scoping during merges.
  * Preserved existing merge call compatibility so previous workflows continue to operate while benefiting from the improved root-aware merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->