### PR TITLE
feat: Add config and smp reset logging

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -187,7 +187,9 @@ namespace hdt
 		logger::debug("config: wind.distanceForNoWind = {}", SkyrimPhysicsWorld::get()->m_distanceForNoWind);
 		logger::debug("config: wind.distanceForMaxWind = {}", SkyrimPhysicsWorld::get()->m_distanceForMaxWind);
 
-		logger::debug("config: smp.logLevel = {}", g_logLevel);
+		const auto configuredLogLevel = 5 - g_logLevel;
+		logger::debug("config: smp.logLevel = {}", configuredLogLevel);
+
 		for (auto& item : Hooks::BipedAnimHooks::BackupNodes) {
 			logger::debug("config: smp.backupNodeByName += {}", item);
 		}

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -70,8 +70,7 @@ namespace hdt
 			case XMLReader::Inspected::StartTag:
 				if (reader.GetLocalName() == "logLevel") {
 					// Inverted so: 0 = critical, 1 = err, 2 = warn, 3 = info, 4 = debug, 5 = trace.
-					int originalVal = reader.readInt();
-					g_logLevel = 5 - std::clamp(originalVal, 0, 5);
+					g_logLevel = 5 - std::clamp(reader.readInt(), 0, 5);
 					spdlog::set_level(static_cast<spdlog::level::level_enum>(g_logLevel));
 				} else if (reader.GetLocalName() == "backupNodeByName") {
 					// Parse the string return value from reader.readText(); so we can have single strings instead of the group, example text -> "Virtual Hands, Virtual Body, Virtual Belly"... said text in a array like so -> { "Virtual Hands", "Virtual Body", "Virtual Belly"
@@ -182,12 +181,12 @@ namespace hdt
 		logger::debug("config: solver.erp = {}", SkyrimPhysicsWorld::get()->getSolverInfo().m_erp);
 		logger::debug("config: solver.min-fps = {}", SkyrimPhysicsWorld::get()->min_fps);
 		logger::debug("config: solver.maxSubSteps = {}", SkyrimPhysicsWorld::get()->m_maxSubSteps);
-		
+
 		logger::debug("config: wind.windStrength = {}", SkyrimPhysicsWorld::get()->m_windStrength);
 		logger::debug("config: wind.enabled = {}", SkyrimPhysicsWorld::get()->m_enableWind);
 		logger::debug("config: wind.distanceForNoWind = {}", SkyrimPhysicsWorld::get()->m_distanceForNoWind);
 		logger::debug("config: wind.distanceForMaxWind = {}", SkyrimPhysicsWorld::get()->m_distanceForMaxWind);
-		
+
 		logger::debug("config: smp.logLevel = {}", g_logLevel);
 		for (auto& item : Hooks::BipedAnimHooks::BackupNodes) {
 			logger::debug("config: smp.backupNodeByName += {}", item);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -14,6 +14,7 @@ namespace hdt
 			case XMLReader::Inspected::StartTag:
 				if (reader.GetLocalName() == "numIterations") {
 					SkyrimPhysicsWorld::get()->getSolverInfo().m_numIterations = btClamped(reader.readInt(), 4, 128);
+					logger::debug("config: solver.numIterations = {}", SkyrimPhysicsWorld::get()->getSolverInfo().m_numIterations);
 				}
 				// This has been dead code for years. Todo: Remove references to this in all the configs/menus.
 				//else if (reader.GetLocalName() == "groupIterations") {
@@ -23,11 +24,14 @@ namespace hdt
 				//}
 				else if (reader.GetLocalName() == "erp") {
 					SkyrimPhysicsWorld::get()->getSolverInfo().m_erp = btClamped(reader.readFloat(), 0.01f, 1.0f);
+					logger::debug("config: solver.erp = {}", SkyrimPhysicsWorld::get()->getSolverInfo().m_erp);
 				} else if (reader.GetLocalName() == "min-fps") {
 					SkyrimPhysicsWorld::get()->min_fps = (btClamped(reader.readInt(), 1, 300));
 					SkyrimPhysicsWorld::get()->m_timeTick = 1.0f / SkyrimPhysicsWorld::get()->min_fps;
+					logger::debug("config: solver.min-fps = {}", SkyrimPhysicsWorld::get()->min_fps);
 				} else if (reader.GetLocalName() == "maxSubSteps") {
 					SkyrimPhysicsWorld::get()->m_maxSubSteps = btClamped(reader.readInt(), 1, 60);
+					logger::debug("config: solver.maxSubSteps = {}", SkyrimPhysicsWorld::get()->m_maxSubSteps);
 				} else {
 					logger::warn("Unknown config : {}", reader.GetLocalName());
 					reader.skipCurrentElement();
@@ -46,12 +50,16 @@ namespace hdt
 			case XMLReader::Inspected::StartTag:
 				if (reader.GetLocalName() == "windStrength") {
 					SkyrimPhysicsWorld::get()->m_windStrength = btClamped(reader.readFloat(), 0.f, 1000.f);
+					logger::debug("config: wind.windStrength = {}", SkyrimPhysicsWorld::get()->m_windStrength);
 				} else if (reader.GetLocalName() == "enabled") {
 					SkyrimPhysicsWorld::get()->m_enableWind = reader.readBool();
+					logger::debug("config: wind.enabled = {}", SkyrimPhysicsWorld::get()->m_enableWind);
 				} else if (reader.GetLocalName() == "distanceForNoWind") {
 					SkyrimPhysicsWorld::get()->m_distanceForNoWind = btClamped(reader.readFloat(), 0.f, 10000.f);
+					logger::debug("config: wind.distanceForNoWind = {}", SkyrimPhysicsWorld::get()->m_distanceForNoWind);
 				} else if (reader.GetLocalName() == "distanceForMaxWind") {
 					SkyrimPhysicsWorld::get()->m_distanceForMaxWind = btClamped(reader.readFloat(), 0.f, 10000.f);
+					logger::debug("config: wind.distanceForMaxWind = {}", SkyrimPhysicsWorld::get()->m_distanceForMaxWind);
 				} else {
 					logger::warn("Unknown config : ", reader.GetLocalName());
 					reader.skipCurrentElement();
@@ -70,8 +78,10 @@ namespace hdt
 			case XMLReader::Inspected::StartTag:
 				if (reader.GetLocalName() == "logLevel") {
 					// Inverted so: 0 = critical, 1 = err, 2 = warn, 3 = info, 4 = debug, 5 = trace.
-					g_logLevel = 5 - std::clamp(reader.readInt(), 0, 5);
+					int originalVal = reader.readInt();
+					g_logLevel = 5 - std::clamp(originalVal, 0, 5);
 					spdlog::set_level(static_cast<spdlog::level::level_enum>(g_logLevel));
+					logger::debug("config: smp.logLevel = {} (original {})", g_logLevel, originalVal);
 				} else if (reader.GetLocalName() == "backupNodeByName") {
 					// Parse the string return value from reader.readText(); so we can have single strings instead of the group, example text -> "Virtual Hands, Virtual Body, Virtual Belly"... said text in a array like so -> { "Virtual Hands", "Virtual Body", "Virtual Belly"
 
@@ -85,35 +95,49 @@ namespace hdt
 						}
 
 						Hooks::BipedAnimHooks::BackupNodes.push_back(item);
+						logger::debug("config: smp.backupNodeByName += {}", item);
 					}
 				} else if (reader.GetLocalName() == "enableNPCFaceParts") {
 					ActorManager::instance()->m_skinNPCFaceParts = reader.readBool();
+					logger::debug("config: smp.enableNPCFaceParts = {}", ActorManager::instance()->m_skinNPCFaceParts);
 				} else if (reader.GetLocalName() == "disableSMPHairWhenWigEquipped") {
 					ActorManager::instance()->m_disableSMPHairWhenWigEquipped = reader.readBool();
+					logger::debug("config: smp.disableSMPHairWhenWigEquipped = {}", ActorManager::instance()->m_disableSMPHairWhenWigEquipped);
 				} else if (reader.GetLocalName() == "clampRotations") {
 					SkyrimPhysicsWorld::get()->m_clampRotations = reader.readBool();
+					logger::debug("config: smp.clampRotations = {}", SkyrimPhysicsWorld::get()->m_clampRotations);
 				} else if (reader.GetLocalName() == "rotationSpeedLimit") {
 					SkyrimPhysicsWorld::get()->m_rotationSpeedLimit = reader.readFloat();
+					logger::debug("config: smp.rotationSpeedLimit = {}", SkyrimPhysicsWorld::get()->m_rotationSpeedLimit);
 				} else if (reader.GetLocalName() == "unclampedResets") {
 					SkyrimPhysicsWorld::get()->m_unclampedResets = reader.readBool();
+					logger::debug("config: smp.unclampedResets = {}", SkyrimPhysicsWorld::get()->m_unclampedResets);
 				} else if (reader.GetLocalName() == "unclampedResetAngle") {
 					SkyrimPhysicsWorld::get()->m_unclampedResetAngle = reader.readFloat();
+					logger::debug("config: smp.unclampedResetAngle = {}", SkyrimPhysicsWorld::get()->m_unclampedResetAngle);
 				} else if (reader.GetLocalName() == "percentageOfFrameTime") {
 					SkyrimPhysicsWorld::get()->m_percentageOfFrameTime = std::clamp(reader.readInt() * 10, 1, 1000);
+					logger::debug("config: smp.percentageOfFrameTime = {}", SkyrimPhysicsWorld::get()->m_percentageOfFrameTime);
 				} else if (reader.GetLocalName() == "useRealTime") {
 					SkyrimPhysicsWorld::get()->m_useRealTime = reader.readBool();
+					logger::debug("config: smp.useRealTime = {}", SkyrimPhysicsWorld::get()->m_useRealTime);
 				} else if (reader.GetLocalName() == "minCullingDistance") {
 					ActorManager::instance()->m_minCullingDistance = reader.readFloat();
+					logger::debug("config: smp.minCullingDistance = {}", ActorManager::instance()->m_minCullingDistance);
 				} else if (reader.GetLocalName() == "maximumActiveSkeletons") {
 					ActorManager::instance()->m_maxActiveSkeletons = reader.readInt();
+					logger::debug("config: smp.maximumActiveSkeletons = {}", ActorManager::instance()->m_maxActiveSkeletons);
 				} else if (reader.GetLocalName() == "autoAdjustMaxSkeletons") {
 					ActorManager::instance()->m_autoAdjustMaxSkeletons = reader.readBool();
+					logger::debug("config: smp.autoAdjustMaxSkeletons = {}", ActorManager::instance()->m_autoAdjustMaxSkeletons);
 				} else if (reader.GetLocalName() == "sampleSize") {
 					SkyrimPhysicsWorld::get()->m_sampleSize = std::max(reader.readInt(), 1);
+					logger::debug("config: smp.sampleSize = {}", SkyrimPhysicsWorld::get()->m_sampleSize);
 				}
 
 				else if (reader.GetLocalName() == "disable1stPersonViewPhysics") {
 					ActorManager::instance()->m_disable1stPersonViewPhysics = reader.readBool();
+					logger::debug("config: smp.disable1stPersonViewPhysics = {}", ActorManager::instance()->m_disable1stPersonViewPhysics);
 				} else {
 					logger::warn("Unknown config : {}", reader.GetLocalName());
 					reader.skipCurrentElement();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -182,12 +182,12 @@ namespace hdt
 		logger::debug("config: solver.erp = {}", SkyrimPhysicsWorld::get()->getSolverInfo().m_erp);
 		logger::debug("config: solver.min-fps = {}", SkyrimPhysicsWorld::get()->min_fps);
 		logger::debug("config: solver.maxSubSteps = {}", SkyrimPhysicsWorld::get()->m_maxSubSteps);
-		
+
 		logger::debug("config: wind.windStrength = {}", SkyrimPhysicsWorld::get()->m_windStrength);
 		logger::debug("config: wind.enabled = {}", SkyrimPhysicsWorld::get()->m_enableWind);
 		logger::debug("config: wind.distanceForNoWind = {}", SkyrimPhysicsWorld::get()->m_distanceForNoWind);
 		logger::debug("config: wind.distanceForMaxWind = {}", SkyrimPhysicsWorld::get()->m_distanceForMaxWind);
-		
+
 		logger::debug("config: smp.logLevel = {}", g_logLevel);
 		for (auto& item : Hooks::BipedAnimHooks::BackupNodes) {
 			logger::debug("config: smp.backupNodeByName += {}", item);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -14,7 +14,6 @@ namespace hdt
 			case XMLReader::Inspected::StartTag:
 				if (reader.GetLocalName() == "numIterations") {
 					SkyrimPhysicsWorld::get()->getSolverInfo().m_numIterations = btClamped(reader.readInt(), 4, 128);
-					logger::debug("config: solver.numIterations = {}", SkyrimPhysicsWorld::get()->getSolverInfo().m_numIterations);
 				}
 				// This has been dead code for years. Todo: Remove references to this in all the configs/menus.
 				//else if (reader.GetLocalName() == "groupIterations") {
@@ -24,14 +23,11 @@ namespace hdt
 				//}
 				else if (reader.GetLocalName() == "erp") {
 					SkyrimPhysicsWorld::get()->getSolverInfo().m_erp = btClamped(reader.readFloat(), 0.01f, 1.0f);
-					logger::debug("config: solver.erp = {}", SkyrimPhysicsWorld::get()->getSolverInfo().m_erp);
 				} else if (reader.GetLocalName() == "min-fps") {
 					SkyrimPhysicsWorld::get()->min_fps = (btClamped(reader.readInt(), 1, 300));
 					SkyrimPhysicsWorld::get()->m_timeTick = 1.0f / SkyrimPhysicsWorld::get()->min_fps;
-					logger::debug("config: solver.min-fps = {}", SkyrimPhysicsWorld::get()->min_fps);
 				} else if (reader.GetLocalName() == "maxSubSteps") {
 					SkyrimPhysicsWorld::get()->m_maxSubSteps = btClamped(reader.readInt(), 1, 60);
-					logger::debug("config: solver.maxSubSteps = {}", SkyrimPhysicsWorld::get()->m_maxSubSteps);
 				} else {
 					logger::warn("Unknown config : {}", reader.GetLocalName());
 					reader.skipCurrentElement();
@@ -50,16 +46,12 @@ namespace hdt
 			case XMLReader::Inspected::StartTag:
 				if (reader.GetLocalName() == "windStrength") {
 					SkyrimPhysicsWorld::get()->m_windStrength = btClamped(reader.readFloat(), 0.f, 1000.f);
-					logger::debug("config: wind.windStrength = {}", SkyrimPhysicsWorld::get()->m_windStrength);
 				} else if (reader.GetLocalName() == "enabled") {
 					SkyrimPhysicsWorld::get()->m_enableWind = reader.readBool();
-					logger::debug("config: wind.enabled = {}", SkyrimPhysicsWorld::get()->m_enableWind);
 				} else if (reader.GetLocalName() == "distanceForNoWind") {
 					SkyrimPhysicsWorld::get()->m_distanceForNoWind = btClamped(reader.readFloat(), 0.f, 10000.f);
-					logger::debug("config: wind.distanceForNoWind = {}", SkyrimPhysicsWorld::get()->m_distanceForNoWind);
 				} else if (reader.GetLocalName() == "distanceForMaxWind") {
 					SkyrimPhysicsWorld::get()->m_distanceForMaxWind = btClamped(reader.readFloat(), 0.f, 10000.f);
-					logger::debug("config: wind.distanceForMaxWind = {}", SkyrimPhysicsWorld::get()->m_distanceForMaxWind);
 				} else {
 					logger::warn("Unknown config : ", reader.GetLocalName());
 					reader.skipCurrentElement();
@@ -81,7 +73,6 @@ namespace hdt
 					int originalVal = reader.readInt();
 					g_logLevel = 5 - std::clamp(originalVal, 0, 5);
 					spdlog::set_level(static_cast<spdlog::level::level_enum>(g_logLevel));
-					logger::debug("config: smp.logLevel = {} (original {})", g_logLevel, originalVal);
 				} else if (reader.GetLocalName() == "backupNodeByName") {
 					// Parse the string return value from reader.readText(); so we can have single strings instead of the group, example text -> "Virtual Hands, Virtual Body, Virtual Belly"... said text in a array like so -> { "Virtual Hands", "Virtual Body", "Virtual Belly"
 
@@ -95,49 +86,33 @@ namespace hdt
 						}
 
 						Hooks::BipedAnimHooks::BackupNodes.push_back(item);
-						logger::debug("config: smp.backupNodeByName += {}", item);
 					}
 				} else if (reader.GetLocalName() == "enableNPCFaceParts") {
 					ActorManager::instance()->m_skinNPCFaceParts = reader.readBool();
-					logger::debug("config: smp.enableNPCFaceParts = {}", ActorManager::instance()->m_skinNPCFaceParts);
 				} else if (reader.GetLocalName() == "disableSMPHairWhenWigEquipped") {
 					ActorManager::instance()->m_disableSMPHairWhenWigEquipped = reader.readBool();
-					logger::debug("config: smp.disableSMPHairWhenWigEquipped = {}", ActorManager::instance()->m_disableSMPHairWhenWigEquipped);
 				} else if (reader.GetLocalName() == "clampRotations") {
 					SkyrimPhysicsWorld::get()->m_clampRotations = reader.readBool();
-					logger::debug("config: smp.clampRotations = {}", SkyrimPhysicsWorld::get()->m_clampRotations);
 				} else if (reader.GetLocalName() == "rotationSpeedLimit") {
 					SkyrimPhysicsWorld::get()->m_rotationSpeedLimit = reader.readFloat();
-					logger::debug("config: smp.rotationSpeedLimit = {}", SkyrimPhysicsWorld::get()->m_rotationSpeedLimit);
 				} else if (reader.GetLocalName() == "unclampedResets") {
 					SkyrimPhysicsWorld::get()->m_unclampedResets = reader.readBool();
-					logger::debug("config: smp.unclampedResets = {}", SkyrimPhysicsWorld::get()->m_unclampedResets);
 				} else if (reader.GetLocalName() == "unclampedResetAngle") {
 					SkyrimPhysicsWorld::get()->m_unclampedResetAngle = reader.readFloat();
-					logger::debug("config: smp.unclampedResetAngle = {}", SkyrimPhysicsWorld::get()->m_unclampedResetAngle);
 				} else if (reader.GetLocalName() == "percentageOfFrameTime") {
 					SkyrimPhysicsWorld::get()->m_percentageOfFrameTime = std::clamp(reader.readInt() * 10, 1, 1000);
-					logger::debug("config: smp.percentageOfFrameTime = {}", SkyrimPhysicsWorld::get()->m_percentageOfFrameTime);
 				} else if (reader.GetLocalName() == "useRealTime") {
 					SkyrimPhysicsWorld::get()->m_useRealTime = reader.readBool();
-					logger::debug("config: smp.useRealTime = {}", SkyrimPhysicsWorld::get()->m_useRealTime);
 				} else if (reader.GetLocalName() == "minCullingDistance") {
 					ActorManager::instance()->m_minCullingDistance = reader.readFloat();
-					logger::debug("config: smp.minCullingDistance = {}", ActorManager::instance()->m_minCullingDistance);
 				} else if (reader.GetLocalName() == "maximumActiveSkeletons") {
 					ActorManager::instance()->m_maxActiveSkeletons = reader.readInt();
-					logger::debug("config: smp.maximumActiveSkeletons = {}", ActorManager::instance()->m_maxActiveSkeletons);
 				} else if (reader.GetLocalName() == "autoAdjustMaxSkeletons") {
 					ActorManager::instance()->m_autoAdjustMaxSkeletons = reader.readBool();
-					logger::debug("config: smp.autoAdjustMaxSkeletons = {}", ActorManager::instance()->m_autoAdjustMaxSkeletons);
 				} else if (reader.GetLocalName() == "sampleSize") {
 					SkyrimPhysicsWorld::get()->m_sampleSize = std::max(reader.readInt(), 1);
-					logger::debug("config: smp.sampleSize = {}", SkyrimPhysicsWorld::get()->m_sampleSize);
-				}
-
-				else if (reader.GetLocalName() == "disable1stPersonViewPhysics") {
+				} else if (reader.GetLocalName() == "disable1stPersonViewPhysics") {
 					ActorManager::instance()->m_disable1stPersonViewPhysics = reader.readBool();
-					logger::debug("config: smp.disable1stPersonViewPhysics = {}", ActorManager::instance()->m_disable1stPersonViewPhysics);
 				} else {
 					logger::warn("Unknown config : {}", reader.GetLocalName());
 					reader.skipCurrentElement();
@@ -200,5 +175,35 @@ namespace hdt
 
 		// Restore original locale
 		std::setlocale(LC_NUMERIC, saved_locale);
+	}
+	void logConfig()
+	{
+		logger::debug("config: solver.numIterations = {}", SkyrimPhysicsWorld::get()->getSolverInfo().m_numIterations);
+		logger::debug("config: solver.erp = {}", SkyrimPhysicsWorld::get()->getSolverInfo().m_erp);
+		logger::debug("config: solver.min-fps = {}", SkyrimPhysicsWorld::get()->min_fps);
+		logger::debug("config: solver.maxSubSteps = {}", SkyrimPhysicsWorld::get()->m_maxSubSteps);
+		
+		logger::debug("config: wind.windStrength = {}", SkyrimPhysicsWorld::get()->m_windStrength);
+		logger::debug("config: wind.enabled = {}", SkyrimPhysicsWorld::get()->m_enableWind);
+		logger::debug("config: wind.distanceForNoWind = {}", SkyrimPhysicsWorld::get()->m_distanceForNoWind);
+		logger::debug("config: wind.distanceForMaxWind = {}", SkyrimPhysicsWorld::get()->m_distanceForMaxWind);
+		
+		logger::debug("config: smp.logLevel = {}", g_logLevel);
+		for (auto& item : Hooks::BipedAnimHooks::BackupNodes) {
+			logger::debug("config: smp.backupNodeByName += {}", item);
+		}
+		logger::debug("config: smp.enableNPCFaceParts = {}", ActorManager::instance()->m_skinNPCFaceParts);
+		logger::debug("config: smp.disableSMPHairWhenWigEquipped = {}", ActorManager::instance()->m_disableSMPHairWhenWigEquipped);
+		logger::debug("config: smp.clampRotations = {}", SkyrimPhysicsWorld::get()->m_clampRotations);
+		logger::debug("config: smp.rotationSpeedLimit = {}", SkyrimPhysicsWorld::get()->m_rotationSpeedLimit);
+		logger::debug("config: smp.unclampedResets = {}", SkyrimPhysicsWorld::get()->m_unclampedResets);
+		logger::debug("config: smp.unclampedResetAngle = {}", SkyrimPhysicsWorld::get()->m_unclampedResetAngle);
+		logger::debug("config: smp.percentageOfFrameTime = {}", SkyrimPhysicsWorld::get()->m_percentageOfFrameTime);
+		logger::debug("config: smp.useRealTime = {}", SkyrimPhysicsWorld::get()->m_useRealTime);
+		logger::debug("config: smp.minCullingDistance = {}", ActorManager::instance()->m_minCullingDistance);
+		logger::debug("config: smp.maximumActiveSkeletons = {}", ActorManager::instance()->m_maxActiveSkeletons);
+		logger::debug("config: smp.autoAdjustMaxSkeletons = {}", ActorManager::instance()->m_autoAdjustMaxSkeletons);
+		logger::debug("config: smp.sampleSize = {}", SkyrimPhysicsWorld::get()->m_sampleSize);
+		logger::debug("config: smp.disable1stPersonViewPhysics = {}", ActorManager::instance()->m_disable1stPersonViewPhysics);
 	}
 }

--- a/src/config.h
+++ b/src/config.h
@@ -6,4 +6,5 @@ namespace hdt
 
 	//
 	void loadConfig();
+	void logConfig();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -285,7 +285,10 @@ bool SMPDebug_Execute(
 		return false;
 	}
 
+	logger::debug("SMPCommand: {} {}"sv, buffer, buffer2);
+
 	if (_strnicmp(buffer, "reset", MAX_PATH) == 0) {
+		logger::debug("smp reset: reloading config and resetting physics world"sv);
 		RE::ConsoleLog::GetSingleton()->Print("running full smp reset");
 		hdt::loadConfig();
 		hdt::SkyrimPhysicsWorld::get()->resetTransformsToOriginal();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -291,6 +291,17 @@ bool SMPDebug_Execute(
 		logger::debug("smp reset: reloading config and resetting physics world"sv);
 		RE::ConsoleLog::GetSingleton()->Print("running full smp reset");
 		hdt::loadConfig();
+hdt::logConfig();
+
+		if (!hdt::SkyrimPhysicsWorld::get()->m_enableWind) {
+			// Wind is off in the config; explicitly clear any residual force.
+			hdt::SkyrimPhysicsWorld::get()->setWind(RE::NiPoint3{ 0, 0, 0 }, 0.f, 1);
+		} else {
+			// Wind is enabled. Force an immediate weather tick to apply new settings,
+			// allowing it to interpolate smoothly from its current vector.
+			hdt::WeatherManager::forceWeatherUpdate();
+		}
+
 		hdt::SkyrimPhysicsWorld::get()->resetTransformsToOriginal();
 		const RE::MenuOpenCloseEvent e{ "", false };
 		hdt::ActorManager::instance()->ProcessEvent(&e, nullptr);
@@ -502,11 +513,12 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 #endif
 
 	//
-	InitializeLog();
-	logger::info("{} v{}"sv, Plugin::NAME, Plugin::VERSION.string());
+	hdt::loadConfig();
 
 	//
-	hdt::loadConfig();
+	InitializeLog();
+	logger::info("{} v{}"sv, Plugin::NAME, Plugin::VERSION.string());
+	hdt::logConfig();
 
 	SKSE::Init(a_skse);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -293,15 +293,6 @@ bool SMPDebug_Execute(
 		hdt::loadConfig();
 		hdt::logConfig();
 
-		if (!hdt::SkyrimPhysicsWorld::get()->m_enableWind) {
-			// Wind is off in the config; explicitly clear any residual force.
-			hdt::SkyrimPhysicsWorld::get()->setWind(RE::NiPoint3{ 0, 0, 0 }, 0.f, 1);
-		} else {
-			// Wind is enabled. Force an immediate weather tick to apply new settings,
-			// allowing it to interpolate smoothly from its current vector.
-			hdt::WeatherManager::forceWeatherUpdate();
-		}
-
 		hdt::SkyrimPhysicsWorld::get()->resetTransformsToOriginal();
 		const RE::MenuOpenCloseEvent e{ "", false };
 		hdt::ActorManager::instance()->ProcessEvent(&e, nullptr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -502,11 +502,11 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 #endif
 
 	//
-	hdt::loadConfig();
-
-	//
 	InitializeLog();
 	logger::info("{} v{}"sv, Plugin::NAME, Plugin::VERSION.string());
+
+	//
+	hdt::loadConfig();
 
 	SKSE::Init(a_skse);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -505,11 +505,8 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 
 	//
 	hdt::loadConfig();
-
 	//
 	InitializeLog();
-	logger::info("{} v{}"sv, Plugin::NAME, Plugin::VERSION.string());
-	hdt::logConfig();
 
 	SKSE::Init(a_skse);
 
@@ -518,6 +515,8 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 	} else {
 		logger::info("{} v{}-{}"sv, Plugin::NAME, Plugin::VERSION.string(), Plugin::BUILD_INFO);
 	}
+
+	hdt::logConfig();
 
 	const auto messaging = SKSE::GetMessagingInterface();
 	if (!messaging->RegisterListener("SKSE", MessageHandler)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -291,7 +291,7 @@ bool SMPDebug_Execute(
 		logger::debug("smp reset: reloading config and resetting physics world"sv);
 		RE::ConsoleLog::GetSingleton()->Print("running full smp reset");
 		hdt::loadConfig();
-hdt::logConfig();
+		hdt::logConfig();
 
 		if (!hdt::SkyrimPhysicsWorld::get()->m_enableWind) {
 			// Wind is off in the config; explicitly clear any residual force.


### PR DESCRIPTION
Adds debug logging to include configs.xml values when they are read and log smp function calls.  To ensure that these values are logged on initial load, the logger needed to be initialized with default values before the config is loaded.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed debug logging during plugin startup and configuration reset so initialization state (solver, wind, SMP settings, and animation nodes) is recorded for diagnostics.
  * Console command execution now logs parsed parameters and an extra message for resets to aid troubleshooting.

* **Chores**
  * Minor startup ordering and formatting tweaks to improve log timing and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->