### PR TITLE
fix: Raise collision limit

### DIFF
--- a/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.h
@@ -10,7 +10,7 @@ namespace hdt
 	public:
 		// Note: It's possible to exceed this with complex outfits, which is why we cap it.
 		// We don't want to stress a simulation island too much!
-		static const int MaxCollisionCount = 256;
+		static const int MaxCollisionCount = 512;
 
 		static void processCollision(SkinnedMeshBody* body0Wrap, SkinnedMeshBody* body1Wrap,
 			CollisionDispatcher* dispatcher);


### PR DESCRIPTION
This used to serve as a performance "improvement" in fsmp (All versions I think?)  by just ignoring collision contacts past a certain point. Which worked great - but, given everything is extremely optimized now we can easily handle well over 500 contacts per outfit without performance regression. 

This also solves a "bug" where your FPS tanks due to two shapes getting stuck inside each-other. It doesn't SOLVE them from getting stuck inside of eachother (Would have to do a depth limit, or some other check for that) - but it prevents your FPS from tanking by giving bullet more context to work with. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Doubled the maximum collision capacity to enhance collision handling and support more complex interactions during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->