### PR TITLE
fix: Read transforms later in the tick, fix game pause

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -198,23 +198,25 @@ namespace Hooks
 		localTrampoline.write_branch<5>(GeometrySkinningBoneFix.address(), localTrampoline.allocate(code));
 	}
 
-	void MainHooks::Update(RE::Main* const a_this)
+	void MainHooks::Update(uint32_t _0, uint32_t _0x18)
 	{
-		//
-		_Update(a_this);
+		_WaitForJobTask(_0, _0x18);
 
-		// why doesn't this class have a GetRuntimeData() helper? the offsets are borked with VR support enabled.
-		bool quitGame = REL::RelocateMember<bool>(a_this, 0x10, 0x8);
+		auto main = RE::Main::GetSingleton();
+		if (main) {
+			// why doesn't this class have a GetRuntimeData() helper? the offsets are borked with VR support enabled.
+			bool quitGame = REL::RelocateMember<bool>(main, 0x10, 0x8);
 
-		//
-		if (quitGame) {
-			Events::ShutdownEvent e;
-			Events::Sources::ShutdownEventEventSource::GetSingleton()->SendEvent(&e);
-		} else {
-			Events::FrameEvent e;
-			e.gamePaused = a_this->freezeTime;
-			Events::Sources::FrameEventSource::GetSingleton()->SendEvent(&e);
+			if (quitGame) {
+				Events::ShutdownEvent e;
+				Events::Sources::ShutdownEventEventSource::GetSingleton()->SendEvent(&e);
+				return;
+			}
 		}
+
+		Events::FrameEvent e;
+		e.gamePaused = false;  // This hook doesn't get called if the game is paused
+		Events::Sources::FrameEventSource::GetSingleton()->SendEvent(&e);
 	}
 
 	void MainHooks::Unk_sub(void* a_this)

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -63,7 +63,9 @@ namespace Hooks
 	public:
 		static void Hook()
 		{
-			REL::Relocation<uintptr_t> UpdateHook1{ REL::VariantID(35551, 36544, 0x05B6D70), REL::VariantOffset(0x11F, 0x160, 0x11F) };  // 0x05AF3D0, 0x05E7EE0, 0x05B6D70 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
+			// 36564     140645EA0
+			// 35565     1405B2FF0
+			REL::Relocation<uintptr_t> UpdateHook1{ REL::VariantID(35565, 36564, 0x5BAB10), REL::VariantOffset(0x2CC, 0x2E7, 0x0) };     // 0x05AF3D0, 0x05E7EE0, 0x05B6D70 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
 			REL::Relocation<uintptr_t> UpdateHook2{ REL::VariantID(35565, 36564, 0x05BAB10), REL::VariantOffset(0x56D, 0x9DC, 0x611) };  // 0x05B2FF0, 0x05EC240, 0x05BAB10 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
 
 			logger::debug("Applying MainHooks hooks!");
@@ -73,7 +75,7 @@ namespace Hooks
 
 			//
 			SKSE::AllocTrampoline(14);
-			_Update = trampoline.write_call<5>(UpdateHook1.address(), Update);
+			_WaitForJobTask = trampoline.write_call<5>(UpdateHook1.address(), Update);
 
 			//
 			SKSE::AllocTrampoline(14);
@@ -83,11 +85,11 @@ namespace Hooks
 			logger::debug("...success");
 		}
 
-		static void Update(RE::Main* const);
+		static void Update(uint32_t _0, uint32_t _0x18);
 		static void Unk_sub(void*);  // RE::BSBethesdaPlatform*
 	public:
+		static inline REL::Relocation<decltype(&Update)> _WaitForJobTask;
 		static inline REL::Relocation<decltype(&Unk_sub)> _Unk_sub;
-		static inline REL::Relocation<decltype(&Update)> _Update;
 	};
 
 	class ActorEquipManagerHooks

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -65,7 +65,7 @@ namespace Hooks
 		{
 			// 36564     140645EA0
 			// 35565     1405B2FF0
-			REL::Relocation<uintptr_t> UpdateHook1{ REL::VariantID(35565, 36564, 0x05BAB10), REL::VariantOffset(0x2CC, 0x2E7, 0x371) };     // 0x05AF3D0, 0x05E7EE0, 0x05B6D70 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
+			REL::Relocation<uintptr_t> UpdateHook1{ REL::VariantID(35565, 36564, 0x05BAB10), REL::VariantOffset(0x2CC, 0x2E7, 0x371) };  // 0x05AF3D0, 0x05E7EE0, 0x05B6D70 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
 			REL::Relocation<uintptr_t> UpdateHook2{ REL::VariantID(35565, 36564, 0x05BAB10), REL::VariantOffset(0x56D, 0x9DC, 0x611) };  // 0x05B2FF0, 0x05EC240, 0x05BAB10 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
 
 			logger::debug("Applying MainHooks hooks!");

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -65,7 +65,7 @@ namespace Hooks
 		{
 			// 36564     140645EA0
 			// 35565     1405B2FF0
-			REL::Relocation<uintptr_t> UpdateHook1{ REL::VariantID(35565, 36564, 0x5BAB10), REL::VariantOffset(0x2CC, 0x2E7, 0x0) };     // 0x05AF3D0, 0x05E7EE0, 0x05B6D70 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
+			REL::Relocation<uintptr_t> UpdateHook1{ REL::VariantID(35565, 36564, 0x05BAB10), REL::VariantOffset(0x2CC, 0x2E7, 0x371) };     // 0x05AF3D0, 0x05E7EE0, 0x05B6D70 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
 			REL::Relocation<uintptr_t> UpdateHook2{ REL::VariantID(35565, 36564, 0x05BAB10), REL::VariantOffset(0x56D, 0x9DC, 0x611) };  // 0x05B2FF0, 0x05EC240, 0x05BAB10 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
 
 			logger::debug("Applying MainHooks hooks!");


### PR DESCRIPTION
This fixes three things:

1. Mods like Joint Fix will no longer be overwritten/ignored
2. The game pause (Like tfc 1) will actually pause smp physics
3. We wait until all the animations,etc is finished. Avoiding reading the previous frame's positions


Todo:

1. Improve hook offsets (Was lazy)
2. RE further to find absolute most stable place to put these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured game loop update and event dispatch handling to improve shutdown process timing and frame processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->