### PR TITLE
feat: Switch to using BudgetMS instead of frames

### DIFF
--- a/configs/configs.xml
+++ b/configs/configs.xml
@@ -7,15 +7,15 @@
 
     <!--
       logLevel: (int 0-5) level of logs
-      0 = trace
-      1 = debug
-      2 = info
-      3 = warn
-      4 = error
-      5 = critical
+      0 = critical
+      1 = err
+      2 = warn
+      3 = info
+      4 = debug
+      5 = trace
 	  6 = off
     -->
-    <logLevel>2</logLevel>
+    <logLevel>3</logLevel>
 
     <!-- ######################## Bone Node Backup #################################### -->
 
@@ -135,32 +135,27 @@
     <maximumActiveSkeletons>20</maximumActiveSkeletons>
 
     <!--
-      percentageOfFrameTime: (int 1-100) [requires autoAdjustMaxSkeleton = true]
-      percentage of the configured min-fps period allocated to additional physics calculus.
+      budgetMs: (int 0.1-30.0) [requires autoAdjustMaxSkeleton = true]
 
-      Each frame, FSMP uses a certain time to calculate physics (T).
-      Each frame, the work done by the Skyrim executable can be split into 2 parts:
-        one that can be parallelized with the FSMP calculus (T1),
-        one that can't because it depend on it (T2).
-      If the FSMP calculus T is shorter than T1, then physics doesn't cost any fps.
-      If it is longer, the Skyrim executable must wait (T - T1) for the physics calculus to finish.
-
-      This setting allows you to choose how much fps you're willing to lose to increase
-      the number of skeletons with physics at the same time :)
-
-      FSMP being heavily parallelized, adding a 10th skeleton on top of 9
-      doesn't cost a lot, so you should do your tests with a reasonable number
-      of skeletons (10?), and set this setting depending on what performance
-      you want to have in a heavy context. Whiterun seems a good place.
-      Absolutely check what happens with the log at level 4 (verbose);
-      it depends A LOT on your personal setup.
-
-      If your min-fps is 60 and your percentage is 30, then the allocated time
-      for additional physics calculus during a frame is 1/60s * 30% = 5ms.
-
-      If no value is set, default is 30, which is NOT optimized.
+      How many milliseconds per frame FSMP is allowed to spend on physics
+      before it starts reducing the number of active skeletons.
+      
+      FSMP runs physics in parallel with the game. If physics finishes 
+      before the game needs the results, it's essentially free. This budget
+      controls the max time FSMP will wait for physics to finish if it 
+      doesn't complete in time.
+      
+      Lower = less fps impact, fewer active skeletons.
+      Higher = more fps impact, more active skeletons.
+      
+      For reference, at 60fps a full frame is ~16.6ms. A budget of 2-3ms 
+      is conservative, 5ms is generous. Test in a busy area like Whiterun 
+      with ~10 skeleton NPCs and check the verbose log (level 4) to see 
+      how your setup performs.
+      
+      Default: 3.5
     -->
