### PR TITLE
perf: Help out the compiler, add some avx2 instructions, and remove pointless code

### DIFF
--- a/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
@@ -3,20 +3,6 @@
 
 namespace hdt
 {
-	SkinnedMeshAlgorithm::SkinnedMeshAlgorithm(const btCollisionAlgorithmConstructionInfo& ci) :
-		btCollisionAlgorithm(ci)
-	{
-	}
-
-	// Algorithm selection for collision checking.
-	// e_CPU is the original one, optimized for CPU performance.
-	// e_CPURefactored is an alternate CPU one, modified for conversion to GPU but still using CPU in practice.
-	// [3/15/2026] Realistically, e_CPURefactored (default) should always be better. e_CPU only does one level of AABB filtering
-	enum CollisionCheckAlgorithmType
-	{
-		e_CPU,
-		e_CPURefactored
-	};
 
 	// CollisionCheckBase1 provides data members and the basic constructor for the target types. Note that we
 	// always collide a vertex shape against something else, so only the second type is templated.
@@ -224,8 +210,7 @@ namespace hdt
 		}
 	};
 
-	// CollisionCheckDispatcher provides a dispatch method to process two lists of colliders.
-	template <typename T, bool SwapResults, CollisionCheckAlgorithmType Algorithm>
+	template <typename T, bool SwapResults>
 	struct CollisionCheckDispatcher : public CollisionChecker<T, SwapResults>
 	{
 		template <typename... Ts>
@@ -233,7 +218,8 @@ namespace hdt
 			CollisionChecker<T, SwapResults>(std::forward<Ts>(ts)...)
 		{}
 
-		void dispatch(ColliderTree* a, ColliderTree* b, const std::vector<Aabb*>& listA, const std::vector<Aabb*>& listB)
+		// Modern Fast Dynamic 1D Sweep and Prune Algorithm eliminating O(N*M) tests
+		void dispatch(ColliderTree* a, ColliderTree* b, std::vector<Aabb*>& listA, std::vector<Aabb*>& listB)
 		{
 			CollisionResult result;
 			CollisionResult temp;
@@ -263,19 +249,16 @@ namespace hdt
 		}
 	};
 
-	// CollisionCheckAlgorithm does the full check between collider trees.
-	template <typename T, bool SwapResults = false, CollisionCheckAlgorithmType Algorithm = e_CPURefactored>
-	struct CollisionCheckAlgorithm : public CollisionCheckDispatcher<T, SwapResults, Algorithm>
+	template <typename T, bool SwapResults = false>
+	struct CollisionCheckAlgorithm : public CollisionCheckDispatcher<T, SwapResults>
 	{
 		template <typename... Ts>
 		CollisionCheckAlgorithm(Ts&&... ts) :
-			CollisionCheckDispatcher<T, SwapResults, Algorithm>(std::forward<Ts>(ts)...)
+			CollisionCheckDispatcher<T, SwapResults>(std::forward<Ts>(ts)...)
 		{}
 
 		int operator()()
 		{
-			static_assert(Algorithm != e_CPU, "Old CPU algorithm specialization missing");
-
 			std::vector<std::pair<ColliderTree*, ColliderTree*>> pairs;
 			pairs.reserve(this->c0->colliders.size() + this->c1->colliders.size());
 			this->c0->checkCollisionL(this->c1, pairs);
@@ -347,104 +330,6 @@ namespace hdt
 		}
 	};
 
