### PR TITLE
feat: Add AVX Version Logging and DLL Product Version Metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,9 +128,13 @@ jobs:
       matrix:
         include:
           - preset: vs2022-windows
+            avx_variant: noavx
           - preset: vs2022-windows-avx
+            avx_variant: avx
           - preset: vs2022-windows-avx2
+            avx_variant: avx2
           - preset: vs2022-windows-avx512
+            avx_variant: avx512
 
     steps:
       - name: Checkout the repository
@@ -188,6 +192,19 @@ jobs:
             Write-Host "BUILD INFO VERIFIED: '$BuildInfo' found in $DllPath"
           } else {
             Write-Error "BUILD INFO MISSING: '$BuildInfo' not found in $DllPath"
+            exit 1
+          }
+
+      - name: Verify AVX variant embedded in DLL
+        shell: pwsh
+        run: |
+          $Variant = "${{ matrix.avx_variant }}"
+          $DllPath = "out/build/${{ matrix.preset }}/plugins/SKSE/Plugins/hdtSMP64.dll"
+          $ProductVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($DllPath).ProductVersion
+          if ($ProductVersion -match [regex]::Escape("($Variant)")) {
+            Write-Host "AVX VARIANT VERIFIED: ProductVersion '$ProductVersion' contains '($Variant)'"
+          } else {
+            Write-Error "AVX VARIANT MISSING: ProductVersion '$ProductVersion' does not contain '($Variant)' in $DllPath"
             exit 1
           }
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,6 +38,10 @@
     },
     {
       "cacheVariables": {
+        "AVX_VARIANT": {
+          "type": "STRING",
+          "value": "noavx"
+        },
         "CMAKE_MSVC_RUNTIME_LIBRARY": {
           "type": "STRING",
           "value": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
@@ -70,6 +74,10 @@
     },
     {
       "cacheVariables": {
+        "AVX_VARIANT": {
+          "type": "STRING",
+          "value": "avx"
+        },
         "VCPKG_TARGET_TRIPLET": {
           "type": "STRING",
           "value": "x64-windows-static-md-avx"
@@ -83,6 +91,10 @@
     },
     {
       "cacheVariables": {
+        "AVX_VARIANT": {
+          "type": "STRING",
+          "value": "avx2"
+        },
         "VCPKG_TARGET_TRIPLET": {
           "type": "STRING",
           "value": "x64-windows-static-md-avx2"
@@ -96,6 +108,10 @@
     },
     {
       "cacheVariables": {
+        "AVX_VARIANT": {
+          "type": "STRING",
+          "value": "avx512"
+        },
         "VCPKG_TARGET_TRIPLET": {
           "type": "STRING",
           "value": "x64-windows-static-md-avx512"

--- a/cmake/Plugin.h.in
+++ b/cmake/Plugin.h.in
@@ -20,4 +20,6 @@ namespace Plugin
 	// Pre-release identifier set by CI for non-production builds (e.g. "dev-abc1234").
 	// Empty string for production/release builds.
 	inline constexpr auto BUILD_INFO = "@PROJECT_BUILD_INFO@"sv;
+
+	inline constexpr auto AVX_VARIANT = "@AVX_VARIANT@"sv;
 }

--- a/cmake/version.rc.in
+++ b/cmake/version.rc.in
@@ -22,7 +22,7 @@ BEGIN
 			VALUE "InternalName", "@PROJECT_NAME@"
 			VALUE "LegalCopyright", "GPLv3"
 			VALUE "ProductName", "@PROJECT_NAME@"
-			VALUE "ProductVersion", "@PROJECT_VERSION@.0"
+			VALUE "ProductVersion", "@PROJECT_VERSION@.0 (@AVX_VARIANT@)"
 		END
 	END
 	BLOCK "VarFileInfo"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -507,9 +507,9 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 	SKSE::Init(a_skse);
 
 	if constexpr (Plugin::BUILD_INFO.empty()) {
-		logger::info("{} v{}"sv, Plugin::NAME, Plugin::VERSION.string());
+		logger::info("{} v{} ({})"sv, Plugin::NAME, Plugin::VERSION.string(), Plugin::AVX_VARIANT);
 	} else {
-		logger::info("{} v{}-{}"sv, Plugin::NAME, Plugin::VERSION.string(), Plugin::BUILD_INFO);
+		logger::info("{} v{}-{} ({})"sv, Plugin::NAME, Plugin::VERSION.string(), Plugin::BUILD_INFO, Plugin::AVX_VARIANT);
 	}
 
 	const auto messaging = SKSE::GetMessagingInterface();


### PR DESCRIPTION
Related to #253, but independent

Add AVX Variant to DLL Product version metadata field 

<img width="602" height="779" alt="image" src="https://github.com/user-attachments/assets/6b12a2bc-f640-4bf4-a366-f7cb59080203" />

And to the logs:
<img width="934" height="65" alt="image" src="https://github.com/user-attachments/assets/a0bfcc43-5d2c-462d-b2e3-14c1437fb29b" />


The duplicate version lines were introduced with the semver build number changes

This is a restore of the changes made in #259 before I messed it up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build pipeline with verification step for AVX variant consistency.

* **New Features**
  * Plugin version information and logs now display the AVX variant identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->