### PR TITLE
refactor: cleanup fomod to no longer reference cuda and update configs to remove unused fields 

### DIFF
--- a/fomod tree/configs/configs-compatibility.xml
+++ b/fomod tree/configs/configs-compatibility.xml
@@ -194,8 +194,6 @@
     -->
     <groupEnableMLCP>false</groupEnableMLCP>
 
-
-
     <!--
       erp: (float ]0-1[) The error correction force applied per simulation
       step, constraints will drift apart naturally, this value will exert a

--- a/fomod tree/configs/configs-compatibility.xml
+++ b/fomod tree/configs/configs-compatibility.xml
@@ -173,15 +173,7 @@
     -->
     <disable1stPersonViewPhysics>false</disable1stPersonViewPhysics>
 
-    <!-- ##################### CUDA ####################################### -->
 
-    <!--
-      enableCuda: (boolean) experimental GPU collision algorithm. Try this if
-      you have a slow CPU and fast GPU. This setting will be ignored if you
-      haven't installed the CUDA-enabled version.
-      If no value is set, default is false.
-    -->
-    <enableCuda>true</enableCuda>
 
   </smp>
   <solver>
@@ -196,17 +188,13 @@
     <numIterations>10</numIterations>
 
     <!--
-      groupIterations: (int 0-4096)
-      If no value is set, default is 2.
-    -->
-    <groupIterations>16</groupIterations>
-
-    <!--
       groupEnableMLCP: (boolean) Turns on the higher quality constraint solver,
       better constraint simulation at the cost of performance.
       If no value is set, default is true.
     -->
     <groupEnableMLCP>false</groupEnableMLCP>
+
+
 
     <!--
       erp: (float ]0-1[) The error correction force applied per simulation

--- a/fomod tree/configs/configs-performance.xml
+++ b/fomod tree/configs/configs-performance.xml
@@ -194,8 +194,6 @@
     -->
     <groupEnableMLCP>false</groupEnableMLCP>
 
-
-
     <!--
       erp: (float ]0-1[) The error correction force applied per simulation
       step, constraints will drift apart naturally, this value will exert a

--- a/fomod tree/configs/configs-performance.xml
+++ b/fomod tree/configs/configs-performance.xml
@@ -173,15 +173,7 @@
     -->
     <disable1stPersonViewPhysics>true</disable1stPersonViewPhysics>
 
-    <!-- ##################### CUDA ####################################### -->
 
-    <!--
-      enableCuda: (boolean) experimental GPU collision algorithm. Try this if
-      you have a slow CPU and fast GPU. This setting will be ignored if you
-      haven't installed the CUDA-enabled version.
-      If no value is set, default is false.
-    -->
-    <enableCuda>true</enableCuda>
 
   </smp>
   <solver>
@@ -196,17 +188,13 @@
     <numIterations>8</numIterations>
 
     <!--
-      groupIterations: (int 0-4096)
-      If no value is set, default is 2.
-    -->
-    <groupIterations>16</groupIterations>
-
-    <!--
       groupEnableMLCP: (boolean) Turns on the higher quality constraint solver,
       better constraint simulation at the cost of performance.
       If no value is set, default is true.
     -->
     <groupEnableMLCP>false</groupEnableMLCP>
+
+
 
     <!--
       erp: (float ]0-1[) The error correction force applied per simulation

--- a/fomod tree/configs/configs-quality.xml
+++ b/fomod tree/configs/configs-quality.xml
@@ -173,15 +173,7 @@
     -->
     <disable1stPersonViewPhysics>true</disable1stPersonViewPhysics>
 
-    <!-- ##################### CUDA ####################################### -->
 
-    <!--
-      enableCuda: (boolean) experimental GPU collision algorithm. Try this if
-      you have a slow CPU and fast GPU. This setting will be ignored if you
-      haven't installed the CUDA-enabled version.
-      If no value is set, default is false.
-    -->
-    <enableCuda>true</enableCuda>
 
   </smp>
   <solver>
@@ -196,17 +188,13 @@
     <numIterations>16</numIterations>
 
     <!--
-      groupIterations: (int 0-4096)
-      If no value is set, default is 2.
-    -->
-    <groupIterations>16</groupIterations>
-
-    <!--
       groupEnableMLCP: (boolean) Turns on the higher quality constraint solver,
       better constraint simulation at the cost of performance.
       If no value is set, default is true.
     -->
     <groupEnableMLCP>true</groupEnableMLCP>
