### PR TITLE
build: Per-preset build dirs + build presets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            build/vcpkg_installed
+            out/build/${{ matrix.preset }}/vcpkg_installed
             ~\AppData\Local\vcpkg\archives
           # Adding the preset name to the key ensures the presets don't overwrite each other's cache
           key: vcpkg-${{ runner.os }}-${{ github.ref_name }}-${{ matrix.preset }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/ports/**') }}
@@ -213,20 +213,20 @@ jobs:
           cmake --preset ${{ matrix.preset }} `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_MANIFEST_MODE=ON `
-            -DCompiledPluginsPath="${{ github.workspace }}/build/plugins"
+            -DCompiledPluginsPath="${{ github.workspace }}/out/build/${{ matrix.preset }}/plugins"
 
       - name: Create the CompiledPluginsPath folder structure
-        run: mkdir -p "${{ github.workspace }}/build/plugins/SKSE/Plugins/"
+        run: mkdir -p "${{ github.workspace }}/out/build/${{ matrix.preset }}/plugins/SKSE/Plugins/"
         shell: bash
 
       - name: Build according to the preset
-        run: cmake --build build --config Release
+        run: cmake --build out/build/${{ matrix.preset }} --config Release
 
       - name: Upload the build folder
         uses: actions/upload-artifact@v4
         with:
           name: raw-${{ matrix.preset }}
-          path: build/plugins/
+          path: out/build/${{ matrix.preset }}/plugins/
 
   release:
     needs: [prepare, build, check_messages]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,248 +1,248 @@
 {
-   "configurePresets":[
-      {
-         "binaryDir":"${sourceDir}/out/build/${presetName}",
-         "cacheVariables":{
-            "CMAKE_BUILD_TYPE":{
-               "type":"STRING",
-               "value":"Debug"
-            }
-         },
-         "errors":{
-            "deprecated":true
-         },
-         "hidden":true,
-         "name":"cmake-dev",
-         "warnings":{
-            "deprecated":true,
-            "dev":true
-         }
+  "configurePresets": [
+    {
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Debug"
+        }
       },
-      {
-         "cacheVariables":{
-            "CMAKE_TOOLCHAIN_FILE":{
-               "type":"STRING",
-               "value":"$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-            },
-            "VCPKG_OVERLAY_PORTS":{
-               "type":"STRING",
-               "value":"${sourceDir}/cmake/ports"
-            },
-            "VCPKG_OVERLAY_TRIPLETS":{
-               "type":"STRING",
-               "value":"${sourceDir}/cmake/triplets"
-            }
-         },
-         "hidden":true,
-         "name":"vcpkg"
+      "errors": {
+        "deprecated": true
       },
-      {
-         "cacheVariables":{
-            "CMAKE_MSVC_RUNTIME_LIBRARY":{
-               "type":"STRING",
-               "value":"MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
-            },
-            "VCPKG_TARGET_TRIPLET":{
-               "type":"STRING",
-               "value":"x64-windows-static-md"
-            }
-         },
-         "hidden":true,
-         "name":"windows"
-      },
-      {
-         "cacheVariables":{
-            "VCPKG_TARGET_TRIPLET":{
-               "type":"STRING",
-               "value":"x64-windows-static-md-avx"
-            }
-         },
-         "hidden":true,
-         "inherits":[
-            "windows"
-         ],
-         "name":"windows-avx"
-      },
-      {
-         "cacheVariables":{
-            "VCPKG_TARGET_TRIPLET":{
-               "type":"STRING",
-               "value":"x64-windows-static-md-avx2"
-            }
-         },
-         "hidden":true,
-         "inherits":[
-            "windows"
-         ],
-         "name":"windows-avx2"
-      },
-      {
-         "cacheVariables":{
-            "VCPKG_TARGET_TRIPLET":{
-               "type":"STRING",
-               "value":"x64-windows-static-md-avx512"
-            }
-         },
-         "hidden":true,
-         "inherits":[
-            "windows"
-         ],
-         "name":"windows-avx512"
-      },
-      {
-         "architecture":{
-            "strategy":"set",
-            "value":"x64"
-         },
-         "cacheVariables":{
-            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX"
-         },
-         "generator":"Visual Studio 17 2022",
-         "inherits":[
-            "cmake-dev",
-            "vcpkg",
-            "windows"
-         ],
-         "name":"vs2022-windows-nocuda",
-         "toolset":"v143"
-      },
-      {
-         "architecture":{
-            "strategy":"set",
-            "value":"x64"
-         },
-         "cacheVariables":{
-            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX"
-         },
-         "generator":"Visual Studio 17 2022",
-         "inherits":[
-            "cmake-dev",
-            "vcpkg",
-            "windows-avx"
-         ],
-         "name":"vs2022-windows-nocuda-avx",
-         "toolset":"v143"
-      },
-      {
-         "architecture":{
-            "strategy":"set",
-            "value":"x64"
-         },
-         "cacheVariables":{
-            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX2"
-         },
-         "generator":"Visual Studio 17 2022",
-         "inherits":[
-            "cmake-dev",
-            "vcpkg",
-            "windows-avx2"
-         ],
-         "name":"vs2022-windows-nocuda-avx2",
-         "toolset":"v143"
-      },
-      {
-         "architecture":{
-            "strategy":"set",
-            "value":"x64"
-         },
-         "cacheVariables":{
-            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX512"
-         },
-         "generator":"Visual Studio 17 2022",
-         "inherits":[
-            "cmake-dev",
-            "vcpkg",
-            "windows-avx512"
-         ],
-         "name":"vs2022-windows-nocuda-avx512",
-         "toolset":"v143"
-      },
-      {
-         "architecture":{
-            "strategy":"set",
-            "value":"x64"
-         },
-         "cacheVariables":{
-            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX",
-            "ENABLE_CUDA_SUPPORT":"ON"
-         },
-         "generator":"Visual Studio 17 2022",
-         "inherits":[
-            "cmake-dev",
-            "vcpkg",
-            "windows"
-         ],
-         "name":"vs2022-windows-cuda",
-         "toolset":"v143"
-      },
-      {
-         "architecture":{
-            "strategy":"set",
-            "value":"x64"
-         },
-         "cacheVariables":{
-            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX",
-            "ENABLE_CUDA_SUPPORT":"ON"
-         },
-         "generator":"Visual Studio 17 2022",
-         "inherits":[
-            "cmake-dev",
-            "vcpkg",
-            "windows-avx"
-         ],
-         "name":"vs2022-windows-cuda-avx",
-         "toolset":"v143"
-      },
-      {
-         "architecture":{
-            "strategy":"set",
-            "value":"x64"
-         },
-         "cacheVariables":{
-            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX2",
-            "ENABLE_CUDA_SUPPORT":"ON"
-         },
-         "generator":"Visual Studio 17 2022",
-         "inherits":[
-            "cmake-dev",
-            "vcpkg",
-            "windows-avx2"
-         ],
-         "name":"vs2022-windows-cuda-avx2",
-         "toolset":"v143"
-      },
-      {
-         "architecture":{
-            "strategy":"set",
-            "value":"x64"
-         },
-         "cacheVariables":{
-            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX512",
-            "ENABLE_CUDA_SUPPORT":"ON"
-         },
-         "generator":"Visual Studio 17 2022",
-         "inherits":[
-            "cmake-dev",
-            "vcpkg",
-            "windows-avx512"
-         ],
-         "name":"vs2022-windows-cuda-avx512",
-         "toolset":"v143"
+      "hidden": true,
+      "name": "cmake-dev",
+      "warnings": {
+        "deprecated": true,
+        "dev": true
       }
-   ],
-   "buildPresets":[
-      {
-         "name":"avx2-debug",
-         "displayName":"Debug",
-         "configurePreset":"vs2022-windows-nocuda-avx2",
-         "configuration":"Debug"
+    },
+    {
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "STRING",
+          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        },
+        "VCPKG_OVERLAY_PORTS": {
+          "type": "STRING",
+          "value": "${sourceDir}/cmake/ports"
+        },
+        "VCPKG_OVERLAY_TRIPLETS": {
+          "type": "STRING",
+          "value": "${sourceDir}/cmake/triplets"
+        }
       },
-      {
-         "name":"avx2-release",
-         "displayName":"Release",
-         "configurePreset":"vs2022-windows-nocuda-avx2",
-         "configuration":"Release"
-      }
-   ],
-   "version":3
+      "hidden": true,
+      "name": "vcpkg"
+    },
+    {
+      "cacheVariables": {
+        "CMAKE_MSVC_RUNTIME_LIBRARY": {
+          "type": "STRING",
+          "value": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
+        },
+        "VCPKG_TARGET_TRIPLET": {
+          "type": "STRING",
+          "value": "x64-windows-static-md"
+        }
+      },
+      "hidden": true,
+      "name": "windows"
+    },
+    {
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": {
+          "type": "STRING",
+          "value": "x64-windows-static-md-avx"
+        }
+      },
+      "hidden": true,
+      "inherits": [
+        "windows"
+      ],
+      "name": "windows-avx"
+    },
+    {
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": {
+          "type": "STRING",
+          "value": "x64-windows-static-md-avx2"
+        }
+      },
+      "hidden": true,
+      "inherits": [
+        "windows"
+      ],
+      "name": "windows-avx2"
+    },
+    {
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": {
+          "type": "STRING",
+          "value": "x64-windows-static-md-avx512"
+        }
+      },
+      "hidden": true,
+      "inherits": [
+        "windows"
+      ],
+      "name": "windows-avx512"
+    },
+    {
+      "architecture": {
+        "strategy": "set",
+        "value": "x64"
+      },
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX"
+      },
+      "generator": "Visual Studio 17 2022",
+      "inherits": [
+        "cmake-dev",
+        "vcpkg",
+        "windows"
+      ],
+      "name": "vs2022-windows-nocuda",
+      "toolset": "v143"
+    },
+    {
+      "architecture": {
+        "strategy": "set",
+        "value": "x64"
+      },
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX"
+      },
+      "generator": "Visual Studio 17 2022",
+      "inherits": [
+        "cmake-dev",
+        "vcpkg",
+        "windows-avx"
+      ],
+      "name": "vs2022-windows-nocuda-avx",
+      "toolset": "v143"
+    },
+    {
+      "architecture": {
+        "strategy": "set",
+        "value": "x64"
+      },
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX2"
+      },
+      "generator": "Visual Studio 17 2022",
+      "inherits": [
+        "cmake-dev",
+        "vcpkg",
+        "windows-avx2"
+      ],
+      "name": "vs2022-windows-nocuda-avx2",
+      "toolset": "v143"
+    },
+    {
+      "architecture": {
+        "strategy": "set",
+        "value": "x64"
+      },
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX512"
+      },
+      "generator": "Visual Studio 17 2022",
+      "inherits": [
+        "cmake-dev",
+        "vcpkg",
+        "windows-avx512"
+      ],
+      "name": "vs2022-windows-nocuda-avx512",
+      "toolset": "v143"
+    },
+    {
+      "architecture": {
+        "strategy": "set",
+        "value": "x64"
+      },
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX",
+        "ENABLE_CUDA_SUPPORT": "ON"
+      },
+      "generator": "Visual Studio 17 2022",
+      "inherits": [
+        "cmake-dev",
+        "vcpkg",
+        "windows"
+      ],
+      "name": "vs2022-windows-cuda",
+      "toolset": "v143"
+    },
+    {
+      "architecture": {
+        "strategy": "set",
+        "value": "x64"
+      },
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX",
+        "ENABLE_CUDA_SUPPORT": "ON"
+      },
+      "generator": "Visual Studio 17 2022",
+      "inherits": [
+        "cmake-dev",
+        "vcpkg",
+        "windows-avx"
+      ],
+      "name": "vs2022-windows-cuda-avx",
+      "toolset": "v143"
+    },
+    {
+      "architecture": {
+        "strategy": "set",
+        "value": "x64"
+      },
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX2",
+        "ENABLE_CUDA_SUPPORT": "ON"
+      },
+      "generator": "Visual Studio 17 2022",
+      "inherits": [
+        "cmake-dev",
+        "vcpkg",
+        "windows-avx2"
+      ],
+      "name": "vs2022-windows-cuda-avx2",
+      "toolset": "v143"
+    },
+    {
+      "architecture": {
+        "strategy": "set",
+        "value": "x64"
+      },
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX512",
+        "ENABLE_CUDA_SUPPORT": "ON"
+      },
+      "generator": "Visual Studio 17 2022",
+      "inherits": [
+        "cmake-dev",
+        "vcpkg",
+        "windows-avx512"
+      ],
+      "name": "vs2022-windows-cuda-avx512",
+      "toolset": "v143"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "avx2-debug",
+      "displayName": "Debug",
+      "configurePreset": "vs2022-windows-nocuda-avx2",
+      "configuration": "Debug"
+    },
+    {
+      "name": "avx2-release",
+      "displayName": "Release",
+      "configurePreset": "vs2022-windows-nocuda-avx2",
+      "configuration": "Release"
+    }
+  ],
+  "version": 3
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,234 +1,248 @@
 {
-  "configurePresets": [
-    {
-      "binaryDir": "${sourceDir}/build",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Debug"
-        }
+   "configurePresets":[
+      {
+         "binaryDir":"${sourceDir}/out/build/${presetName}",
+         "cacheVariables":{
+            "CMAKE_BUILD_TYPE":{
+               "type":"STRING",
+               "value":"Debug"
+            }
+         },
+         "errors":{
+            "deprecated":true
+         },
+         "hidden":true,
+         "name":"cmake-dev",
+         "warnings":{
+            "deprecated":true,
+            "dev":true
+         }
       },
-      "errors": {
-        "deprecated": true
+      {
+         "cacheVariables":{
+            "CMAKE_TOOLCHAIN_FILE":{
+               "type":"STRING",
+               "value":"$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+            },
+            "VCPKG_OVERLAY_PORTS":{
+               "type":"STRING",
+               "value":"${sourceDir}/cmake/ports"
+            },
+            "VCPKG_OVERLAY_TRIPLETS":{
+               "type":"STRING",
+               "value":"${sourceDir}/cmake/triplets"
+            }
+         },
+         "hidden":true,
+         "name":"vcpkg"
       },
-      "hidden": true,
-      "name": "cmake-dev",
-      "warnings": {
-        "deprecated": true,
-        "dev": true
+      {
+         "cacheVariables":{
+            "CMAKE_MSVC_RUNTIME_LIBRARY":{
+               "type":"STRING",
+               "value":"MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
+            },
+            "VCPKG_TARGET_TRIPLET":{
+               "type":"STRING",
+               "value":"x64-windows-static-md"
+            }
+         },
+         "hidden":true,
+         "name":"windows"
+      },
+      {
+         "cacheVariables":{
+            "VCPKG_TARGET_TRIPLET":{
+               "type":"STRING",
+               "value":"x64-windows-static-md-avx"
+            }
+         },
+         "hidden":true,
+         "inherits":[
+            "windows"
+         ],
+         "name":"windows-avx"
+      },
+      {
+         "cacheVariables":{
+            "VCPKG_TARGET_TRIPLET":{
+               "type":"STRING",
+               "value":"x64-windows-static-md-avx2"
+            }
+         },
+         "hidden":true,
+         "inherits":[
+            "windows"
+         ],
+         "name":"windows-avx2"
+      },
+      {
+         "cacheVariables":{
+            "VCPKG_TARGET_TRIPLET":{
+               "type":"STRING",
+               "value":"x64-windows-static-md-avx512"
+            }
+         },
+         "hidden":true,
+         "inherits":[
+            "windows"
+         ],
+         "name":"windows-avx512"
+      },
+      {
+         "architecture":{
+            "strategy":"set",
+            "value":"x64"
+         },
+         "cacheVariables":{
+            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX"
+         },
+         "generator":"Visual Studio 17 2022",
+         "inherits":[
+            "cmake-dev",
+            "vcpkg",
+            "windows"
+         ],
+         "name":"vs2022-windows-nocuda",
+         "toolset":"v143"
+      },
+      {
+         "architecture":{
+            "strategy":"set",
+            "value":"x64"
+         },
+         "cacheVariables":{
+            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX"
+         },
+         "generator":"Visual Studio 17 2022",
+         "inherits":[
+            "cmake-dev",
+            "vcpkg",
+            "windows-avx"
+         ],
+         "name":"vs2022-windows-nocuda-avx",
+         "toolset":"v143"
+      },
+      {
+         "architecture":{
+            "strategy":"set",
+            "value":"x64"
+         },
+         "cacheVariables":{
+            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX2"
+         },
+         "generator":"Visual Studio 17 2022",
+         "inherits":[
+            "cmake-dev",
+            "vcpkg",
+            "windows-avx2"
+         ],
+         "name":"vs2022-windows-nocuda-avx2",
+         "toolset":"v143"
+      },
+      {
+         "architecture":{
+            "strategy":"set",
+            "value":"x64"
+         },
+         "cacheVariables":{
+            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX512"
+         },
+         "generator":"Visual Studio 17 2022",
+         "inherits":[
+            "cmake-dev",
+            "vcpkg",
+            "windows-avx512"
+         ],
+         "name":"vs2022-windows-nocuda-avx512",
+         "toolset":"v143"
+      },
+      {
+         "architecture":{
+            "strategy":"set",
+            "value":"x64"
+         },
+         "cacheVariables":{
+            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX",
+            "ENABLE_CUDA_SUPPORT":"ON"
+         },
+         "generator":"Visual Studio 17 2022",
+         "inherits":[
+            "cmake-dev",
+            "vcpkg",
+            "windows"
+         ],
+         "name":"vs2022-windows-cuda",
+         "toolset":"v143"
+      },
+      {
+         "architecture":{
+            "strategy":"set",
+            "value":"x64"
+         },
+         "cacheVariables":{
+            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX",
+            "ENABLE_CUDA_SUPPORT":"ON"
+         },
+         "generator":"Visual Studio 17 2022",
+         "inherits":[
+            "cmake-dev",
+            "vcpkg",
+            "windows-avx"
+         ],
+         "name":"vs2022-windows-cuda-avx",
+         "toolset":"v143"
+      },
+      {
+         "architecture":{
+            "strategy":"set",
+            "value":"x64"
+         },
+         "cacheVariables":{
+            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX2",
+            "ENABLE_CUDA_SUPPORT":"ON"
+         },
+         "generator":"Visual Studio 17 2022",
+         "inherits":[
+            "cmake-dev",
+            "vcpkg",
+            "windows-avx2"
+         ],
+         "name":"vs2022-windows-cuda-avx2",
+         "toolset":"v143"
+      },
+      {
+         "architecture":{
+            "strategy":"set",
+            "value":"x64"
+         },
+         "cacheVariables":{
+            "CMAKE_CXX_FLAGS":"/EHsc /MP /W4 /WX /arch:AVX512",
+            "ENABLE_CUDA_SUPPORT":"ON"
+         },
+         "generator":"Visual Studio 17 2022",
+         "inherits":[
+            "cmake-dev",
+            "vcpkg",
+            "windows-avx512"
+         ],
+         "name":"vs2022-windows-cuda-avx512",
+         "toolset":"v143"
       }
-    },
-    {
-      "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": {
-          "type": "STRING",
-          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-        },
-        "VCPKG_OVERLAY_PORTS": {
-          "type": "STRING",
-          "value": "${sourceDir}/cmake/ports"
-        },
-        "VCPKG_OVERLAY_TRIPLETS": {
-          "type": "STRING",
-          "value": "${sourceDir}/cmake/triplets"
-        }
+   ],
+   "buildPresets":[
+      {
+         "name":"avx2-debug",
+         "displayName":"Debug",
+         "configurePreset":"vs2022-windows-nocuda-avx2",
+         "configuration":"Debug"
       },
-      "hidden": true,
-      "name": "vcpkg"
-    },
-    {
-      "cacheVariables": {
-        "CMAKE_MSVC_RUNTIME_LIBRARY": {
-          "type": "STRING",
-          "value": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
-        },
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-windows-static-md"
-        }
-      },
-      "hidden": true,
-      "name": "windows"
-    },
-    {
-      "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-windows-static-md-avx"
-        }
-      },
-      "hidden": true,
-      "inherits": [
-        "windows"
-      ],
-      "name": "windows-avx"
-    },
-    {
-      "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-windows-static-md-avx2"
-        }
-      },
-      "hidden": true,
-      "inherits": [
-        "windows"
-      ],
-      "name": "windows-avx2"
-    },
-    {
-      "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": {
-          "type": "STRING",
-          "value": "x64-windows-static-md-avx512"
-        }
-      },
-      "hidden": true,
-      "inherits": [
-        "windows"
-      ],
-      "name": "windows-avx512"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows"
-      ],
-      "name": "vs2022-windows-nocuda",
-      "toolset": "v143"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows-avx"
-      ],
-      "name": "vs2022-windows-nocuda-avx",
-      "toolset": "v143"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX2"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows-avx2"
-      ],
-      "name": "vs2022-windows-nocuda-avx2",
-      "toolset": "v143"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX512"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows-avx512"
-      ],
-      "name": "vs2022-windows-nocuda-avx512",
-      "toolset": "v143"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX",
-        "ENABLE_CUDA_SUPPORT": "ON"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows"
-      ],
-      "name": "vs2022-windows-cuda",
-      "toolset": "v143"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX",
-        "ENABLE_CUDA_SUPPORT": "ON"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows-avx"
-      ],
-      "name": "vs2022-windows-cuda-avx",
-      "toolset": "v143"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX2",
-        "ENABLE_CUDA_SUPPORT": "ON"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows-avx2"
-      ],
-      "name": "vs2022-windows-cuda-avx2",
-      "toolset": "v143"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX512",
-        "ENABLE_CUDA_SUPPORT": "ON"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows-avx512"
-      ],
-      "name": "vs2022-windows-cuda-avx512",
-      "toolset": "v143"
-    }
-  ],
-  "version": 3
+      {
+         "name":"avx2-release",
+         "displayName":"Release",
+         "configurePreset":"vs2022-windows-nocuda-avx2",
+         "configuration":"Release"
+      }
+   ],
+   "version":3
 }

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ git submodule update --init --recursive
 cmake --preset vs2022-windows-nocuda-avx2
 
 #
-cmake --build build --config Release
+cmake --build --preset avx2-release
 ```
 
 ## Build Targets


### PR DESCRIPTION
Isolate each preset into its own build dir so switching between presets or refreshing the cmake cache in VS doesn't step on anything. Easier + Faster + Happier

Also added explicit build presets for avx2 debug/release to make it a lot easier to work with it in visual studio. 

Will move the build folder to: /out/ rather than just having a build folder in the main project folder. 

This commit basically makes working with visual studio 100x easier and less bug prone. Having one build folder is also incredibly tedious when testing different profiles. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized build system to use preset-specific output directories for improved build organization.
  * Updated build documentation with new preset-based build commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->