### PR TITLE
fix: Correct/improve simulation island assignment

### DIFF
--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -229,6 +229,65 @@ namespace hdt
 		btDiscreteDynamicsWorldMt::integrateTransforms(timeStep);
 	}
 
+	// Todo: Improve island handling in the future!
+	void SkinnedMeshWorld::calculateSimulationIslands()
+	{
+		BT_PROFILE("calculateSimulationIslands");
+		getSimulationIslandManager()->updateActivationState(getCollisionWorld(), getCollisionWorld()->getDispatcher());
+
+		{
+			for (int i = 0; i < m_predictiveManifolds.size(); i++) {
+				btPersistentManifold* manifold = m_predictiveManifolds[i];
+				const btCollisionObject* colObj0 = manifold->getBody0();
+				const btCollisionObject* colObj1 = manifold->getBody1();
+				if (((colObj0) && (!(colObj0)->isStaticOrKinematicObject())) &&
+					((colObj1) && (!(colObj1)->isStaticOrKinematicObject()))) {
+					getSimulationIslandManager()->getUnionFind().unite((colObj0)->getIslandTag(),
+						(colObj1)->getIslandTag());
+				}
+			}
+		}
+		{
+			int numConstraints = int(m_constraints.size());
+			for (int i = 0; i < numConstraints; i++) {
+				btTypedConstraint* constraint = m_constraints[i];
+				if (constraint->isEnabled()) {
+					const btRigidBody* colObj0 = &constraint->getRigidBodyA();
+					const btRigidBody* colObj1 = &constraint->getRigidBodyB();
+
+					if (((colObj0) && (!(colObj0)->isStaticOrKinematicObject())) &&
+						((colObj1) && (!(colObj1)->isStaticOrKinematicObject()))) {
+						getSimulationIslandManager()->getUnionFind().unite((colObj0)->getIslandTag(),
+							(colObj1)->getIslandTag());
+					}
+				}
+			}
+		}
+
+		// Force all dynamic bodies within a single HDT system into one simulation island.
+		// Without this, kinematic bones (added with group=0, mask=0) that anchor constraints
+		// between dynamic bones dont merge islands in Bullet's union-find.. This causes
+		// dynamic bones from the same system to end up in separate islands, dispatched to
+		// different solver threads. Since BT_THREADSAFE is off, getOrInitSolverBody's
+		// companionId is not thread-safe, and shared kinematic bodies become a data race one thread writes
+		// a companionId indexing its own solver body pool, another thread reads it and indexes into a
+		// different pool, dereferencing garbage as a btRigidBody*
+		for (auto& system : m_systems) {
+			int firstDynamicTag = -1;
+			for (auto& bone : system->m_bones) {
+				if (!bone->m_rig.isStaticOrKinematicObject()) {
+					if (firstDynamicTag == -1) {
+						firstDynamicTag = bone->m_rig.getIslandTag();
+					} else {
+						getSimulationIslandManager()->getUnionFind().unite(firstDynamicTag, bone->m_rig.getIslandTag());
+					}
+				}
+			}
+		}
+
+		getSimulationIslandManager()->storeIslandActivationState(getCollisionWorld());
+	}
+
 	// Island-based constraint solving...
 	// btDiscreteDynamicsWorldMt::solveConstraints decomposes the world into independent
 	// simulation islands and dispatches each to a solver from the pool on separate threads.

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "hdtSkinnedMeshSystem.h"
+#include <BulletCollision/CollisionDispatch/btSimulationIslandManager.h>
 #include <BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.h>
 
 namespace hdt
@@ -42,6 +43,7 @@ namespace hdt
 		void predictUnconstraintMotion(btScalar timeStep) override;
 		void integrateTransforms(btScalar timeStep) override;
 		void performDiscreteCollisionDetection() override;
+		void calculateSimulationIslands() override;
 		void solveConstraints(btContactSolverInfo& solverInfo) override;
 
 		std::vector<RE::BSTSmartPointer<SkinnedMeshSystem>> m_systems;


### PR DESCRIPTION
Like I said in this comment:
	       // Force all dynamic bodies within a single HDT system into one simulation island.
		// Without this, kinematic bones (added with group=0, mask=0) that anchor constraints
		// between dynamic bones dont merge islands in Bullet's union-find.. This causes
		// dynamic bones from the same system to end up in separate islands, dispatched to
		// different solver threads. Since BT_THREADSAFE is off, getOrInitSolverBody's
		// companionId is not thread-safe, and shared kinematic bodies become a data race one thread writes
		// a companionId indexing its own solver body pool, another thread reads it and indexes into a
		// different pool, dereferencing garbage as a btRigidBody*


This takes control of bullet's island assignment. On one side, it corrects a race issue that will lead to a crash (As mentioned in the comment), but on the other major plus side it'll avoid creating too many simulation islands which is actually a known and problematic performance concern with Bullet Physics. 

Less thread spam will result in significantly better cpu performance due to less thread pool overhead, and better cache locality! 

Intent of this commit:

- Create islands based off constraint groups, otherwise bullet creates a mess. So a skirt with two groups (Each side is usually a group), will be 2 islands. A ponytail one. And so on. 
- Fixes a CTD due to race issues
- Still avoids locking 
- Most certainly a solid optimization for most if not all people


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized physics simulation calculations for skeletal mesh systems, improving constraint resolution and simulation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->