+
+
 
     <!--
       erp: (float ]0-1[) The error correction force applied per simulation

--- a/fomod tree/configs/configs-reasonable.xml
+++ b/fomod tree/configs/configs-reasonable.xml
@@ -194,8 +194,6 @@
     -->
     <groupEnableMLCP>false</groupEnableMLCP>
 
-
-
     <!--
       erp: (float ]0-1[) The error correction force applied per simulation
       step, constraints will drift apart naturally, this value will exert a

--- a/fomod tree/configs/configs-reasonable.xml
+++ b/fomod tree/configs/configs-reasonable.xml
@@ -173,15 +173,7 @@
     -->
     <disable1stPersonViewPhysics>false</disable1stPersonViewPhysics>
 
-    <!-- ##################### CUDA ####################################### -->
 
-    <!--
-      enableCuda: (boolean) experimental GPU collision algorithm. Try this if
-      you have a slow CPU and fast GPU. This setting will be ignored if you
-      haven't installed the CUDA-enabled version.
-      If no value is set, default is false.
-    -->
-    <enableCuda>true</enableCuda>
 
   </smp>
   <solver>
@@ -196,17 +188,13 @@
     <numIterations>10</numIterations>
 
     <!--
-      groupIterations: (int 0-4096)
-      If no value is set, default is 2.
-    -->
-    <groupIterations>16</groupIterations>
-
-    <!--
       groupEnableMLCP: (boolean) Turns on the higher quality constraint solver,
       better constraint simulation at the cost of performance.
       If no value is set, default is true.
     -->
     <groupEnableMLCP>false</groupEnableMLCP>
+
+
 
     <!--
       erp: (float ]0-1[) The error correction force applied per simulation

--- a/fomod tree/fomod/ModuleConfig.xml
+++ b/fomod tree/fomod/ModuleConfig.xml
@@ -45,37 +45,8 @@ Current active developers at the time of this writing, ordered by date of involv
 				</group>
 			</optionalFileGroups>
 		</installStep>
-		<installStep name="">
+		<installStep name="AVX">
 			<optionalFileGroups order="Explicit">
-				<group name="CUDA or not" type="SelectExactlyOne">
-					<plugins order="Explicit">
-						<plugin name="CUDA">
-							<description>Q: What is CUDA?
-A: CUDA is a NVidia API enabling general purpose processing on the GPU. Useful when the GPU is powerful, the calculus are adapted for GPU, and the transfers between the CPU and GPU minimal.
-
-If you wish CUDA GPU acceleration, CUDA must be enabled in the MCM.
-CUDA GPU acceleration is not yet enough optimized, so it is often slower than having CUDA disabled.
-
-Moreover, it has been reported that the CUDA version of FSMP is not compatible with NVIDIA‘s Linux drivers.
-If you use Linux, it is recommended you install the NOT CUDA version (thanks Vainly for this info).</description>
-							<conditionFlags>
-								<flag name="CUDA">On</flag>
-							</conditionFlags>
-							<typeDescriptor>
-								<type name="Optional" />
-							</typeDescriptor>
-						</plugin>
-						<plugin name="NOT CUDA (recommended)">
-							<description>Probably more stability and performance with this version rather than a CUDA version with the CUDA option disabled.</description>
-							<conditionFlags>
-								<flag name="CUDA">Off</flag>
-							</conditionFlags>
-							<typeDescriptor>
-								<type name="Recommended" />
-							</typeDescriptor>
-						</plugin>
-					</plugins>
-				</group>
 				<group name="AVX" type="SelectExactlyOne">
 					<plugins order="Explicit">
 						<plugin name="No AVX">
@@ -177,43 +148,6 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 		<patterns>
 			<pattern>
 				<dependencies operator="And">
