### PR TITLE
chore: do not build or release cuda versions anymore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
       - dev
-      - hardenrelease
+      - nocuda
     paths:
       - "**.cpp"
       - "**.h"
@@ -24,7 +24,7 @@ on:
     branches:
       - master
       - dev
-      - hardenrelease
+      - nocuda
     paths:
       - "**.cpp"
       - "**.h"
@@ -147,36 +147,16 @@ jobs:
       # Use a matrix to run all presets at the same time
       matrix:
         include:
-          - preset: vs2022-windows-nocuda
-            cuda: false
-          - preset: vs2022-windows-nocuda-avx
-            cuda: false
-          - preset: vs2022-windows-nocuda-avx2
-            cuda: false
-          - preset: vs2022-windows-nocuda-avx512
-            cuda: false
-          - preset: vs2022-windows-cuda
-            cuda: true
-          - preset: vs2022-windows-cuda-avx
-            cuda: true
-          - preset: vs2022-windows-cuda-avx2
-            cuda: true
-          - preset: vs2022-windows-cuda-avx512
-            cuda: true
+          - preset: vs2022-windows
+          - preset: vs2022-windows-avx
+          - preset: vs2022-windows-avx2
+          - preset: vs2022-windows-avx512
 
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
           submodules: recursive # This handles the 'git submodule update --init --recursive' automatically
-
-      - name: Install CUDA Toolkit
-        if: matrix.cuda
-        uses: Jimver/cuda-toolkit@v0.2.30
-        with:
-          cuda: "12.6.3"
-          method: network
-          sub-packages: '["nvcc", "cudart"]'
 
       - name: Inject version into CMake
         shell: pwsh

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -103,7 +103,7 @@
         "vcpkg",
         "windows"
       ],
-      "name": "vs2022-windows-nocuda",
+      "name": "vs2022-windows",
       "toolset": "v143"
     },
     {
@@ -120,7 +120,7 @@
         "vcpkg",
         "windows-avx"
       ],
-      "name": "vs2022-windows-nocuda-avx",
+      "name": "vs2022-windows-avx",
       "toolset": "v143"
     },
     {
@@ -137,7 +137,7 @@
         "vcpkg",
         "windows-avx2"
       ],
-      "name": "vs2022-windows-nocuda-avx2",
+      "name": "vs2022-windows-avx2",
       "toolset": "v143"
     },
     {
@@ -154,79 +154,7 @@
         "vcpkg",
         "windows-avx512"
       ],
-      "name": "vs2022-windows-nocuda-avx512",
-      "toolset": "v143"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX",
-        "ENABLE_CUDA_SUPPORT": "ON"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows"
-      ],
-      "name": "vs2022-windows-cuda",
-      "toolset": "v143"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX",
-        "ENABLE_CUDA_SUPPORT": "ON"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows-avx"
-      ],
-      "name": "vs2022-windows-cuda-avx",
-      "toolset": "v143"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX2",
-        "ENABLE_CUDA_SUPPORT": "ON"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows-avx2"
-      ],
-      "name": "vs2022-windows-cuda-avx2",
-      "toolset": "v143"
-    },
-    {
-      "architecture": {
-        "strategy": "set",
-        "value": "x64"
-      },
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /arch:AVX512",
-        "ENABLE_CUDA_SUPPORT": "ON"
-      },
-      "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows-avx512"
-      ],
-      "name": "vs2022-windows-cuda-avx512",
+      "name": "vs2022-windows-avx512",
       "toolset": "v143"
     }
   ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -162,13 +162,13 @@
     {
       "name": "avx2-debug",
       "displayName": "Debug",
-      "configurePreset": "vs2022-windows-nocuda-avx2",
+      "configurePreset": "vs2022-windows-avx2",
       "configuration": "Debug"
     },
     {
       "name": "avx2-release",
       "displayName": "Release",
-      "configurePreset": "vs2022-windows-nocuda-avx2",
+      "configurePreset": "vs2022-windows-avx2",
       "configuration": "Release"
     }
   ],

--- a/fomod tree/fomod/ModuleConfig.xml
+++ b/fomod tree/fomod/ModuleConfig.xml
@@ -151,7 +151,7 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 					<flagDependency flag="NOAVX" value="On" />
 				</dependencies>
 				<files>
-					<folder source="raw-vs2022-windows-nocuda\SKSE" destination="SKSE" priority="0" />
+					<folder source="raw-vs2022-windows\SKSE" destination="SKSE" priority="0" />
 				</files>
 			</pattern>
 			<pattern>
@@ -159,7 +159,7 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 					<flagDependency flag="AVX" value="On" />
 				</dependencies>
 				<files>
-					<folder source="raw-vs2022-windows-nocuda-avx\SKSE" destination="SKSE" priority="0" />
+					<folder source="raw-vs2022-windows-avx\SKSE" destination="SKSE" priority="0" />
 				</files>
 			</pattern>
 			<pattern>
@@ -167,7 +167,7 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 					<flagDependency flag="AVX2" value="On" />
 				</dependencies>
 				<files>
-					<folder source="raw-vs2022-windows-nocuda-avx2\SKSE" destination="SKSE" priority="0" />
+					<folder source="raw-vs2022-windows-avx2\SKSE" destination="SKSE" priority="0" />
 				</files>
 			</pattern>
 			<pattern>
@@ -175,7 +175,7 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 					<flagDependency flag="AVX512" value="On" />
 				</dependencies>
 				<files>
-					<folder source="raw-vs2022-windows-nocuda-avx512\SKSE" destination="SKSE" priority="0" />
+					<folder source="raw-vs2022-windows-avx512\SKSE" destination="SKSE" priority="0" />
 				</files>
 			</pattern>
 		</patterns>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Windows build configuration by consolidating build presets and removing CUDA support variants.
  * Updated build system and installation configuration to reflect streamlined build options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->