### PR TITLE
perf: Use a special spinlock for highly contested areas

### DIFF
--- a/src/hdtSkinnedMesh/hdtBulletHelper.h
+++ b/src/hdtSkinnedMesh/hdtBulletHelper.h
@@ -397,4 +397,30 @@ namespace hdt
 	template <class T>
 	using vectorA16 = std::vector<T>;
 
+	class SpinLock
+	{
+		std::atomic<bool> m_flag{ false };
+
+	public:
+		void lock() noexcept
+		{
+			for (;;) {
+				if (!m_flag.exchange(true, std::memory_order_acquire))
+					return;
+				// spin on cachelocal read until it looks free
+				while (m_flag.load(std::memory_order_relaxed))
+					_mm_pause();
+			}
+		}
+
+		void unlock() noexcept
+		{
+			m_flag.store(false, std::memory_order_release);
+		}
+
+		bool try_lock() noexcept
+		{
+			return !m_flag.exchange(true, std::memory_order_acquire);
+		}
+	};
 }

--- a/src/hdtSkinnedMesh/hdtDispatcher.h
+++ b/src/hdtSkinnedMesh/hdtDispatcher.h
@@ -42,7 +42,7 @@ namespace hdt
 
 		void clearAllManifold();
 
-		std::mutex m_lock;
+		hdt::SpinLock m_lock;
 		std::vector<std::pair<SkinnedMeshBody*, SkinnedMeshBody*>> m_pairs;
 #ifdef CUDA
 		std::vector<std::function<void()>> m_immediateFuncs;


### PR DESCRIPTION
Fair performance improvement here. 

I removed the old mutex since it's an overkill for how lightweight the functions using it are. Not to mention this whole process is ran on the main thread, so spinlocks just make more sense.

This is a TTAS spinlock which is designed specifically for highly contested areas like this. 

Surprisingly yielded a ~0.20ms average performance increase on my 9950X3D in an average scene (More complex scene would be better obviously). Was expecting much lower!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal synchronization mechanisms in the collision detection system for improved performance and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->