### PR TITLE
fix: Corect/optimize a minor memory leak

### DIFF
--- a/src/hdtSerialization.h
+++ b/src/hdtSerialization.h
@@ -106,10 +106,11 @@ namespace hdt
 	template <class _Storage_t, class _Stream_t>
 	inline void Serializer<_Storage_t, _Stream_t>::ReadData(SKSE::SerializationInterface* intfc, uint32_t length)
 	{
-		char* data_block = new char[length];
-		intfc->ReadRecordData(data_block, length);
-		std::string s_data(data_block, length);
-		//_MESSAGE("Reading Data: %s", s_data.c_str());
+		std::string s_data;
+		s_data.resize(length);
+
+		intfc->ReadRecordData(s_data.data(), length);
+
 		_Stream_t _stream;
 		_stream << s_data;
 		this->Deserialize(_stream);


### PR DESCRIPTION
Minor memory leak here. The data_block is never being deleted. 

We can actually just directly read into the std::string too, which avoids having to double allocate the memory for no reason. 

So fix  + optimization here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to memory management and buffer handling. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->