### PR TITLE
fix: Use stop ERP/CFM for rotations too

### DIFF
--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -1209,6 +1209,14 @@ namespace hdt
 			constraint->setParam(BT_CONSTRAINT_CFM, cinfo.motorCFM, i);
 			constraint->setParam(BT_CONSTRAINT_STOP_ERP, cinfo.stopERP, i);
 			constraint->setParam(BT_CONSTRAINT_STOP_CFM, cinfo.stopCFM, i);
+
+			auto rotMotor = constraint->getRotationalLimitMotor(i);
+			if (rotMotor) {
+				rotMotor->m_motorERP = cinfo.motorERP;
+				rotMotor->m_motorCFM = cinfo.motorCFM;
+				rotMotor->m_stopERP = cinfo.stopERP;
+				rotMotor->m_stopCFM = cinfo.stopCFM;
+			}
 		}
 		constraint->getTranslationalLimitMotor()->m_bounce = cinfo.linearBounce;
 		constraint->getRotationalLimitMotor(0)->m_bounce = cinfo.angularBounce[0];


### PR DESCRIPTION
Right now it only applies this to the linear settings, not entirely sure why since these would be incredibly helpful for avoiding spasms in the rotations too. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved per-axis rotational constraint parameter synchronization, ensuring motor parameters are correctly applied for more accurate physics behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->