-	// Old algorithm - lower memory use, possibly faster (for CPU), but not at all suited to GPU processing
-	template <typename T, bool SwapResults>
-	struct CollisionCheckAlgorithm<T, SwapResults, e_CPU> : public CollisionChecker<T, SwapResults>
-	{
-		template <typename... Ts>
-		CollisionCheckAlgorithm(Ts&&... ts) :
-			CollisionChecker<T, SwapResults>(std::forward<Ts>(ts)...)
-		{}
-
-		int operator()()
-		{
-			std::vector<std::pair<ColliderTree*, ColliderTree*>> pairs;
-			pairs.reserve(this->c0->colliders.size() + this->c1->colliders.size());
-			this->c0->checkCollisionL(this->c1, pairs);
-			if (pairs.empty())
-				return 0;
-
-			decltype(auto) func = [this](const std::pair<ColliderTree*, ColliderTree*>& pair) {
-				if (this->numResults >= SkinnedMeshAlgorithm::MaxCollisionCount)
-					return;
-
-				auto a = pair.first, b = pair.second;
-
-				auto aabbA = a->aabbMe;
-				auto aabbB = b->aabbMe;
-				auto abeg = a->aabb;
-				auto bbeg = b->aabb;
-				auto asize = b->isKinematic ? a->dynCollider : a->numCollider;
-				auto bsize = a->isKinematic ? b->dynCollider : b->numCollider;
-				auto aend = abeg + asize;
-				auto bend = bbeg + bsize;
-
-				CollisionResult result;
-				CollisionResult temp;
-				bool hasResult = false;
-
-				thread_local std::vector<Aabb*> list;
-				if (asize > bsize) {
-					list.reserve(std::max<size_t>(bsize, list.capacity()));
-					for (auto i = bbeg; i < bend; ++i) {
-						if (i->collideWith(aabbA))
-							list.push_back(i);
-					}
-
-					for (auto i = abeg; i < aend; ++i) {
-						if (!i->collideWith(aabbB))
-							continue;
-
-						for (auto j : list) {
-							if (!i->collideWith(*j))
-								continue;
-							if (this->checkCollide(&a->cbuf[i - abeg], &b->cbuf[j - bbeg], temp)) {
-								if (!hasResult || result.depth > temp.depth) {
-									hasResult = true;
-									result = temp;
-								}
-							}
-						}
-					}
-				} else {
-					list.reserve(std::max<size_t>(bsize, list.capacity()));
-					for (auto i = abeg; i < aend; ++i) {
-						if (i->collideWith(aabbB))
-							list.push_back(i);
-					}
-
-					for (auto j = bbeg; j < bend; ++j) {
-						if (!j->collideWith(aabbA))
-							continue;
-
-						for (auto i : list) {
-							if (!i->collideWith(*j))
-								continue;
-							if (this->checkCollide(&a->cbuf[i - abeg], &b->cbuf[j - bbeg], temp)) {
-								if (!hasResult || result.depth > temp.depth) {
-									hasResult = true;
-									result = temp;
-								}
-							}
-						}
-					}
-				}
-				list.clear();
-
-				if (hasResult) {
-					this->addResult(result);
-				}
-			};
-
-			if (pairs.size() >= std::thread::hardware_concurrency())
-				concurrency::parallel_for_each(pairs.begin(), pairs.end(), func);
-			else
-				for (auto& i : pairs) func(i);
-
-			return this->numResults;
-		}
-	};
-
 	template <class T1>
 	int checkCollide(PerVertexShape* a, T1* b, CollisionResult* results)
 	{
@@ -456,8 +341,8 @@ namespace hdt
 		return CollisionCheckAlgorithm<PerTriangleShape, true>(b, a, results)();
 	}
 
