### PR TITLE
chore: bump version to 3.0.0 to test CMakeLists.txt-driven versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
 	hdtsmp64
-	VERSION 2.5.0
+	VERSION 3.0.0
 	LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
This commit is the test case for the dev build versioning PR. Expected CI behavior when this PR targets copilot/update-dev-build-versioning:
- prepare job reads VERSION 3.0.0 from CMakeLists.txt
- build_info = "verify-dev-build-versioning-<short_sha>" (note: slash in branch name sanitized to dash)
- tag_version = "3.0.0-verify-dev-build-versioning-<short_sha>"
- compiled binary logs: "hdtsmp64 v3.0.0-verify-dev-build-versioning-<sha>"

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>