-    <percentageOfFrameTime>30</percentageOfFrameTime>
+	  <budgetMs>3.5</budgetMs>
 
     <!--
       sampleSize: (int) how many samples (sample taken every min_fps
@@ -204,19 +199,6 @@
       If no value is set, default is 10.
     -->
     <numIterations>16</numIterations>
-
-    <!--
-      groupIterations: (int 0-4096)
-      If no value is set, default is 2.
-    -->
-    <groupIterations>16</groupIterations>
-
-    <!--
-      groupEnableMLCP: (boolean) Turns on the higher quality constraint solver,
-      better constraint simulation at the cost of performance.
-      If no value is set, default is true.
-    -->
-    <groupEnableMLCP>false</groupEnableMLCP>
 
     <!--
       erp: (float ]0-1[) The error correction force applied per simulation

--- a/configs/configs.xml
+++ b/configs/configs.xml
@@ -139,20 +139,20 @@
 
       How many milliseconds per frame FSMP is allowed to spend on physics
       before it starts reducing the number of active skeletons.
-      
-      FSMP runs physics in parallel with the game. If physics finishes 
+
+      FSMP runs physics in parallel with the game. If physics finishes
       before the game needs the results, it's essentially free. This budget
-      controls the max time FSMP will wait for physics to finish if it 
+      controls the max time FSMP will wait for physics to finish if it
       doesn't complete in time.
-      
+
       Lower = less fps impact, fewer active skeletons.
       Higher = more fps impact, more active skeletons.
-      
-      For reference, at 60fps a full frame is ~16.6ms. A budget of 2-3ms 
-      is conservative, 5ms is generous. Test in a busy area like Whiterun 
-      with ~10 skeleton NPCs and check the verbose log (level 4) to see 
+
+      For reference, at 60fps a full frame is ~16.6ms. A budget of 2-3ms
+      is conservative, 5ms is generous. Test in a busy area like Whiterun
+      with ~10 skeleton NPCs and check the verbose log (level 4) to see
       how your setup performs.
-      
+
       Default: 3.5
     -->
 	  <budgetMs>3.5</budgetMs>

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -513,25 +513,31 @@ namespace hdt
 
 		if (world->m_doMetrics) {
 			const auto averageProcessingTimeInMainLoop = world->m_averageSMPProcessingTimeInMainLoop;
-			// 30% of processing time is in hdt per profiling;
-			// Setting it higher provides more time for hdt processing and can activate more skeletons.
-			const auto target_time = world->m_timeTick * world->m_percentageOfFrameTime;
+
+			const auto maxBudgetTime = world->m_budgetMs;
 			const auto averageTimePerSkeletonInMainLoop = activeSkeletons > 0 ? averageProcessingTimeInMainLoop / activeSkeletons : 0.f;
 
 			logger::trace(
-				"msecs/activeSkeleton {:.2f} activeSkeletons/maxActive/total {}/{}/{} processTimeInMainLoop/targetTime {:.2f}/{:.2f}",
+				"msecs/activeSkeleton {:.2f} activeSkeletons/maxActive/total {}/{}/{} processTimeInMainLoop/budgetTime {:.2f}/{:.2f}",
 				averageTimePerSkeletonInMainLoop,
 				activeSkeletons,
 				maxActiveSkeletons,
 				m_skeletons.size(),
 				averageProcessingTimeInMainLoop,
-				target_time);
+				maxBudgetTime);
 
 			if (m_autoAdjustMaxSkeletons) {
-				maxActiveSkeletons += target_time > averageProcessingTimeInMainLoop ? 2 : -2;
+				// Deadzones to prevent constantly switching back and fourth
+				if (averageProcessingTimeInMainLoop > maxBudgetTime) {
+					maxActiveSkeletons -= 2;
+				} else if (averageProcessingTimeInMainLoop < maxBudgetTime * 0.9f) {  // under 90% of budget
+					maxActiveSkeletons += 2;
+				}
+
 				// clamp the value to the m_maxActiveSkeletons value
 				maxActiveSkeletons = std::clamp(maxActiveSkeletons, 1, m_maxActiveSkeletons);
 				frameCount = 1;
+
 			} else if (maxActiveSkeletons != m_maxActiveSkeletons)
 				maxActiveSkeletons = m_maxActiveSkeletons;
 		}

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -98,8 +98,8 @@ namespace hdt
 					SkyrimPhysicsWorld::get()->m_unclampedResets = reader.readBool();
 				} else if (reader.GetLocalName() == "unclampedResetAngle") {
 					SkyrimPhysicsWorld::get()->m_unclampedResetAngle = reader.readFloat();
-				} else if (reader.GetLocalName() == "percentageOfFrameTime") {
-					SkyrimPhysicsWorld::get()->m_percentageOfFrameTime = std::clamp(reader.readInt() * 10, 1, 1000);
+				} else if (reader.GetLocalName() == "budgetMs") {
+					SkyrimPhysicsWorld::get()->m_budgetMs = std::clamp(reader.readFloat(), 0.1f, 20.0f);
 				} else if (reader.GetLocalName() == "useRealTime") {
 					SkyrimPhysicsWorld::get()->m_useRealTime = reader.readBool();
 				} else if (reader.GetLocalName() == "minCullingDistance") {

--- a/src/hdtSkyrimPhysicsWorld.cpp
+++ b/src/hdtSkyrimPhysicsWorld.cpp
@@ -357,11 +357,14 @@ namespace hdt
 	RE::BSEventNotifyControl SkyrimPhysicsWorld::ProcessEvent(const Events::FrameSyncEvent*, RE::BSTEventSource<Events::FrameSyncEvent>*)
 	{
 		if (m_doMetrics) {
-			LARGE_INTEGER ticks;
+			LARGE_INTEGER ticks, freq;
 			QueryPerformanceCounter(&ticks);
-			int64_t startTime = ticks.QuadPart;
+			int64_t t0 = ticks.QuadPart;
 
 			m_tasks.wait();
+
+			QueryPerformanceCounter(&ticks);
+			int64_t t1 = ticks.QuadPart;
 
 			{
 				std::lock_guard<decltype(m_lock)> l(m_lock);
@@ -369,18 +372,45 @@ namespace hdt
 			}
 
 			QueryPerformanceCounter(&ticks);
-			int64_t endTime = ticks.QuadPart;
-			QueryPerformanceFrequency(&ticks);
-			// float ticks_per_ms = static_cast<float>(ticks.QuadPart) * 1e-3;
-			m_SMPProcessingTimeInMainLoop += (endTime - startTime) / static_cast<float>(ticks.QuadPart) * 1e3f;
-			m_averageSMPProcessingTimeInMainLoop = (m_averageSMPProcessingTimeInMainLoop * (m_sampleSize - 1) + m_SMPProcessingTimeInMainLoop) / m_sampleSize;
-			float totalSMPTime = m_averageSMPProcessingTimeInMainLoop + m_2ndStepAverageProcessingTime;
+			int64_t t2 = ticks.QuadPart;
+			QueryPerformanceFrequency(&freq);
+			float f = static_cast<float>(freq.QuadPart);
+
+			float instWaitTime = (t1 - t0) / f * 1000.0f;
+			float instWriteTime = (t2 - t1) / f * 1000.0f;
+			float instSetupTime = m_SMPProcessingTimeInMainLoop;
+
+			float instFpsImpact = instSetupTime + instWaitTime + instWriteTime;
+
+			m_averageSMPProcessingTimeInMainLoop = (m_averageSMPProcessingTimeInMainLoop * (m_sampleSize - 1) + instFpsImpact) / m_sampleSize;
+
+			// Smooth the individual components for logging so the math adds up perfectly visually
+			static float avgSetupTime = 0.0f;
+			static float avgWaitTime = 0.0f;
+			static float avgWriteTime = 0.0f;
+
+			avgSetupTime = (avgSetupTime * (m_sampleSize - 1) + instSetupTime) / m_sampleSize;
+			avgWaitTime = (avgWaitTime * (m_sampleSize - 1) + instWaitTime) / m_sampleSize;
+			avgWriteTime = (avgWriteTime * (m_sampleSize - 1) + instWriteTime) / m_sampleSize;
+
+			// The background thread's math time (this is already smoothed in doUpdate2ndStep)
+			float avgBackgroundCalcTime = m_2ndStepAverageProcessingTime;
+
+			// How much of that background math was successfully hidden?
+			float avgHiddenTime = std::max(0.0f, avgBackgroundCalcTime - avgWaitTime);
+
+			float avgTotalCpuWork = avgSetupTime + avgBackgroundCalcTime + avgWriteTime;
+
 			logger::info(
-				"smp cost in main loop (msecs): {:.2f}, cost outside main loop: {:.2f}, percentage outside vs total: {:.2f}",
-				m_averageSMPProcessingTimeInMainLoop, m_2ndStepAverageProcessingTime, 100. * m_2ndStepAverageProcessingTime / totalSMPTime);
+				"[SMP Metrics] Avg Frame-time Impact: {:.2f}ms (Setup: {:.2f}, Wait: {:.2f}, Apply: {:.2f}) | Avg Hidden Time: {:.2f}ms | Avg Total CPU Work: {:.2f}ms",
+				m_averageSMPProcessingTimeInMainLoop,  // This will exactly equal Setup + Wait + Apply
+				avgSetupTime,
+				avgWaitTime,
+				avgWriteTime,
+				avgHiddenTime,
+				avgTotalCpuWork);
 		} else {
 			m_tasks.wait();
-
 			{
 				std::lock_guard<decltype(m_lock)> l(m_lock);
 				writeTransform();

--- a/src/hdtSkyrimPhysicsWorld.h
+++ b/src/hdtSkyrimPhysicsWorld.h
@@ -70,7 +70,7 @@ namespace hdt
 
 		bool m_useRealTime = false;
 		int min_fps = 60;
-		int m_percentageOfFrameTime = 300;  // percentage of time per frame doing hdt. Profiler shows 30% is reasonable. Out of 1000.
+		float m_budgetMs = 3.5f;
 		float m_timeTick = 1 / 60.f;
 		int m_maxSubSteps = 4;
 		bool m_clampRotations = true;


### PR DESCRIPTION
Just switches to use a potentially more user-friendly "budgetMs" value. So you can specify how much time FSMP can steal from your game every frame. Allows for more predictable behavior. 

Also overhauls the metrics a bit more to give more insight into the timings, while providing slightly better wording/metrics for users to understand. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Increased logging verbosity level for more detailed diagnostic output.
  * Replaced physics timing parameter from percentage-based to millisecond-based budget system.

* **Improvements**
  * Refined skeleton auto-adjustment logic with improved deadzone thresholds for more stable physics performance.
  * Enhanced physics performance metrics reporting with clearer frame-time impact measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->