### PR TITLE
fix: Avoid dangling pointer issues

### DIFF
--- a/src/hdtSkyrimBone.cpp
+++ b/src/hdtSkyrimBone.cpp
@@ -23,7 +23,7 @@ namespace hdt
 	void SkyrimBone::resetTransformToOriginal()
 	{
 		m_node->local = convertBt(m_origTransform);
-		updateTransformUpDown(m_node, false);
+		updateTransformUpDown(m_node.get(), false);
 	}
 
 	void SkyrimBone::readTransform(float timeStep)
@@ -110,7 +110,7 @@ namespace hdt
 		m_node->world = m_node->world;
 
 		if (m_forceUpdateType == 1) {
-			updateTransformUpDown(m_node, false);
+			updateTransformUpDown(m_node.get(), false);
 		} else if (m_forceUpdateType == 2) {
 			const auto& children = m_node->GetChildren();
 			for (uint16_t j = 0; j < children.size(); ++j) {

--- a/src/hdtSkyrimBone.h
+++ b/src/hdtSkyrimBone.h
@@ -15,8 +15,8 @@ namespace hdt
 		void writeTransform() override;
 
 		int m_depth;
-		RE::NiNode* m_node;
-		RE::NiNode* m_skeleton;
+		RE::NiPointer<RE::NiNode> m_node;
+		RE::NiPointer<RE::NiNode> m_skeleton;
 
 	private:
 		int m_forceUpdateType;


### PR DESCRIPTION
This will correct a dangling pointer bug that is leading to the CTD reported in the discord: https://discord.com/channels/939147296963166338/1188211022889230376/1484537017374216377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal memory management for pointer handling.
  * Updated internal method calling conventions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->