### PR TITLE
build: fix detours.lib debug variant linked in Release builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,7 +98,19 @@ source_group("src" FILES "${VERSION_HEADER}")
 configure_file("${ROOT_DIR}/cmake/version.rc.in" "${CMAKE_CURRENT_BINARY_DIR}/version.rc" @ONLY)
 
 find_path(DETOURS_INCLUDE_DIRS "detours/detours.h")
-find_library(DETOURS_LIBRARY detours REQUIRED)
+# find_library resolves to whichever variant it finds first — on vcpkg it tends to
+# pick debug/lib even for Release builds.  Look up both variants explicitly so we
+# can pass them with the optimized/debug keywords below.
+find_library(DETOURS_LIBRARY_RELEASE NAMES detours NO_DEFAULT_PATH
+    PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
+find_library(DETOURS_LIBRARY_DEBUG NAMES detours NO_DEFAULT_PATH
+    PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib")
+if(NOT DETOURS_LIBRARY_RELEASE)
+    message(FATAL_ERROR "detours: release library not found in vcpkg installed dir")
+endif()
+if(NOT DETOURS_LIBRARY_DEBUG)
+    set(DETOURS_LIBRARY_DEBUG ${DETOURS_LIBRARY_RELEASE})
+endif()
 
 add_library("${PROJECT_NAME}" SHARED ${SOURCE_FILES} "${VERSION_HEADER}" "${CMAKE_CURRENT_BINARY_DIR}/version.rc"
 									 "${ROOT_DIR}/.clang-format" "${ROOT_DIR}/.editorconfig")
@@ -168,7 +180,8 @@ find_package(xbyak REQUIRED CONFIG)
 include_directories(${BULLET_INCLUDE_DIRS})
 
 target_link_libraries("${PROJECT_NAME}" PRIVATE CommonLibSSE::CommonLibSSE xbyak::xbyak spdlog::spdlog
-												${DETOURS_LIBRARY} ${BULLET_LIBRARIES})
+												optimized ${DETOURS_LIBRARY_RELEASE} debug ${DETOURS_LIBRARY_DEBUG}
+												${BULLET_LIBRARIES})
 
 target_precompile_headers("${PROJECT_NAME}" PRIVATE "${SOURCE_DIR}/PCH.h")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,15 +101,24 @@ find_path(DETOURS_INCLUDE_DIRS "detours/detours.h")
 # find_library resolves to whichever variant it finds first — on vcpkg it tends to
 # pick debug/lib even for Release builds.  Look up both variants explicitly so we
 # can pass them with the optimized/debug keywords below.
+# Prefer the public VCPKG_INSTALLED_DIR variable; fall back to the internal
+# _VCPKG_INSTALLED_DIR for older vcpkg, and error if neither is set.
+if(DEFINED VCPKG_INSTALLED_DIR)
+	set(_detours_vcpkg_installed "${VCPKG_INSTALLED_DIR}")
+elseif(DEFINED _VCPKG_INSTALLED_DIR)
+	set(_detours_vcpkg_installed "${_VCPKG_INSTALLED_DIR}")
+else()
+	message(FATAL_ERROR "detours: could not determine vcpkg installed directory (set VCPKG_INSTALLED_DIR)")
+endif()
 find_library(DETOURS_LIBRARY_RELEASE NAMES detours NO_DEFAULT_PATH
-    PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
+	PATHS "${_detours_vcpkg_installed}/${VCPKG_TARGET_TRIPLET}/lib")
 find_library(DETOURS_LIBRARY_DEBUG NAMES detours NO_DEFAULT_PATH
-    PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib")
+	PATHS "${_detours_vcpkg_installed}/${VCPKG_TARGET_TRIPLET}/debug/lib")
 if(NOT DETOURS_LIBRARY_RELEASE)
-    message(FATAL_ERROR "detours: release library not found in vcpkg installed dir")
+	message(FATAL_ERROR "detours: release library not found in vcpkg installed dir")
 endif()
 if(NOT DETOURS_LIBRARY_DEBUG)
-    set(DETOURS_LIBRARY_DEBUG ${DETOURS_LIBRARY_RELEASE})
+	set(DETOURS_LIBRARY_DEBUG ${DETOURS_LIBRARY_RELEASE})
 endif()
 
 add_library("${PROJECT_NAME}" SHARED ${SOURCE_FILES} "${VERSION_HEADER}" "${CMAKE_CURRENT_BINARY_DIR}/version.rc"
@@ -134,7 +143,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 endif()
 
 target_include_directories("${PROJECT_NAME}" PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/src" "${SOURCE_DIR}"
-													 ${DETOURS_LIBRARY} ${BULLET_INCLUDE_DIRS})
+													 ${DETOURS_INCLUDE_DIRS} ${BULLET_INCLUDE_DIRS})
 
 set(SKSE_SUPPORT_XBYAK ON)
 


### PR DESCRIPTION
## Summary

- `find_library(DETOURS_LIBRARY detours)` was resolving to `debug/lib/detours.lib` for **all** build configurations because vcpkg exposes both debug and release paths and CMake picks whichever it finds first
- The debug variant is compiled with `/MDd`, which defines `_DEBUG`, enabling `DETOUR_ASSERT` → `Detour_AssertExprWithFunctionName` → `__imp__CrtDbgReport` — a symbol only present in the debug CRT (`ucrtbased.dll`)
- This caused `LNK2019: unresolved external symbol __imp__CrtDbgReport` on every Release build

## Fix

Find both variants explicitly using `_VCPKG_INSTALLED_DIR`/`VCPKG_TARGET_TRIPLET` (set by the vcpkg toolchain) and pass them to `target_link_libraries` with the `optimized`/`debug` keywords so each build configuration links the correct variant.

## Test plan

- [ ] Release build links cleanly with no `LNK2019` errors
- [ ] Debug build still links the debug detours variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration for dependency linking to support separate Release and Debug library variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->