-					<flagDependency flag="CUDA" value="On" />
-					<flagDependency flag="AVX" value="On" />
-				</dependencies>
-				<files>
-					<folder source="raw-vs2022-windows-cuda-avx\SKSE" destination="SKSE" priority="0" />
-				</files>
-			</pattern>
-			<pattern>
-				<dependencies operator="And">
-					<flagDependency flag="CUDA" value="On" />
-					<flagDependency flag="NOAVX" value="On" />
-				</dependencies>
-				<files>
-					<folder source="raw-vs2022-windows-cuda\SKSE" destination="SKSE" priority="0" />
-				</files>
-			</pattern>
-			<pattern>
-				<dependencies operator="And">
-					<flagDependency flag="CUDA" value="On" />
-					<flagDependency flag="AVX2" value="On" />
-				</dependencies>
-				<files>
-					<folder source="raw-vs2022-windows-cuda-avx2\SKSE" destination="SKSE" priority="0" />
-				</files>
-			</pattern>
-			<pattern>
-				<dependencies operator="And">
-					<flagDependency flag="CUDA" value="On" />
-					<flagDependency flag="AVX512" value="On" />
-				</dependencies>
-				<files>
-					<folder source="raw-vs2022-windows-cuda-avx512\SKSE" destination="SKSE" priority="0" />
-				</files>
-			</pattern>
-			<pattern>
-				<dependencies operator="And">
-					<flagDependency flag="CUDA" value="Off" />
 					<flagDependency flag="NOAVX" value="On" />
 				</dependencies>
 				<files>
@@ -222,7 +156,6 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 			</pattern>
 			<pattern>
 				<dependencies operator="And">
-					<flagDependency flag="CUDA" value="Off" />
 					<flagDependency flag="AVX" value="On" />
 				</dependencies>
 				<files>
@@ -231,7 +164,6 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 			</pattern>
 			<pattern>
 				<dependencies operator="And">
-					<flagDependency flag="CUDA" value="Off" />
 					<flagDependency flag="AVX2" value="On" />
 				</dependencies>
 				<files>
@@ -240,7 +172,6 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 			</pattern>
 			<pattern>
 				<dependencies operator="And">
-					<flagDependency flag="CUDA" value="Off" />
 					<flagDependency flag="AVX512" value="On" />
 				</dependencies>
 				<files>

--- a/fomod tree/fomod/ModuleConfig.xml
+++ b/fomod tree/fomod/ModuleConfig.xml
@@ -147,7 +147,7 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 	<conditionalFileInstalls>
 		<patterns>
 			<pattern>
-				<dependencies operator="And">
+				<dependencies>
 					<flagDependency flag="NOAVX" value="On" />
 				</dependencies>
 				<files>
@@ -155,7 +155,7 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 				</files>
 			</pattern>
 			<pattern>
-				<dependencies operator="And">
+				<dependencies>
 					<flagDependency flag="AVX" value="On" />
 				</dependencies>
 				<files>
@@ -163,7 +163,7 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 				</files>
 			</pattern>
 			<pattern>
-				<dependencies operator="And">
+				<dependencies>
 					<flagDependency flag="AVX2" value="On" />
 				</dependencies>
 				<files>
@@ -171,7 +171,7 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 				</files>
 			</pattern>
 			<pattern>
-				<dependencies operator="And">
+				<dependencies>
 					<flagDependency flag="AVX512" value="On" />
 				</dependencies>
 				<files>


### PR DESCRIPTION
Refactor cleanup fomod to no longer reference cuda and update configs to remove unused fields:

In Vortex

<img width="2307" height="1265" alt="image" src="https://github.com/user-attachments/assets/98d7785e-77bb-4db3-800c-fdfb2bb8a73a" />

<img width="2307" height="1257" alt="image" src="https://github.com/user-attachments/assets/d0ad29eb-01ae-4d21-b2f0-edb89b755fc5" />

<img width="2306" height="1263" alt="image" src="https://github.com/user-attachments/assets/2bc519d8-b4b8-48ae-bf7b-830e12842a4b" />

MO2 on Linux
<img width="1532" height="1068" alt="image" src="https://github.com/user-attachments/assets/d2cf6685-e8cd-4697-a377-a748f1697d95" />

<img width="1532" height="1068" alt="image" src="https://github.com/user-attachments/assets/53968d49-f84f-498b-9f1a-635b2c34b603" />

<img width="1532" height="1068" alt="image" src="https://github.com/user-attachments/assets/6443ecf2-43f7-45d8-970a-44841f5f67d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed CUDA-related configuration settings from system configuration files.
  * Simplified installer by removing CUDA selection option; users now select only CPU instruction set support (No AVX/AVX/AVX2/AVX512).

* **Chores**
  * Updated project dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->