-	void SkinnedMeshAlgorithm::MergeBuffer::doMerge(SkinnedMeshShape* a, SkinnedMeshShape* b,
-		CollisionResult* collision, int count)
+	template <class T0, class T1>
+	void SkinnedMeshAlgorithm::MergeBuffer::doMerge(T0* a, T1* b, CollisionResult* collision, int count)
 	{
 		for (int i = 0; i < count; ++i) {
 			auto& res = collision[i];
@@ -600,11 +485,5 @@ namespace hdt
 			processCollision(body0->m_shape->asPerVertexShape(), body1->m_shape->asPerVertexShape(), merge, collision.get());
 
 		merge.apply(body0, body1, dispatcher);
-	}
-
-	void SkinnedMeshAlgorithm::registerAlgorithm(btCollisionDispatcherMt* dispatcher)
-	{
-		static CreateFunc s_gimpact_cf;
-		dispatcher->registerCollisionCreateFunc(CUSTOM_CONCAVE_SHAPE_TYPE, CUSTOM_CONCAVE_SHAPE_TYPE, &s_gimpact_cf);
 	}
 }

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.h
@@ -5,36 +5,9 @@
 
 namespace hdt
 {
-	class SkinnedMeshAlgorithm : public btCollisionAlgorithm
+	class SkinnedMeshAlgorithm
 	{
 	public:
-		SkinnedMeshAlgorithm(const btCollisionAlgorithmConstructionInfo& ci);
-
-		void processCollision([[maybe_unused]] const btCollisionObjectWrapper* body0Wrap, [[maybe_unused]] const btCollisionObjectWrapper* body1Wrap, [[maybe_unused]] const btDispatcherInfo& dispatchInfo, [[maybe_unused]] btManifoldResult* resultOut) override
-		{
-		}
-
-		btScalar calculateTimeOfImpact([[maybe_unused]] btCollisionObject* body0, [[maybe_unused]] btCollisionObject* body1, [[maybe_unused]] const btDispatcherInfo& dispatchInfo, [[maybe_unused]] btManifoldResult* resultOut) override
-		{
-			return 1;
-		}  // TOI cost too much
-		void getAllContactManifolds([[maybe_unused]] btManifoldArray& manifoldArray) override
-		{
-		}
-
-		struct CreateFunc : public btCollisionAlgorithmCreateFunc
-		{
-			btCollisionAlgorithm* CreateCollisionAlgorithm(btCollisionAlgorithmConstructionInfo& ci,
-				[[maybe_unused]] const btCollisionObjectWrapper* body0Wrap,
-				[[maybe_unused]] const btCollisionObjectWrapper* body1Wrap) override
-			{
-				void* mem = ci.m_dispatcher1->allocateCollisionAlgorithm(sizeof(SkinnedMeshAlgorithm));
-				return new (mem) SkinnedMeshAlgorithm(ci);
-			}
-		};
-
-		static void registerAlgorithm(btCollisionDispatcherMt* dispatcher);
-
 		// Note: It's possible to exceed this with complex outfits, which is why we cap it.
 		// We don't want to stress a simulation island too much!
 		static const int MaxCollisionCount = 256;
@@ -124,7 +97,9 @@ namespace hdt
 				return c;
 			}
 
-			void doMerge(SkinnedMeshShape* shape0, SkinnedMeshShape* shape1, CollisionResult* collisions, int count);
+			template <class T0, class T1>
+			void doMerge(T0* shape0, T1* shape1, CollisionResult* collisions, int count);
+
 			void apply(SkinnedMeshBody* body0, SkinnedMeshBody* body1, CollisionDispatcher* dispatcher);
 
 			int mergeStride;

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshBody.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshBody.cpp
@@ -24,35 +24,152 @@ namespace hdt
 		return _mm_mul_ps(w, p.get128());
 	}
 
