### PR TITLE
perf: Improve simulation island union

### DIFF
--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -184,7 +184,7 @@ namespace hdt
 
 	void SkinnedMeshWorld::predictUnconstraintMotion(btScalar timeStep)
 	{
-		for (int i = 0; i < m_nonStaticRigidBodies.size(); i++) {
+		concurrency::parallel_for(0, (int)m_nonStaticRigidBodies.size(), [&](int i) {
 			btRigidBody* body = m_nonStaticRigidBodies[i];
 			if (!body->isStaticOrKinematicObject()) {
 				// not realistic, just an approximate
@@ -193,7 +193,7 @@ namespace hdt
 			} else {
 				body->predictIntegratedTransform(timeStep, body->getInterpolationWorldTransform());
 			}
-		}
+		});
 	}
 
 	void SkinnedMeshWorld::integrateTransforms(btScalar timeStep)
@@ -229,58 +229,51 @@ namespace hdt
 		btDiscreteDynamicsWorldMt::integrateTransforms(timeStep);
 	}
 
-	// Todo: Improve island handling in the future!
 	void SkinnedMeshWorld::calculateSimulationIslands()
 	{
 		BT_PROFILE("calculateSimulationIslands");
 		getSimulationIslandManager()->updateActivationState(getCollisionWorld(), getCollisionWorld()->getDispatcher());
 
-		{
-			for (int i = 0; i < m_predictiveManifolds.size(); i++) {
-				btPersistentManifold* manifold = m_predictiveManifolds[i];
-				const btCollisionObject* colObj0 = manifold->getBody0();
-				const btCollisionObject* colObj1 = manifold->getBody1();
+		auto unionFind = &getSimulationIslandManager()->getUnionFind();
+
+		for (int i = 0; i < m_predictiveManifolds.size(); i++) {
+			btPersistentManifold* manifold = m_predictiveManifolds[i];
+			const btCollisionObject* colObj0 = manifold->getBody0();
+			const btCollisionObject* colObj1 = manifold->getBody1();
+			if (((colObj0) && (!(colObj0)->isStaticOrKinematicObject())) &&
+				((colObj1) && (!(colObj1)->isStaticOrKinematicObject()))) {
+				unionFind->unite((colObj0)->getIslandTag(), (colObj1)->getIslandTag());
+			}
+		}
+
+		int numConstraints = int(m_constraints.size());
+		for (int i = 0; i < numConstraints; i++) {
+			btTypedConstraint* constraint = m_constraints[i];
+			if (constraint->isEnabled()) {
+				const btRigidBody* colObj0 = &constraint->getRigidBodyA();
+				const btRigidBody* colObj1 = &constraint->getRigidBodyB();
 				if (((colObj0) && (!(colObj0)->isStaticOrKinematicObject())) &&
 					((colObj1) && (!(colObj1)->isStaticOrKinematicObject()))) {
-					getSimulationIslandManager()->getUnionFind().unite((colObj0)->getIslandTag(),
-						(colObj1)->getIslandTag());
-				}
-			}
-		}
-		{
-			int numConstraints = int(m_constraints.size());
-			for (int i = 0; i < numConstraints; i++) {
-				btTypedConstraint* constraint = m_constraints[i];
-				if (constraint->isEnabled()) {
-					const btRigidBody* colObj0 = &constraint->getRigidBodyA();
-					const btRigidBody* colObj1 = &constraint->getRigidBodyB();
-
-					if (((colObj0) && (!(colObj0)->isStaticOrKinematicObject())) &&
-						((colObj1) && (!(colObj1)->isStaticOrKinematicObject()))) {
-						getSimulationIslandManager()->getUnionFind().unite((colObj0)->getIslandTag(),
-							(colObj1)->getIslandTag());
-					}
+					unionFind->unite((colObj0)->getIslandTag(), (colObj1)->getIslandTag());
 				}
 			}
 		}
 
-		// Force all dynamic bodies within a single HDT system into one simulation island.
-		// Without this, kinematic bones (added with group=0, mask=0) that anchor constraints
-		// between dynamic bones dont merge islands in Bullet's union-find.. This causes
-		// dynamic bones from the same system to end up in separate islands, dispatched to
-		// different solver threads. Since BT_THREADSAFE is off, getOrInitSolverBody's
-		// companionId is not thread-safe, and shared kinematic bodies become a data race one thread writes
-		// a companionId indexing its own solver body pool, another thread reads it and indexes into a
-		// different pool, dereferencing garbage as a btRigidBody*
-		for (auto& system : m_systems) {
-			int firstDynamicTag = -1;
-			for (auto& bone : system->m_bones) {
-				if (!bone->m_rig.isStaticOrKinematicObject()) {
-					if (firstDynamicTag == -1) {
-						firstDynamicTag = bone->m_rig.getIslandTag();
-					} else {
-						getSimulationIslandManager()->getUnionFind().unite(firstDynamicTag, bone->m_rig.getIslandTag());
-					}
+		// If two dynamic bones are colliding, they MUST be processed by the same island! Without this the solver will cause an
+		// EXCEPTION_ACCESS_VIOLATION reading m_tmpSolverBodyPool :(
+		btDispatcher* dispatcher = getCollisionWorld()->getDispatcher();
+		int numManifolds = dispatcher->getNumManifolds();
+		for (int i = 0; i < numManifolds; i++) {
+			btPersistentManifold* manifold = dispatcher->getManifoldByIndexInternal(i);
+
+			// Only unite if they are actively generating contact points
+			if (manifold->getNumContacts() > 0) {
+				const btCollisionObject* colObj0 = static_cast<const btCollisionObject*>(manifold->getBody0());
+				const btCollisionObject* colObj1 = static_cast<const btCollisionObject*>(manifold->getBody1());
+
+				if (((colObj0) && (!(colObj0)->isStaticOrKinematicObject())) &&
+					((colObj1) && (!(colObj1)->isStaticOrKinematicObject()))) {
+					unionFind->unite((colObj0)->getIslandTag(), (colObj1)->getIslandTag());
 				}
 			}
 		}


### PR DESCRIPTION
So my original code was just a quick solution to solve a race issue problem which led to a CTD with certain outfits. (As noted by the todo)

Did a deeper dive, verified BT_THREADSAFE IS enabled (Checked the assembly), and figured out a significantly smarter solution without having to sacrifice some parallelism. 

Now islands are created perfectly, with no pointless joining. Allowing for maximum potential parallelism!

Here's the gains in a very SMP heavy enviroment:

Before:
[12:49:53.969] [41952] [I] smp cost in main loop (msecs): 4.98, cost outside main loop: 5.11, percentage outside vs total: 50.64
[12:49:54.391] [41952] [I] smp cost in main loop (msecs): 5.11, cost outside main loop: 5.33, percentage outside vs total: 51.08
[12:49:54.813] [41952] [I] smp cost in main loop (msecs): 5.05, cost outside main loop: 5.06, percentage outside vs total: 50.06

After:
[12:50:54.584] [30192] [I] smp cost in main loop (msecs): 3.12, cost outside main loop: 3.03, percentage outside vs total: 49.21
[12:50:55.004] [30192] [I] smp cost in main loop (msecs): 3.17, cost outside main loop: 3.17, percentage outside vs total: 49.95
[12:50:55.424] [30192] [I] smp cost in main loop (msecs): 3.19, cost outside main loop: 3.20, percentage outside vs total: 50.09

I also parallelized the predictUnconstraintMotion function. Initially I figured the thread overhead would outweigh the performance gain, but in testing with very heavy setups, I noted a ~0.10ms increase. So for sure a worthwhile optimization I'd say.

And then just a tad bit of code cleanup.. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized physics simulation motion prediction processing for improved efficiency.
  * Refined collision detection island calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->