### PR TITLE
fix: Fix skyrim face morph bug

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -213,6 +213,50 @@ namespace hdt
 			return RE::BSEventNotifyControl::kContinue;
 		}
 
+		// Skyrim Bug Fix: This fixes a bug with skyrim where if a BSTriShape comes before a BSDynamicTriShape
+		// in the BSFaceGenNiNode, the face/actor will be skipped by the facial morph workers. This is not a SMP
+		// bug, but many smp mods (hair especially) tend to trigger this issue due to improper nifs
+		if (e->headNode) {
+			auto& children = e->headNode->GetChildren();
+
+			auto isStaticTriShape = [](RE::NiAVObject* c) {
+				return c && c->AsTriShape() && !c->AsDynamicTriShape();
+			};
+
+			// Check if any static shape sits before a dynamic one
+			bool seenStatic = false;
+			bool needsReorder = false;
+			for (auto& child : children) {
+				if (!child)
+					continue;
+				if (isStaticTriShape(child.get())) {
+					seenStatic = true;
+				} else if (child->AsDynamicTriShape() && seenStatic) {
+					needsReorder = true;
+					break;
+				}
+			}
+
+			if (needsReorder) {
+				logger::debug("FaceGen node order is incorrect (static physics shapes placed before dynamic head parts). Reordering to fix frozen face morphs...");
+
+				std::vector<RE::NiPointer<RE::NiAVObject>> staticShapes;
+				for (int i = static_cast<int>(children.size()) - 1; i >= 0; --i) {
+					auto* child = children[static_cast<std::uint16_t>(i)].get();
+					if (isStaticTriShape(child)) {
+						staticShapes.emplace_back(child);
+						e->headNode->DetachChildAt2(static_cast<std::uint16_t>(i));
+					}
+				}
+
+				for (auto it = staticShapes.rbegin(); it != staticShapes.rend(); ++it) {
+					e->headNode->AttachChild(it->get(), false);
+				}
+
+				logger::debug("FaceGen node reordering complete. Facial expressions restored.");
+			}
+		}
+
 		fixArmorNameMaps();
 
 		auto& skeleton = getSkeletonData(e->skeleton);


### PR DESCRIPTION
This is actually a skyrim bug caused by hard part items like hair including other BSTriShapes that get placed before the BSDynamicTriShapes. Skyrim traverses the BSFaceGenNiNode before dispatching the actor to the face morph worker, and early exits due to hitting a static trishape. 

Super simple fix: Just move said shapes behind the BSDynamicTriShapes.

I propose we fix it on FSMP purely because it's virtually only SMP mods that cause this issue, and it's caused directly by them trying to add collision shapes to the head. While it's technically out of our scope, so is our bone fix and yet we've included that too.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected an ordering issue that occurred during character head geometry processing where shape components were being initialized in an incorrect sequence. Previously, this could cause model rendering issues and compatibility problems. The fix ensures proper component ordering and improves stability when processing character data and geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->