### PR TITLE
perf: Optimize the read transforms

### DIFF
--- a/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.cpp
@@ -17,9 +17,9 @@ namespace hdt
 		if (this->block_resetting)
 			return;
 
-		concurrency::parallel_for_each(m_bones.begin(), m_bones.end(), [=](const auto& bone) {
+		for (const auto& bone : m_bones) {
 			bone->readTransform(timeStep);
-		});
+		}
 
 		for (auto i : m_constraints) {
 			i->scaleConstraint();

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.h
@@ -20,6 +20,7 @@ namespace hdt
 	public:
 		virtual ~SkinnedMeshSystem() = default;
 
+		virtual float prepareForRead(float timeStep) { return timeStep; }
 		virtual void resetTransformsToOriginal();
 		virtual void readTransform(float timeStep);
 		virtual void writeTransform();

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -84,7 +84,7 @@ namespace hdt
 			addConstraint(system->m_constraints[i]->m_constraint, true);
 
 		// -10 allows RESET_PHYSICS down the calls. But equality with a float?...
-		system->readTransform(RESET_PHYSICS);
+		system->readTransform(system->prepareForRead(RESET_PHYSICS));
 
 		system->m_world = this;
 	}

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "hdtSkinnedMeshSystem.h"
+#include "hdtSkyrimSystem.h"
 #include <BulletCollision/CollisionDispatch/btSimulationIslandManager.h>
 #include <BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.h>
 
@@ -22,6 +23,10 @@ namespace hdt
 		const btVector3& getWind() const { return m_windSpeed; }
 
 	protected:
+		// Contains grouped systems that share the same actor
+		std::vector<SkyrimSystem*> m_sorted;
+		std::vector<float> m_timeSteps;
+
 		void resetTransformsToOriginal()
 		{
 			for (int i = 0; i < m_systems.size(); ++i) m_systems[i]->resetTransformsToOriginal();
@@ -29,7 +34,41 @@ namespace hdt
 
 		void readTransform(float timeStep)
 		{
-			concurrency::parallel_for_each(m_systems.begin(), m_systems.end(), [=](const auto& system) { system->readTransform(timeStep); });
+			const size_t n = m_systems.size();
+			if (n == 0)
+				return;
+
+			m_sorted.resize(n);
+			for (size_t i = 0; i < n; ++i)
+				m_sorted[i] = static_cast<SkyrimSystem*>(m_systems[i].get());
+
+			std::ranges::sort(m_sorted, std::less<>{}, [](const SkyrimSystem* sys) {
+				return sys->m_skeleton.get();
+			});
+
+			m_timeSteps.resize(n);
+
+			// Loop over the systems to find all the ones connected to one body, and only call processSkeletonRoot once
+			size_t i = 0;
+			while (i < n) {
+				SkyrimSystem* first = m_sorted[i];
+				float ts = first->processSkeletonRoot(timeStep);
+				void* key = first->m_skeleton.get();
+				m_timeSteps[i] = ts;
+
+				for (size_t j = i + 1; j < n && m_sorted[j]->m_skeleton.get() == key; ++j) {
+					m_sorted[j]->m_lastRootRotation = first->m_lastRootRotation;
+					m_sorted[j]->m_oldRoot = first->m_oldRoot;
+					m_timeSteps[j] = ts;
+					i = j;
+				}
+				++i;
+			}
+
+			concurrency::parallel_for(size_t{ 0 }, n,
+				[this](size_t i) {
+					m_sorted[i]->readTransform(m_timeSteps[i]);
+				});
 		}
 
 		void writeTransform()

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
@@ -29,7 +29,7 @@ namespace hdt
 
 		void readTransform(float timeStep)
 		{
-			for (int i = 0; i < m_systems.size(); ++i) m_systems[i]->readTransform(timeStep);
+			concurrency::parallel_for_each(m_systems.begin(), m_systems.end(), [=](const auto& system) { system->readTransform(timeStep); });
 		}
 
 		void writeTransform()

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
@@ -23,8 +23,6 @@ namespace hdt
 		const btVector3& getWind() const { return m_windSpeed; }
 
 	protected:
-		// Contains grouped systems that share the same actor
-		std::vector<SkyrimSystem*> m_sorted;
 		std::vector<float> m_timeSteps;
 
 		void resetTransformsToOriginal()
@@ -38,37 +36,15 @@ namespace hdt
 			if (n == 0)
 				return;
 
-			m_sorted.resize(n);
-			for (size_t i = 0; i < n; ++i)
-				m_sorted[i] = static_cast<SkyrimSystem*>(m_systems[i].get());
-
-			std::ranges::sort(m_sorted, std::less<>{}, [](const SkyrimSystem* sys) {
-				return sys->m_skeleton.get();
-			});
-
 			m_timeSteps.resize(n);
 
-			// Loop over the systems to find all the ones connected to one body, and only call processSkeletonRoot once
-			size_t i = 0;
-			while (i < n) {
-				SkyrimSystem* first = m_sorted[i];
-				float ts = first->processSkeletonRoot(timeStep);
-				void* key = first->m_skeleton.get();
-				m_timeSteps[i] = ts;
+			// processSkeletonRoot must be ran synchronously to avoid race issues
+			for (size_t i = 0; i < n; ++i)
+				m_timeSteps[i] = m_systems[i]->prepareForRead(timeStep);
 
-				for (size_t j = i + 1; j < n && m_sorted[j]->m_skeleton.get() == key; ++j) {
-					m_sorted[j]->m_lastRootRotation = first->m_lastRootRotation;
-					m_sorted[j]->m_oldRoot = first->m_oldRoot;
-					m_timeSteps[j] = ts;
-					i = j;
-				}
-				++i;
-			}
-
-			concurrency::parallel_for(size_t{ 0 }, n,
-				[this](size_t i) {
-					m_sorted[i]->readTransform(m_timeSteps[i]);
-				});
+			concurrency::parallel_for(size_t{ 0 }, n, [this](size_t i) {
+				m_systems[i]->readTransform(m_timeSteps[i]);
+			});
 		}
 
 		void writeTransform()

