### PR TITLE
fix: Add VR offset manually

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -344,7 +344,7 @@ namespace Hooks
 
 	void BSFaceGenNiNodeHooks::HookSetBoneName()
 	{
-		static REL::Relocation<uintptr_t> addr{ REL::RelocationID(26303, 26886) };
+		static REL::Relocation<uintptr_t> addr{ REL::VariantID(26303, 26886, 0x3E44E0) };
 		_SetBoneName = reinterpret_cast<SetBoneName_t*>(addr.address());
 		DetourAttach((PVOID*)&_SetBoneName, (PVOID)SetBoneName_Hook);
 	}


### PR DESCRIPTION
Alandtse recently added the HookSetBoneName VR offset to the VR address-library project. However, since it was added so recently and that version has issues with some versions of Community Shaders, it is better to manually map it in our project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal memory address resolution mechanism for improved system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->