+#if defined(__AVX2__)
+	__forceinline __m128 calcVertexStateFMA(__m128 skinPos, const Bone& bone, __m128 w)
+	{
+		__m128 px = pshufd<0x00>(skinPos);
+		__m128 py = pshufd<0x55>(skinPos);
+		__m128 pz = pshufd<0xAA>(skinPos);
+		__m128 r = _mm_fmadd_ps(bone.m_vertexToWorld.m_col[2].get128(), pz, bone.m_vertexToWorld.m_col[3].get128());
+		r = _mm_fmadd_ps(bone.m_vertexToWorld.m_col[1].get128(), py, r);
+		r = _mm_fmadd_ps(bone.m_vertexToWorld.m_col[0].get128(), px, r);
+		r = _mm_blend_ps(r, _mm_load_ps(bone.m_reserved), 0x8);
+		return _mm_mul_ps(w, r);
+	}
+#endif
+
 	void SkinnedMeshBody::internalUpdate()
 	{
-		for (size_t i = 0; i < m_skinnedBones.size(); ++i) {
-			auto& v = m_skinnedBones[i];
+		const size_t numBones = m_skinnedBones.size();
+		const auto* __restrict skinnedBones = m_skinnedBones.data();
+		auto* __restrict bonesDst = m_bones.data();
+
+		for (size_t i = 0; i < numBones; ++i) {
+			if (i + 8 < numBones)
+				_mm_prefetch((const char*)&skinnedBones[i + 8], _MM_HINT_T1);
+			if (i + 4 < numBones)
+				_mm_prefetch((const char*)skinnedBones[i + 4].ptr, _MM_HINT_T0);
+			auto& v = skinnedBones[i];
 			auto boneT = v.ptr->m_currentTransform;
-			m_bones[i].m_vertexToWorld = btMatrix4x3T(boneT) * v.vertexToBone;
-			m_bones[i].m_maginMultipler = v.ptr->m_marginMultipler * boneT.getScale();
+			bonesDst[i].m_vertexToWorld = btMatrix4x3T(boneT) * v.vertexToBone;
+			bonesDst[i].m_maginMultipler = v.ptr->m_marginMultipler * boneT.getScale();
 		}
 
-		int size = static_cast<int>(m_vpos.size());
+		const int size = static_cast<int>(m_vpos.size());
+		const Vertex* __restrict verts = m_vertices.data();
+		VertexPos* __restrict vpos = m_vpos.data();
+		const Bone* __restrict bones = bonesDst;
 
-		for (int idx = 0; idx < size; ++idx) {
-			auto& v = m_vertices[idx];
+		// We can use AVX2 here due to sequential memory reads..
+#if defined(__AVX2__)
+
+		constexpr int PF = 6;
+		int idx = 0;
+		for (; idx + 1 < size; idx += 2) {
+			if (idx + PF < size) {
+				_mm_prefetch((const char*)&verts[idx + PF], _MM_HINT_T0);
+				_mm_prefetch((const char*)&verts[idx + PF + 1], _MM_HINT_T0);
+			}
+
+			{
+				auto& v = verts[idx];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexStateFMA(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx].set(pm);
+			}
+			{
+				auto& v = verts[idx + 1];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexStateFMA(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexStateFMA(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx + 1].set(pm);
+			}
+		}
+		for (; idx < size; ++idx) {
+			auto& v = verts[idx];
 			auto p = v.m_skinPos.get128();
 			auto w = _mm_load_ps(v.m_weight);
-			auto flg = _mm_movemask_ps(_mm_cmplt_ps(_mm_set_ps1(FLT_EPSILON), w));
-			auto posMargin = calcVertexState(p, m_bones[v.getBoneIdx(0)], setAll0(w));
-			if (flg & 0b0010)
-				posMargin += calcVertexState(p, m_bones[v.getBoneIdx(1)], setAll1(w));
-			if (flg & 0b0100)
-				posMargin += calcVertexState(p, m_bones[v.getBoneIdx(2)], setAll2(w));
-			if (flg & 0b1000)
-				posMargin += calcVertexState(p, m_bones[v.getBoneIdx(3)], setAll3(w));
-			m_vpos[idx].set(posMargin);
+			auto pm = calcVertexStateFMA(p, bones[v.getBoneIdx(0)], setAll0(w));
+			pm += calcVertexStateFMA(p, bones[v.getBoneIdx(1)], setAll1(w));
+			pm += calcVertexStateFMA(p, bones[v.getBoneIdx(2)], setAll2(w));
+			pm += calcVertexStateFMA(p, bones[v.getBoneIdx(3)], setAll3(w));
+			vpos[idx].set(pm);
 		}
 
-		// FIXME PROFILING Lots of times is spent here.
-		m_shape->internalUpdate();
+#else
 
+		constexpr int PF = 8;
+		int idx = 0;
+		for (; idx + 3 < size; idx += 4) {
+			if (idx + PF + 3 < size) {
+				_mm_prefetch((const char*)&verts[idx + PF], _MM_HINT_T0);
+				_mm_prefetch((const char*)&verts[idx + PF + 1], _MM_HINT_T0);
+				_mm_prefetch((const char*)&verts[idx + PF + 2], _MM_HINT_T0);
+				_mm_prefetch((const char*)&verts[idx + PF + 3], _MM_HINT_T0);
+			}
+
+			{
+				auto& v = verts[idx];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx].set(pm);
+			}
+			{
+				auto& v = verts[idx + 1];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx + 1].set(pm);
+			}
+			{
+				auto& v = verts[idx + 2];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx + 2].set(pm);
+			}
+			{
+				auto& v = verts[idx + 3];
+				auto p = v.m_skinPos.get128();
+				auto w = _mm_load_ps(v.m_weight);
+				auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(2)], setAll2(w));
+				pm += calcVertexState(p, bones[v.getBoneIdx(3)], setAll3(w));
+				vpos[idx + 3].set(pm);
+			}
+		}
+		for (; idx < size; ++idx) {
+			auto& v = verts[idx];
+			auto p = v.m_skinPos.get128();
+			auto w = _mm_load_ps(v.m_weight);
+			auto pm = calcVertexState(p, bones[v.getBoneIdx(0)], setAll0(w));
+			pm += calcVertexState(p, bones[v.getBoneIdx(1)], setAll1(w));
+			pm += calcVertexState(p, bones[v.getBoneIdx(2)], setAll2(w));
+			pm += calcVertexState(p, bones[v.getBoneIdx(3)], setAll3(w));
+			vpos[idx].set(pm);
+		}
+
+#endif
+
+		m_shape->internalUpdate();
 		m_bulletShape.m_aabb = m_shape->m_tree.aabbAll;
 	}
 

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshShape.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshShape.cpp
@@ -54,15 +54,23 @@ namespace hdt
 
 	void PerVertexShape::internalUpdate()
 	{
-		auto& vertices = m_owner->m_vpos;
+		const VertexPos* __restrict vertices = m_owner->m_vpos.data();
+		const Collider* __restrict colliders = m_colliders.data();
+		Aabb* __restrict aabbs = m_aabb.data();
+		const size_t size = m_colliders.size();
 
-		size_t size = m_colliders.size();
+		const __m128 marginFactor = _mm_set1_ps(m_shapeProp.margin);
+
 		for (size_t i = 0; i < size; ++i) {
-			auto c = &m_colliders[i];
-			auto p0 = vertices[c->vertex].m_data;
-			auto margin = _mm_set_ps1(p0.m128_f32[3] * m_shapeProp.margin);
-			m_aabb[i].m_min = p0 - margin;
-			m_aabb[i].m_max = p0 + margin;
+			__m128 p0 = vertices[colliders[i].vertex].m_data;
+
+			// Broadcast the W component and multiply by margin factor
+			__m128 bcast = _mm_shuffle_ps(p0, p0, _MM_SHUFFLE(3, 3, 3, 3));
+			__m128 margin = _mm_mul_ps(bcast, marginFactor);
+
+			// Force 16-byte aligned vector stores to prevent MSVC scalar assignment fallback
+			_mm_store_ps(reinterpret_cast<float*>(&aabbs[i].m_min), _mm_sub_ps(p0, margin));
+			_mm_store_ps(reinterpret_cast<float*>(&aabbs[i].m_max), _mm_add_ps(p0, margin));
 		}
 
 		m_tree.updateAabb();
@@ -103,6 +111,10 @@ namespace hdt
 	{
 	}
 
+	// Note: Don't waste your time trying to optimize this...
+	// 1: The compiler auto-vertorizes, unrolls, and broadcasts W already (Very sensitive to changes)
+	// 2: Memory wall is the main issue
+	// 3: AVX2 would just have overhead
 	void PerTriangleShape::internalUpdate()
 	{
 		auto& vertices = m_owner->m_vpos;

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshShape.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshShape.h
@@ -26,7 +26,6 @@ namespace hdt
 		virtual void clipColliders();
 		virtual void finishBuild() = 0;
 		virtual void internalUpdate() = 0;
-		virtual int getBonePerCollider() = 0;
 		virtual void markUsedVertices(bool* flags) = 0;
 		virtual void remapVertices(UINT* map) = 0;
 
@@ -34,6 +33,7 @@ namespace hdt
 		virtual int getColliderBoneIndex(const Collider* c, int boneIdx) = 0;
 		virtual btVector3 baryCoord(const Collider* c, const btVector3& p) = 0;
 		virtual float baryWeight(const btVector3& w, int boneIdx) = 0;
+		virtual int getBonePerCollider() = 0;
 
 		SkinnedMeshBody* m_owner;
 		vectorA16<Aabb> m_aabb;
@@ -49,26 +49,17 @@ namespace hdt
 		virtual ~PerVertexShape();
 
 		PerVertexShape* asPerVertexShape() override { return this; }
-
 		void internalUpdate() override;
-		int getBonePerCollider() override { return 4; }
 
-		float getColliderBoneWeight(const Collider* c, int boneIdx) override
-		{
-			return m_owner->m_vertices[c->vertex].m_weight[boneIdx];
-		}
+		inline int getBonePerCollider() override final { return 4; }
+		inline float getColliderBoneWeight(const Collider* c, int boneIdx) override final { return m_owner->m_vertices[c->vertex].m_weight[boneIdx]; }
+		inline int getColliderBoneIndex(const Collider* c, int boneIdx) override final { return m_owner->m_vertices[c->vertex].getBoneIdx(boneIdx); }
+		inline btVector3 baryCoord([[maybe_unused]] const Collider* c, [[maybe_unused]] const btVector3& p) override final { return btVector3(1, 1, 1); }
+		inline float baryWeight([[maybe_unused]] const btVector3& w, [[maybe_unused]] int boneIdx) override final { return 1; }
 
-		int getColliderBoneIndex(const Collider* c, int boneIdx) override
-		{
-			return m_owner->m_vertices[c->vertex].getBoneIdx(boneIdx);
-		}
-
-		btVector3 baryCoord([[maybe_unused]] const Collider* c, [[maybe_unused]] const btVector3& p) override { return btVector3(1, 1, 1); }
-		float baryWeight([[maybe_unused]] const btVector3& w, [[maybe_unused]] int boneIdx) override { return 1; }
 		void finishBuild() override;
 		void markUsedVertices(bool* flags) override;
 		void remapVertices(UINT* map) override;
-
 		void autoGen();
 
 		struct ShapeProp
@@ -85,21 +76,12 @@ namespace hdt
 
 		PerVertexShape* asPerVertexShape() override { return m_verticesCollision.get(); }
 		PerTriangleShape* asPerTriangleShape() override { return this; }
-
 		void internalUpdate() override;
-		int getBonePerCollider() override { return 12; }
 
-		float getColliderBoneWeight(const Collider* c, int boneIdx) override
-		{
-			return m_owner->m_vertices[c->vertices[boneIdx / 4]].m_weight[boneIdx % 4];
-		}
-
-		int getColliderBoneIndex(const Collider* c, int boneIdx) override
-		{
-			return m_owner->m_vertices[c->vertices[boneIdx / 4]].getBoneIdx(boneIdx % 4);
-		}
-
-		btVector3 baryCoord(const Collider* c, const btVector3& p) override
+		inline int getBonePerCollider() override final { return 12; }
+		inline float getColliderBoneWeight(const Collider* c, int boneIdx) override final { return m_owner->m_vertices[c->vertices[boneIdx / 4]].m_weight[boneIdx % 4]; }
+		inline int getColliderBoneIndex(const Collider* c, int boneIdx) override final { return m_owner->m_vertices[c->vertices[boneIdx / 4]].getBoneIdx(boneIdx % 4); }
+		inline btVector3 baryCoord(const Collider* c, const btVector3& p) override final
 		{
 			return BaryCoord(
 				m_owner->m_vpos[c->vertices[0]].pos(),
@@ -107,7 +89,8 @@ namespace hdt
 				m_owner->m_vpos[c->vertices[2]].pos(),
 				p);
 		}
-		float baryWeight(const btVector3& w, int boneIdx) override { return w[boneIdx / 4]; }
+		inline float baryWeight(const btVector3& w, int boneIdx) override final { return w[boneIdx / 4]; }
+
 		void finishBuild() override;
 		void markUsedVertices(bool* flags) override;
 		void remapVertices(UINT* map) override;

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -29,8 +29,6 @@ namespace hdt
 		auto collisionConfiguration = new btDefaultCollisionConfiguration;
 		auto collisionDispatcher = new CollisionDispatcher(collisionConfiguration);
 
-		SkinnedMeshAlgorithm::registerAlgorithm(collisionDispatcher);
-
 		m_dispatcher1 = collisionDispatcher;
 		m_broadphasePairCache = new btDbvtBroadphase();
 	}


### PR DESCRIPTION
This once again focuses on our dispatch path. The performance increase will mostly be noticed on AVX2 supported hardware though. 

Commit notes:

- We don't need to extend btCollisionAlgorithmConstructionInfo, that was likely very old code. We control the dispatcher, so that was just dead code. 
- Removed the virtual calls in the collision algorithm. Pointless overhead
- Optimized "SkinnedMeshBody::internalUpdate" - There's now a proper AVX2 path

**For SkinnedMeshBody::internalUpdate, a couple notes:**
This looks very messy, but it's a battle with the compiler. The compiler refuses to add FMA correctly and is creating chain stalls. So we unroll it a bit manually, and explicitly add a calcVertexStateFMA function instead of hoping the compiler will handle it for us. 

This nasty looking code is taking full advantage of ILP basically without stalling. 

The SIMD path probably doesn't need a manual unroll, but I figured FUCK it.

**void PerVertexShape::internalUpdate():**
This function had a scalar extraction stall, and was making the compiler emit poor instructions. It was emitting 4 separate 4 byte scalar writes instead of 1 fast 16 byte. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined collision detection architecture by removing legacy algorithm dispatching and decoupling internal systems.
  * Optimized vertex computation with AVX2 SIMD operations and prefetching for improved performance.
  * Generalized internal merge logic for enhanced type flexibility.
  * Simplified and finalized public interface methods for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->