### PR TITLE
chore: fix version tag missing branch name when not on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
       - dev
-      - testbuild
+      - fixrelease
     paths:
       - "**.cpp"
       - "**.h"
@@ -24,7 +24,7 @@ on:
     branches:
       - master
       - dev
-      - testbuild
+      - fixrelease
     paths:
       - "**.cpp"
       - "**.h"
@@ -67,7 +67,7 @@ jobs:
         with:
           tag_prefix: "v"
           version_from_branch: true # Filter existing tags by branch
-          version_format: "${major}.${minor}.${patch}"
+          version_format: "${major}.${minor}.${patch}${{ github.ref_name != 'master' && format('-{0}', github.ref_name) || '' }}"
           major_pattern: "/!:|BREAKING CHANGE:/"
           minor_pattern: "/feat(\\(.+\\))?:/"
           bump_each_commit: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,6 @@ jobs:
     outputs:
       # Make the version accessible to other jobs
       new_version: ${{ steps.versioning.outputs.version }}
-      # We add this output so the release job can retrieve the complete tag (e.g., v1.2.3 or v1.2.3-dev)
-      version_tag: ${{ steps.versioning.outputs.version_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           tag_prefix: "v"
           version_from_branch: true # Filter existing tags by branch
-          version_format: "${major}.${minor}.${patch}${{ github.ref_name != 'master' && format('-{0}', github.ref_name) || '' }}"
+          version_format: "${major}.${minor}.${patch}"
           major_pattern: "/!:|BREAKING CHANGE:/"
           minor_pattern: "/feat(\\(.+\\))?:/"
           bump_each_commit: true
@@ -269,10 +269,10 @@ jobs:
         with:
           # This is where the version is saved into Git with a Tag
           # If the branch isn't master, we append the branch name to the tag to avoid conflicts
-          tag_name: ${{ needs.prepare.outputs.version_tag }}
+          tag_name: ${{ github.ref_name == 'master' && format('v{0}', needs.prepare.outputs.new_version) || format('v{0}-{1}', needs.prepare.outputs.new_version, github.ref_name) }}
           name: FSMP v${{ needs.prepare.outputs.new_version }} (${{ github.ref_name }})
           body: |
-            ## Release v${{ needs.prepare.outputs.new_version }}
+            ## Release ${{ github.ref_name == 'master' && format('v{0}', needs.prepare.outputs.new_version) || format('v{0}-{1}', needs.prepare.outputs.new_version, github.ref_name) }}
             Build Date: ${{ github.event.head_commit.timestamp }}
             Commit: ${{ github.sha }}
             Automated Semantic Build.


### PR DESCRIPTION
chore: fix version tag missing branch name when not on master

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build/release workflow to monitor a different branch for CI triggers.
  * Made version tagging branch-aware: releases on main use v{version}, others use v{version}-{branch}.
  * Streamlined release metadata and public version output for clearer, consistent release names and notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->