### PR TITLE
perf: Optimize, cleanup, and documented the collision dispatcher

### DIFF
--- a/src/hdtSkinnedMesh/hdtDispatcher.cpp
+++ b/src/hdtSkinnedMesh/hdtDispatcher.cpp
@@ -7,6 +7,7 @@
 #endif
 
 #include <LinearMath/btPoolAllocator.h>
+#include <algorithm>
 
 #ifdef CUDA
 // If defined, triangle-vertex and vertex-vertex collision results aren't applied until the next frame. This
@@ -43,25 +44,38 @@ namespace hdt
 		return shape0->canCollideWith(shape1) && shape1->canCollideWith(shape0);
 	}
 
+	static inline bool isSkinnedMesh(const btCollisionObject* obj)
+	{
+		return obj->getCollisionShape()->getShapeType() == CUSTOM_CONCAVE_SHAPE_TYPE;
+	}
+
 	bool CollisionDispatcher::needsCollision(const btCollisionObject* body0, const btCollisionObject* body1)
 	{
-		auto shape0 = dynamic_cast<const SkinnedMeshBody*>(body0);
-		auto shape1 = dynamic_cast<const SkinnedMeshBody*>(body1);
+		bool skinned0 = isSkinnedMesh(body0);
+		bool skinned1 = isSkinnedMesh(body1);
 
-		if (shape0 || shape1) {
+		if (skinned0 || skinned1) {
+			auto shape0 = skinned0 ? static_cast<const SkinnedMeshBody*>(body0) : nullptr;
+			auto shape1 = skinned1 ? static_cast<const SkinnedMeshBody*>(body1) : nullptr;
 			return hdt::needsCollision(shape0, shape1);
 		}
+
 		if (body0->isStaticOrKinematicObject() && body1->isStaticOrKinematicObject())
 			return false;
+
+		// Todo: This is likely dead code as only skinned objects can collide as of right now (3/20/2026)
 		if (body0->checkCollideWith(body1) || body1->checkCollideWith(body0)) {
 			auto rb0 = static_cast<SkinnedMeshBone*>(body0->getUserPointer());
-			auto rb1 = static_cast<SkinnedMeshBone*>(body0->getUserPointer());
+			auto rb1 = static_cast<SkinnedMeshBone*>(body1->getUserPointer());
 
 			return rb0->canCollideWith(rb1) && rb1->canCollideWith(rb0);
 		} else
 			return false;
 	}
 
+	// Docs: This is called by Bullet's broad phase, which finds pairs that may be colliding. We built these aabb's inside SkinnedMeshBody::updateBoundingSphereAabb() using Skyrim's bone 
+	// spheres. This function checks if those pairs are even allowed to collide, updates the skinned shapes, then passes it to the next few phases of collision checks.
+	// Collision phases are: Bullet's broadphase, our BVH midphase, then finally our narrowphase 
 	void CollisionDispatcher::dispatchAllCollisionPairs(btOverlappingPairCache* pairCache, [[maybe_unused]] const btDispatcherInfo& dispatchInfo, [[maybe_unused]] btDispatcher* dispatcher)
 	{
 		auto size = pairCache->getNumOverlappingPairs();
@@ -75,36 +89,27 @@ namespace hdt
 		UpdateMap to_update;
 		// Find bodies and meshes that need collision checking. We want to keep them together in a map so they can
 		// be grouped by CUDA stream
-		for (int i = 0; i < size; ++i)
-#else
-		SpinLock lock;
-		std::unordered_set<SkinnedMeshBody*> bodies;
-		std::unordered_set<PerVertexShape*> vertex_shapes;
-		std::unordered_set<PerTriangleShape*> triangle_shapes;
-
-		concurrency::parallel_for(0, size, [&](int i)
-#endif
-		{
+		for (int i = 0; i < size; ++i) {
 			auto& pair = pairs[i];
 
-			auto shape0 = dynamic_cast<SkinnedMeshBody*>(static_cast<btCollisionObject*>(pair.m_pProxy0->m_clientObject));
-			auto shape1 = dynamic_cast<SkinnedMeshBody*>(static_cast<btCollisionObject*>(pair.m_pProxy1->m_clientObject));
+			auto obj0 = static_cast<btCollisionObject*>(pair.m_pProxy0->m_clientObject);
+			auto obj1 = static_cast<btCollisionObject*>(pair.m_pProxy1->m_clientObject);
+			bool skinned0 = isSkinnedMesh(obj0);
+			bool skinned1 = isSkinnedMesh(obj1);
 
-			if (shape0 || shape1) {
-				if (hdt::needsCollision(shape0, shape1) && shape0->isBoundingSphereCollided(shape1)) {
-#ifdef CUDA
+			if (skinned0 || skinned1) {
+				auto shape0 = skinned0 ? static_cast<SkinnedMeshBody*>(obj0) : nullptr;
+				auto shape1 = skinned1 ? static_cast<SkinnedMeshBody*>(obj1) : nullptr;
+
+				if (hdt::needsCollision(shape0, shape1)) {
 					auto it0 = to_update.insert({ shape0, { nullptr, nullptr } }).first;
 					auto it1 = to_update.insert({ shape1, { nullptr, nullptr } }).first;
-#else
-						HDT_LOCK_GUARD(l, lock);
-						bodies.insert(shape0);
-						bodies.insert(shape1);
-#endif
+
 					m_pairs.push_back(std::make_pair(shape0, shape1));
 
 					auto a = shape0->m_shape->asPerTriangleShape();
 					auto b = shape1->m_shape->asPerTriangleShape();
-#ifdef CUDA
+
 					if (a)
 						it0->second.second = a;
 					else
@@ -117,25 +122,11 @@ namespace hdt
 						it0->second.first = a->m_verticesCollision;
 						it1->second.first = b->m_verticesCollision;
 					}
-#else
-						if (a)
-							triangle_shapes.insert(a);
-						else
-							vertex_shapes.insert(shape0->m_shape->asPerVertexShape());
-						if (b)
-							triangle_shapes.insert(b);
-						else
-							vertex_shapes.insert(shape1->m_shape->asPerVertexShape());
-						if (a && b) {
-							vertex_shapes.insert(a->m_verticesCollision.get());
-							vertex_shapes.insert(b->m_verticesCollision.get());
-						}
-#endif
 				}
 			} else
 				getNearCallback()(pair, *this, dispatchInfo);
-#ifdef CUDA
 		}
+
 		bool haveCuda = CudaInterface::instance()->hasCuda() && (!FrameTimer::instance()->running() || FrameTimer::instance()->cudaFrame());
 		FrameTimer::instance()->logEvent(FrameTimer::e_Start);
 		if (haveCuda) {
@@ -261,23 +252,73 @@ namespace hdt
 		FrameTimer::instance()->logEvent(FrameTimer::e_End);
 	}
 #else
-			});
-		concurrency::parallel_for_each(bodies.begin(), bodies.end(), [](SkinnedMeshBody* shape) {
-			shape->internalUpdate();
-		});
-		concurrency::parallel_for_each(vertex_shapes.begin(), vertex_shapes.end(), [](PerVertexShape* shape) {
-			shape->internalUpdate();
-		});
-		concurrency::parallel_for_each(triangle_shapes.begin(), triangle_shapes.end(), [](PerTriangleShape* shape) {
-			shape->internalUpdate();
-		});
-		for (auto body : bodies) {
-			body->m_bulletShape.m_aabb = body->m_shape->m_tree.aabbAll;
+		std::vector<SkinnedMeshBody*> bodies;
+		// SkinnedMeshBody:internalUpdate() already calls m_shape->internalUpdate() for both
+		// PerVertexShape and PerTriangleShape, so separate vertex/triangle shape update lists are
+		// unnecessary. The only shapes not covered are the m_verticesCollision companions
+		// that PerTriangleShape creates for triangle-vs-triangle collision pairs.
+		// Tldr: Triangle shapes ARE still updated because body->internalUpdate() handles them
+		std::vector<PerVertexShape*> extra_vertex_shapes;
+
+		bodies.reserve(size * 2);
+		extra_vertex_shapes.reserve(size);
+
+		for (int i = 0; i < size; ++i) {
+			auto& pair = pairs[i];
+			auto obj0 = static_cast<btCollisionObject*>(pair.m_pProxy0->m_clientObject);
+			auto obj1 = static_cast<btCollisionObject*>(pair.m_pProxy1->m_clientObject);
+
+			bool skinned0 = isSkinnedMesh(obj0);
+			bool skinned1 = isSkinnedMesh(obj1);
+
+			if (skinned0 || skinned1) {
+				auto shape0 = skinned0 ? static_cast<SkinnedMeshBody*>(obj0) : nullptr;
+				auto shape1 = skinned1 ? static_cast<SkinnedMeshBody*>(obj1) : nullptr;
+
+				if (hdt::needsCollision(shape0, shape1)) {
+					bodies.push_back(shape0);
+					bodies.push_back(shape1);
+					m_pairs.push_back(std::make_pair(shape0, shape1));
+
+					auto a = shape0->m_shape->asPerTriangleShape();
+					auto b = shape1->m_shape->asPerTriangleShape();
+
+					if (a && b) {
+						extra_vertex_shapes.push_back(a->m_verticesCollision.get());
+						extra_vertex_shapes.push_back(b->m_verticesCollision.get());
+					}
+				}
+			} else {
+				// [3/13/2026]
+				// This should never be called. We do addRigidBody(&system->m_bones[i]->m_rig, 0, 0) which means it's invisible
+				// to bullet's collision detector entirely. Why is this here? Likely in preparation for non-skinned objects..?
+				getNearCallback()(pair, *this, dispatchInfo);
+			}
 		}
+
+		// Wipe duplicates, since we don't want to reskin anything!
+		std::sort(bodies.begin(), bodies.end());
+		bodies.erase(std::unique(bodies.begin(), bodies.end()), bodies.end());
+
+		std::sort(extra_vertex_shapes.begin(), extra_vertex_shapes.end());
+		extra_vertex_shapes.erase(std::unique(extra_vertex_shapes.begin(), extra_vertex_shapes.end()), extra_vertex_shapes.end());
+
+		concurrency::parallel_for_each(bodies.begin(), bodies.end(), [](SkinnedMeshBody* shape) {
+			if (shape->m_useBoundingSphere)
+				shape->internalUpdate();
+		});
+
+		if (!extra_vertex_shapes.empty()) {
+			concurrency::parallel_for_each(extra_vertex_shapes.begin(), extra_vertex_shapes.end(), [](PerVertexShape* shape) {
+				shape->internalUpdate();
+			});
+		}
+
 		concurrency::parallel_for_each(m_pairs.begin(), m_pairs.end(), [&, this](const std::pair<SkinnedMeshBody*, SkinnedMeshBody*>& i) {
 			if (i.first->m_shape->m_tree.collapseCollideL(&i.second->m_shape->m_tree))
 				SkinnedMeshAlgorithm::processCollision(i.first, i.second, this);
 		});
+
 		m_pairs.clear();
 	}
 #endif


### PR DESCRIPTION
What this commit does:

- Removes all pointless lock overhead for both cuda and cpu
- Fixes a "bug" with the body0/body1 typo (Although as noted, likely dead code)
- Documents the file further to provide context, and insight into the flow
- Significantly optimizes the function by avoiding pointless skin updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized collision detection dispatching for improved performance in physics calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->