--- a/src/hdtSkyrimBone.cpp
+++ b/src/hdtSkyrimBone.cpp
@@ -29,50 +29,50 @@ namespace hdt
 	void SkyrimBone::readTransform(float timeStep)
 	{
 		auto oldScale = m_currentTransform.getScale();
+
 		m_currentTransform = convertNi(m_node->world);
+
 		auto newScale = m_currentTransform.getScale();
-
 		auto current = m_rig.getWorldTransform();
+		auto isStaticOrKinematic = m_rig.isStaticOrKinematicObject();
+		auto scaleChanged = !btFuzzyZero(newScale - oldScale);
 
-		auto factor = oldScale / newScale;
-		if (!m_rig.isStaticOrKinematicObject() && !btFuzzyZero(factor - 1)) {
-			auto factor2 = factor * factor;
-			auto factor3 = factor2 * factor;
-			auto factor5 = factor3 * factor2;
-			auto inertia = m_rig.getInvInertiaDiagLocal();
-			m_rig.setMassProps(1.0f / (m_rig.getInvMass() * factor3), btVector3(1, 1, 1));
-			m_rig.setInvInertiaDiagLocal(inertia * factor5);
-			m_rig.updateInertiaTensor();
+		if (scaleChanged) {
+			auto factor = oldScale / newScale;
+			if (!isStaticOrKinematic) {
+				auto factor2 = factor * factor;
+				auto factor3 = factor2 * factor;
+				auto factor5 = factor3 * factor2;
+				auto inertia = m_rig.getInvInertiaDiagLocal();
+				m_rig.setMassProps(1.0f / (m_rig.getInvMass() * factor3), btVector3(1, 1, 1));
+				m_rig.setInvInertiaDiagLocal(inertia * factor5);
+				m_rig.updateInertiaTensor();
+			}
+			auto invFactor = 1.0f / factor;
+			m_localToRig.getOrigin() *= invFactor;
+			m_rigToLocal.getOrigin() *= invFactor;
+			m_rig.getCollisionShape()->setLocalScaling(setAll(newScale));
 		}
-
-		factor = newScale / oldScale;
-		if (!btFuzzyZero(factor - 1)) {
-			m_localToRig.getOrigin() *= factor;
-			m_rigToLocal.getOrigin() *= factor;
-		}
-		m_rig.getCollisionShape()->setLocalScaling(setAll(newScale));
 
 		auto dest = m_currentTransform.asTransform() * m_localToRig;
-
 		if (timeStep <= RESET_PHYSICS) {
-			m_origToSkeletonTransform = convertNi(m_skeleton->world).inverse() * convertNi(m_node->world);
+			static const btVector3 zero(0, 0, 0);
+			m_origToSkeletonTransform = convertNi(m_skeleton->world).inverse() * m_currentTransform;
 			m_origTransform = convertNi(m_node->local);
 			m_rig.setWorldTransform(dest);
 			m_rig.setInterpolationWorldTransform(dest);
-			m_rig.setLinearVelocity(btVector3(0, 0, 0));
-			m_rig.setAngularVelocity(btVector3(0, 0, 0));
-			m_rig.setInterpolationLinearVelocity(btVector3(0, 0, 0));
-			m_rig.setInterpolationAngularVelocity(btVector3(0, 0, 0));
+			m_rig.setLinearVelocity(zero);
+			m_rig.setAngularVelocity(zero);
+			m_rig.setInterpolationLinearVelocity(zero);
+			m_rig.setInterpolationAngularVelocity(zero);
 			m_rig.updateInertiaTensor();
-
 			//auto det = dest.getBasis().determinant();
 			//if (det < FLT_EPSILON || isnan(det) || isinf(det))
 			//	_WARNING("Invalid rotation matrix!!");
-
 			//det = m_rig.getInvInertiaTensorWorld().determinant();
 			//if (isnan(det) || isinf(det))
 			//	_WARNING("Invalid inertia tensor matrix!!");
-		} else if (m_rig.isStaticOrKinematicObject()) {
+		} else if (isStaticOrKinematic) {
 			btVector3 linVel, angVel;
 			btTransformUtil::calculateVelocity(current, dest, timeStep, linVel, angVel);
 			m_rig.setLinearVelocity(linVel);
@@ -107,6 +107,7 @@ namespace hdt
 
 		m_node->world.rotate = convertBt(transform.getBasis());
 		m_node->world.translate = convertBt(transform.getOrigin());
+		// Todo: Look into why the hell we're doing this lol?
 		m_node->world = m_node->world;
 
 		if (m_forceUpdateType == 1) {

--- a/src/hdtSkyrimPhysicsWorld.cpp
+++ b/src/hdtSkyrimPhysicsWorld.cpp
@@ -114,6 +114,8 @@ namespace hdt
 
 				readTransform(remainingTimeStep);
 
+				m_resetPc -= m_resetPc > 0;
+
 				m_tasks.run([this, interval, tick, remainingTimeStep] { doUpdate2ndStep(interval, tick, remainingTimeStep); });
 			}
 		}
@@ -308,7 +310,7 @@ namespace hdt
 	{
 		std::lock_guard<decltype(m_lock)> l(m_lock);
 		for (auto& i : m_systems)
-			i->readTransform(RESET_PHYSICS);
+			i->readTransform(i->prepareForRead(RESET_PHYSICS));
 	}
 
 	RE::BSEventNotifyControl SkyrimPhysicsWorld::ProcessEvent(const Events::FrameEvent* e, RE::BSTEventSource<Events::FrameEvent>*)

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -80,7 +80,7 @@ namespace hdt
 		m_oldRoot = m_skeleton;
 	}
 
-	float SkyrimSystem::processSkeletonRoot(float timeStep)
+	float SkyrimSystem::prepareForRead(float timeStep)
 	{
 		auto newRoot = m_skeleton.get();
 		while (newRoot->parent) {
@@ -89,6 +89,11 @@ namespace hdt
 
 		if (m_oldRoot != newRoot) {
 			timeStep = RESET_PHYSICS;
+		}
+
+		if (!m_initialized) {
+			timeStep = RESET_PHYSICS;
+			m_initialized = true;
 		}
 
 		if (timeStep <= RESET_PHYSICS) {
@@ -102,7 +107,6 @@ namespace hdt
 				timeStep = RESET_PHYSICS;
 				updateTransformUpDown(m_skeleton.get(), true);
 				m_lastRootRotation = convertNi(m_skeleton->world.rotate);
-				SkyrimPhysicsWorld::get()->m_resetPc -= 1;
 			} else if (!RE::PlayerCamera::GetSingleton()->GetRuntimeData2().isWeapSheathed || RE::PlayerCamera::GetSingleton()->currentState->id == RE::CameraState::kFirstPerson)  // isWeaponSheathed or potentially isCameraFree || cameraState is first person
 			{
 				m_lastRootRotation = convertNi(m_skeleton->world.rotate);
@@ -143,21 +147,6 @@ namespace hdt
 
 		m_oldRoot = hdt::make_nismart(newRoot);
 		return timeStep;
-	}
-
-	void SkyrimSystem::readTransform(float timeStep)
-	{
-		if (!m_initialized) {
-			timeStep = RESET_PHYSICS;
-			m_initialized = true;
-		}
-
-		SkinnedMeshSystem::readTransform(timeStep);
-	}
-
-	void SkyrimSystem::writeTransform()
-	{
-		SkinnedMeshSystem::writeTransform();
 	}
 
 	SkyrimSystemCreator::SkyrimSystemCreator()

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -80,7 +80,7 @@ namespace hdt
 		m_oldRoot = m_skeleton;
 	}
 
-	void SkyrimSystem::readTransform(float timeStep)
+	float SkyrimSystem::processSkeletonRoot(float timeStep)
 	{
 		auto newRoot = m_skeleton.get();
 		while (newRoot->parent) {
@@ -89,11 +89,6 @@ namespace hdt
 
 		if (m_oldRoot != newRoot) {
 			timeStep = RESET_PHYSICS;
-		}
-
-		if (!m_initialized) {
-			timeStep = RESET_PHYSICS;
-			m_initialized = true;
 		}
 
 		if (timeStep <= RESET_PHYSICS) {
@@ -146,8 +141,18 @@ namespace hdt
 			}
 		}
 
-		SkinnedMeshSystem::readTransform(timeStep);
 		m_oldRoot = hdt::make_nismart(newRoot);
+		return timeStep;
+	}
+
+	void SkyrimSystem::readTransform(float timeStep)
+	{
+		if (!m_initialized) {
+			timeStep = RESET_PHYSICS;
+			m_initialized = true;
+		}
+
+		SkinnedMeshSystem::readTransform(timeStep);
 	}
 
 	void SkyrimSystem::writeTransform()

--- a/src/hdtSkyrimSystem.h
+++ b/src/hdtSkyrimSystem.h
@@ -25,6 +25,8 @@ namespace hdt
 		SkyrimSystem(RE::NiNode* skeleton);
 		~SkyrimSystem() override = default;
 
+		float processSkeletonRoot(float timeStep);
+
 		SkinnedMeshBone* findBone(const RE::BSFixedString& name);
 		SkinnedMeshBody* findBody(const RE::BSFixedString& name);
 		int findBoneIdx(const RE::BSFixedString& name);

--- a/src/hdtSkyrimSystem.h
+++ b/src/hdtSkyrimSystem.h
@@ -25,14 +25,11 @@ namespace hdt
 		SkyrimSystem(RE::NiNode* skeleton);
 		~SkyrimSystem() override = default;
 
-		float processSkeletonRoot(float timeStep);
-
 		SkinnedMeshBone* findBone(const RE::BSFixedString& name);
 		SkinnedMeshBody* findBody(const RE::BSFixedString& name);
 		int findBoneIdx(const RE::BSFixedString& name);
 
-		void readTransform(float timeStep) override;
-		void writeTransform() override;
+		float prepareForRead(float timeStep) override;
 
 		const std::vector<RE::BSTSmartPointer<SkinnedMeshBody>>& meshes() const { return m_meshes; }
 


### PR DESCRIPTION
Going parallel on the bones like that was leading to tons of latency, and likely causing cpu cache misses. The actual read transform loop isn't heavy enough to justify it either. If need be in the future, this could be manually batched and dispatched, but I doubt we'll ever see over 1k bones in a single system anyways.

Now it only parallel's on the actual systems, and the code in hdtSkyrimBone.cpp was cleaned up to avoid pointless work (No actual logic changed, just avoiding work when it's not needed).

Also added a note on: 
m_node->world = m_node->world;

Not sure why that is being done, but I'm scared removing it will somehow break something lol

Edit: New changes
I refactored the skeleton update function out of readTransforms, into a "prepareRead" function. It makes more sense logically, and allows us to run readTransform on parallel threads.

I corrected Day's strange bug from my previous refactor attempt (Missed some areas), and significantly simplified the logic.

Lastly, "m_resetPc " was actually bugged in FSMP. It would decrement multiple times in a single frame due to multiple different physics systems on a single player. It's now decremented in the SkyrimWorld right after the read function runs. Insuring switching from first to third person doesn't cause a physics explosion. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized physics transform processing by reorganizing parallelization strategy at the system level rather than per-bone, improving overall efficiency.
  
* **Bug Fixes**
  * Refined physics reset behavior with corrected counter management during system updates.
  * Improved scale-related physics calculations and collision shape updates.

* **Refactor**
  * Streamlined physics initialization and preparation workflow with new internal hooks for per-system time-step adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->