### PR TITLE
fix: Build shapes based off the neutral havok pose

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCE_FILES
 	"${SOURCE_DIR}/hdtSkinnedMesh/hdtVertex.h"
 	"${SOURCE_DIR}/Events.h"
 	"${SOURCE_DIR}/Events.cpp"
+	"${SOURCE_DIR}/HavokUtils.h"
 	"${SOURCE_DIR}/Hooks.cpp"
 	"${SOURCE_DIR}/Hooks.h"
 	"${SOURCE_DIR}/dhdtPapyrusFunctions.cpp"

--- a/src/HavokUtils.h
+++ b/src/HavokUtils.h
@@ -1,0 +1,57 @@
+#pragma once
+
+namespace hdt::havok
+{
+	inline const RE::hkaSkeleton* getAnimationSkeleton(RE::Actor* a_actor)
+	{
+		RE::BSAnimationGraphManagerPtr graphManager;
+		if (!a_actor->GetAnimationGraphManager(graphManager) || !graphManager || graphManager->graphs.empty())
+			return nullptr;
+
+		const auto& graph = graphManager->graphs[0];
+		if (!graph || !graph->characterInstance.setup)
+			return nullptr;
+
+		return reinterpret_cast<const RE::hkaSkeleton*>(graph->characterInstance.setup->animationSkeleton.get());
+	}
+
+	inline bool getReferencePoseByIndex(const RE::hkaSkeleton* a_skeleton, std::int32_t a_boneIndex, RE::hkQsTransform& a_outTransform)
+	{
+		if (a_boneIndex < 0 || a_boneIndex >= static_cast<std::int32_t>(a_skeleton->referencePose.size()))
+			return false;
+
+		a_outTransform = a_skeleton->referencePose[a_boneIndex];
+		return true;
+	}
+
+	inline RE::NiTransform hKQsTransformToNiTransform(const RE::hkQsTransform& a_hkTransform)
+	{
+		const auto* r = a_hkTransform.rotation.vec.quad.m128_f32;
+		const float qx = r[0], qy = r[1], qz = r[2], qw = r[3];
+		const float sqx = qx * qx, sqy = qy * qy, sqz = qz * qz, sqw = qw * qw;
+		const float invs = 1.0f / (sqx + sqy + sqz + sqw);
+
+		RE::NiTransform result;
+
+		result.rotate.entry[0][0] = (sqx - sqy - sqz + sqw) * invs;
+		result.rotate.entry[1][1] = (-sqx + sqy - sqz + sqw) * invs;
+		result.rotate.entry[2][2] = (-sqx - sqy + sqz + sqw) * invs;
+
+		auto cross = [&](float a, float b, float c, float d, int i, int j) {
+			result.rotate.entry[i][j] = 2.0f * (a * b + c * d) * invs;
+			result.rotate.entry[j][i] = 2.0f * (a * b - c * d) * invs;
+		};
+
+		cross(qx, qy, qz, qw, 1, 0);
+		cross(qx, qz, qy, qw, 0, 2);
+		cross(qy, qz, qx, qw, 2, 1);
+
+		const auto* t = a_hkTransform.translation.quad.m128_f32;
+		result.translate.x = t[0];
+		result.translate.y = t[1];
+		result.translate.z = t[2];
+		result.scale = a_hkTransform.scale.quad.m128_f32[0];
+
+		return result;
+	}
+}

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -1,6 +1,7 @@
 #include "hdtSkyrimSystem.h"
 #include "hdtSkinnedMesh/hdtSkinnedMeshShape.h"
 
+#include "HavokUtils.h"
 #include "XmlReader.h"
 #include "hdtSkyrimPhysicsWorld.h"
 
@@ -200,15 +201,15 @@ namespace hdt
 		m_model = model;
 		m_filePath = path;
 
-		if (!old_system) {
-			updateTransformUpDown(m_skeleton, true);
-		}
-
 		XMLReader reader((uint8_t*)loaded.data(), loaded.size());
 		m_reader = &reader;
 
 		m_reader->nextStartElement();
 		if (m_reader->GetName() != "system") {
+			if (!old_system) {
+				updateTransformUpDown(m_skeleton, true);
+			}
+
 			return nullptr;
 		}
 
@@ -222,6 +223,37 @@ namespace hdt
 
 		// Set locale to en_US
 		std::setlocale(LC_NUMERIC, "en_US");
+
+		// This forces the skeleton into a neutral reference pose, which avoids building invalid shape data
+		// We pull the references directly from havok for the exact same reference data the engine uses
+		std::vector<std::pair<RE::NiAVObject*, RE::NiTransform>> savedPoses;
+
+		if (auto* userData = skeleton->GetUserData()) {
+			if (auto* actor = userData->As<RE::Actor>()) {
+				if (auto havokSkel = havok::getAnimationSkeleton(actor)) {
+					savedPoses.reserve(havokSkel->bones.size());
+
+					for (int32_t i = 0; i < static_cast<int32_t>(havokSkel->bones.size()); ++i) {
+						if (auto boneNode = skeleton->GetObjectByName(RE::BSFixedString(havokSkel->bones[i].name.data()))) {
+							savedPoses.emplace_back(boneNode, boneNode->local);
+
+							RE::hkQsTransform refPose;
+							if (havok::getReferencePoseByIndex(havokSkel, i, refPose))
+								boneNode->local = havok::hKQsTransformToNiTransform(refPose);
+						}
+					}
+
+					if (!savedPoses.empty()) {
+						RE::NiUpdateData updateData;
+						skeleton->Update(updateData);
+					}
+				}
+			}
+		}
+
+		if (!old_system) {
+			updateTransformUpDown(m_skeleton, true);
+		}
 
 		try {
 			while (m_reader->Inspect()) {
@@ -313,6 +345,13 @@ namespace hdt
 		std::sort(m_mesh->m_bones.begin(), m_mesh->m_bones.end(), [](const auto& a, const auto& b) {
 			return static_cast<SkyrimBone*>(a.get())->m_depth < static_cast<SkyrimBone*>(b.get())->m_depth;
 		});
+
+		// Restore the original pose to avoid a visual 1 havok tick T-Pose (Only for visual reasons, it wont break anything otherwise)
+		for (auto& [node, transform] : savedPoses) node->local = transform;
+		if (!savedPoses.empty()) {
+			RE::NiUpdateData updateData;
+			skeleton->Update(updateData);
+		}
 
 		return m_mesh->valid() ? m_mesh : nullptr;
 	}


### PR DESCRIPTION
This fixes a bug that many aren't even aware exists unless you have a very complex outfit (Like the chains from Devious Devices).

SMP builds it's data on improper reference data. Leading to either offset physics items, different physics, etc. Mostly only noticeable when an outfit has like a chain link between two nodes. 

It works by just grabbing the neutral reference pose from the actor's havok skeleton, applying it, building the shapes, then just to avoid a 1 havok tick T-Pose - resets back to the original pose. 

This has been extensively tested on my SMPFixes mod for a few months now. No issues 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utility routines to access animation skeleton data and convert transforms for improved animation interoperability.

* **Improvements**
  * More robust system initialization that temporarily applies reference poses, updates skeleton state, and restores original poses for reliable bone transform handling.

* **Build System**
  * Build configuration updated to include the new utility components in the library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->