### PR TITLE
perf: switch to unordered_sets for O(1) lookup

### DIFF
--- a/src/hdtSkinnedMesh/hdtSkinnedMeshBody.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshBody.h
@@ -91,17 +91,17 @@ namespace hdt
 		std::vector<RE::BSFixedString> m_tags;
 		std::unordered_set<RE::BSFixedString> m_canCollideWithTags;
 		std::unordered_set<RE::BSFixedString> m_noCollideWithTags;
-		std::vector<SkinnedMeshBone*> m_canCollideWithBones;
-		std::vector<SkinnedMeshBone*> m_noCollideWithBones;
+		std::unordered_set<SkinnedMeshBone*> m_canCollideWithBones;
+		std::unordered_set<SkinnedMeshBone*> m_noCollideWithBones;
 
 		float flexible(const Vertex& v);
 
 		bool canCollideWith(const SkinnedMeshBone* bone) const
 		{
-			if (m_canCollideWithBones.size()) {
-				return std::find(m_canCollideWithBones.begin(), m_canCollideWithBones.end(), bone) != m_canCollideWithBones.end();
+			if (!m_canCollideWithBones.empty()) {
+				return m_canCollideWithBones.contains(const_cast<SkinnedMeshBone*>(bone));
 			}
-			return std::find(m_noCollideWithBones.begin(), m_noCollideWithBones.end(), bone) == m_noCollideWithBones.end();
+			return !m_noCollideWithBones.contains(const_cast<SkinnedMeshBone*>(bone));
 		}
 
 		virtual bool canCollideWith(const SkinnedMeshBody* body) const;

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -821,11 +821,11 @@ namespace hdt
 				} else if (nodeName == "can-collide-with-bone") {
 					auto bone = getOrCreateBone(m_reader->readText());
 					if (bone)
-						body->m_canCollideWithBones.push_back(bone);
+						body->m_canCollideWithBones.insert(bone);
 				} else if (nodeName == "no-collide-with-bone") {
 					auto bone = getOrCreateBone(m_reader->readText());
 					if (bone)
-						body->m_noCollideWithBones.push_back(bone);
+						body->m_noCollideWithBones.insert(bone);
 				} else if (nodeName == "weight-threshold") {
 					auto boneName = m_reader->getAttribute("bone");
 					float wt = m_reader->readFloat();
@@ -920,11 +920,11 @@ namespace hdt
 				} else if (nodeName == "can-collide-with-bone") {
 					auto bone = getOrCreateBone(m_reader->readText());
 					if (bone)
-						body->m_canCollideWithBones.push_back(bone);
+						body->m_canCollideWithBones.insert(bone);
 				} else if (nodeName == "no-collide-with-bone") {
 					auto bone = getOrCreateBone(m_reader->readText());
 					if (bone)
-						body->m_noCollideWithBones.push_back(bone);
+						body->m_noCollideWithBones.insert(bone);
 				} else if (nodeName == "weight-threshold") {
 					auto boneName = m_reader->getAttribute("bone");
 					float wt = m_reader->readFloat();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal bone collision detection system for improved performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->