### PR TITLE
perf: limit physics threading to P-cores on Intel hybrid CPUs

### DIFF
--- a/src/hdtSkinnedMesh/hdtBulletHelper.h
+++ b/src/hdtSkinnedMesh/hdtBulletHelper.h
@@ -7,6 +7,9 @@
 #include <cassert>
 #include <cfloat>
 #include <intrin.h>
+#include <thread>
+#include <vector>
+#include <windows.h>
 
 #undef min
 #undef max
@@ -421,6 +424,43 @@ namespace hdt
 
 	template <class T>
 	using vectorA16 = std::vector<T>;
+
+	// Returns the count of performance cores on Intel hybrid CPUs (P-cores only).
+	// On AMD and non-hybrid Intel, all cores have EfficiencyClass == 0, so isHybrid
+	// stays false and this falls back to hardware_concurrency() — no change in behaviour.
+	inline int getPCoreCount()
+	{
+		DWORD length = 0;
+		if (!GetLogicalProcessorInformationEx(RelationProcessorCore, nullptr, &length) &&
+			GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+			return static_cast<int>(std::thread::hardware_concurrency());
+
+		std::vector<uint8_t> buffer(length);
+		auto* info = reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*>(buffer.data());
+		if (!GetLogicalProcessorInformationEx(RelationProcessorCore, info, &length))
+			return static_cast<int>(std::thread::hardware_concurrency());
+
+		bool isHybrid = false;
+		for (DWORD offset = 0; offset < length;) {
+			auto* entry = reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*>(buffer.data() + offset);
+			if (entry->Processor.EfficiencyClass > 0)
+				isHybrid = true;
+			offset += entry->Size;
+		}
+
+		if (!isHybrid)
+			return static_cast<int>(std::thread::hardware_concurrency());
+
+		int pCores = 0;
+		for (DWORD offset = 0; offset < length;) {
+			auto* entry = reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*>(buffer.data() + offset);
+			if (entry->Processor.EfficiencyClass > 0)
+				pCores += static_cast<int>(__popcnt64(entry->Processor.GroupMask[0].Mask));
+			offset += entry->Size;
+		}
+
+		return std::max(1, pCores);
+	}
 
 	class SpinLock
 	{

--- a/src/hdtSkinnedMesh/hdtBulletHelper.h
+++ b/src/hdtSkinnedMesh/hdtBulletHelper.h
@@ -454,8 +454,10 @@ namespace hdt
 		int pCores = 0;
 		for (DWORD offset = 0; offset < length;) {
 			auto* entry = reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*>(buffer.data() + offset);
-			if (entry->Processor.EfficiencyClass > 0)
-				pCores += static_cast<int>(__popcnt64(entry->Processor.GroupMask[0].Mask));
+			if (entry->Processor.EfficiencyClass > 0) {
+				for (WORD g = 0; g < entry->Processor.GroupCount; ++g)
+					pCores += static_cast<int>(__popcnt64(entry->Processor.GroupMask[g].Mask));
+			}
 			offset += entry->Size;
 		}
 

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
@@ -320,7 +320,12 @@ namespace hdt
 				listB.clear();
 			};
 
-			if (pairs.size() >= std::thread::hardware_concurrency())
+			// Use P-core count as the parallelism threshold. On Intel hybrid CPUs
+			// hardware_concurrency() includes E-cores, which inflates the threshold and
+			// causes small workloads to go serial unnecessarily, or dispatches to E-cores
+			// whose slowness stalls the barrier. getPCoreCount() is cached at first call.
+			static const int physicsThreadCount = getPCoreCount();
+			if (pairs.size() >= static_cast<size_t>(physicsThreadCount))
 				// FIXME PROFILING This is the line where we spend the most time in the whole mod.
 				concurrency::parallel_for_each(pairs.begin(), pairs.end(), func);
 			else

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -15,10 +15,12 @@ namespace hdt
 		btDiscreteDynamicsWorldMt(
 			nullptr,
 			nullptr,
-			// Pool of regular sequential solvers one per hardware thread.
+			// Pool of regular sequential solvers, one per performance core.
+			// On Intel hybrid CPUs (Alder Lake+) this excludes E-cores, which are ~3-4x
+			// slower for compute work and cause tail-latency stalls in parallel island solving.
+			// On AMD and non-hybrid Intel, getPCoreCount() returns hardware_concurrency().
 			// Each island gets dispatched to a free solver on any thread.
-			new btConstraintSolverPoolMt(
-				std::max(1, static_cast<int>(std::thread::hardware_concurrency()))),
+			new btConstraintSolverPoolMt(getPCoreCount()),
 			nullptr,  // no Mt solver, avoids btBatchedConstraints entirely (we are not designed for that yet)
 			nullptr)
 	{


### PR DESCRIPTION
## Summary

- `std::thread::hardware_concurrency()` includes E-cores on Intel 12th gen+ (Alder Lake, Raptor Lake). E-cores are ~3–4× slower for compute work, so physics tasks dispatched to them stall the barrier all other threads wait at
- `btConstraintSolverPoolMt` was sized by total thread count, allocating solver slots that map to E-core threads
- The parallel/serial dispatch threshold in the collision algorithm used the same inflated count, causing work to go parallel even when there weren't enough P-cores to benefit

## Fix

Adds `getPCoreCount()` in `hdtBulletHelper.h` using `GetLogicalProcessorInformationEx` to count only cores with `EfficiencyClass > 0` (P-cores). **On AMD and non-hybrid Intel all cores report class 0, so `isHybrid` stays false and the function returns `hardware_concurrency()` unchanged — no behaviour change on those CPUs.**

- `hdtSkinnedMeshWorld.cpp`: `btConstraintSolverPoolMt` now sized by `getPCoreCount()`
- `hdtSkinnedMeshAlgorithm.cpp`: parallel dispatch threshold uses `getPCoreCount()` (cached as a `static const`)

## Test plan

- [ ] Verify no performance regression on AMD CPUs (should be identical behaviour)
- [ ] Verify no performance regression on non-hybrid Intel CPUs
- [ ] Verify improved frame times on Intel 12th/13th/14th gen hybrid CPUs under physics load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized physics engine to better utilize performance cores on Intel hybrid processors.
  * Improved collision detection and physics solver thread allocation for enhanced efficiency on hybrid CPU architectures.
  * Parallelism decisions now scale based on actual performance core availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->