### PR TITLE
fix: Skeleton node memory leak

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -673,18 +673,36 @@ namespace hdt
 
 	void ActorManager::Skeleton::doSkeletonClean(RE::NiNode* dst, std::string_view prefix)
 	{
-		auto& children = dst->GetChildren();
+		std::vector<std::pair<RE::NiNode*, RE::NiAVObject*>> toDetach;
 
-		for (uint16_t i = children.size(); i-- > 0;) {
-			auto child = castNiNode(children[static_cast<std::uint16_t>(i)].get());
-			if (!child)
-				continue;
+		std::function<void(RE::NiNode*)> traverse = [&](RE::NiNode* node) {
+			if (!node)
+				return;
+			for (auto& childPtr : node->GetChildren()) {
+				if (!childPtr)
+					continue;
+				auto* rawChild = childPtr.get();
 
-			if (prefix == std::string_view(child->name).substr(0, prefix.size())) {
-				dst->DetachChildAt2(i);
-			} else {
-				doSkeletonClean(child, prefix);
+				const char* cname = rawChild->name.c_str();
+				std::string_view childName = (cname && cname[0]) ? std::string_view(cname) : std::string_view{};
+
+				if (childName.size() >= prefix.size() &&
+					childName.substr(0, prefix.size()) == prefix) {
+					toDetach.push_back({ node, rawChild });
+				} else {
+					auto* childNode = rawChild->AsNode();
+					if (childNode) {
+						traverse(childNode);
+					}
+				}
 			}
+		};
+
+		traverse(dst);
+
+		for (auto& [parent, child] : toDetach) {
+			RE::NiPointer<RE::NiAVObject> ref;
+			parent->DetachChild(child, ref);
 		}
 	}
 
@@ -1110,9 +1128,12 @@ namespace hdt
 		// clean swapped out headparts
 		cleanHead();
 
-		this->head.headNode = hdt::make_nismart(headNode);
-		++this->head.id;
-		this->head.prefix = headPrefix(this->head.id);
+		// Todo: This didn't have a null check before, but I don't see why not.
+		if (!this->head.headNode) {
+			this->head.headNode = hdt::make_nismart(headNode);
+			++this->head.id;
+			this->head.prefix = headPrefix(this->head.id);
+		}
 
 		auto it = std::find_if(this->head.headParts.begin(), this->head.headParts.end(), [geometry](const Head::HeadPart& p) {
 			return p.headPart == geometry;


### PR DESCRIPTION
This fixes a long standing bug with SMP where nodes could sometimes permanently be stuck in the Skyrim skeleton in a corrupted state.  Some of the code might seem redundant, but this really is the best way to remove these annoying a** nodes once they are in this state... If you traverse the tree any other way, it'll fail to pick up these corrupted nodes.

Secondly, I put a null check around the headNode assignment. I could see how that could potentially lead to other issues such as memory leaks too. I tested it pretty extensively to verify it didn't cause issues of it's own. Left a "Todo" as I don't consider that "fix" complete and plan to come back to it in the future with an actual debugger attached to verify all is well. 

Why did you use DetatchChild1 over DetatchChild2? Are you STUPID?
DetatchChild2 is suppose to clear the memory for us, but for WHATEVER reason it was leaking. I don't care enough to look into it, this works - the memory is free - everyone is happy!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety of actor skeleton management with additional validation checks to prevent potential null pointer issues and crashes.
  * Enhanced stability of node hierarchy operations and descendant node handling during cleanup processes.

* **Refactor**
  * Optimized skeleton cleanup traversal logic and node detachment operations to improve overall performance and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->