### PR TITLE
fix: Fix skyrim bug leading to broken facial morphs, undo previous attempt

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -213,50 +213,6 @@ namespace hdt
 			return RE::BSEventNotifyControl::kContinue;
 		}
 
-		// Skyrim Bug Fix: This fixes a bug with skyrim where if a BSTriShape comes before a BSDynamicTriShape
-		// in the BSFaceGenNiNode, the face/actor will be skipped by the facial morph workers. This is not a SMP
-		// bug, but many smp mods (hair especially) tend to trigger this issue due to improper nifs
-		if (e->headNode) {
-			auto& children = e->headNode->GetChildren();
-
-			auto isStaticTriShape = [](RE::NiAVObject* c) {
-				return c && c->AsTriShape() && !c->AsDynamicTriShape();
-			};
-
-			// Check if any static shape sits before a dynamic one
-			bool seenStatic = false;
-			bool needsReorder = false;
-			for (auto& child : children) {
-				if (!child)
-					continue;
-				if (isStaticTriShape(child.get())) {
-					seenStatic = true;
-				} else if (child->AsDynamicTriShape() && seenStatic) {
-					needsReorder = true;
-					break;
-				}
-			}
-
-			if (needsReorder) {
-				logger::debug("FaceGen node order is incorrect (static physics shapes placed before dynamic head parts). Reordering to fix frozen face morphs...");
-
-				std::vector<RE::NiPointer<RE::NiAVObject>> staticShapes;
-				for (int i = static_cast<int>(children.size()) - 1; i >= 0; --i) {
-					auto* child = children[static_cast<std::uint16_t>(i)].get();
-					if (isStaticTriShape(child)) {
-						staticShapes.emplace_back(child);
-						e->headNode->DetachChildAt2(static_cast<std::uint16_t>(i));
-					}
-				}
-
-				for (auto it = staticShapes.rbegin(); it != staticShapes.rend(); ++it) {
-					e->headNode->AttachChild(it->get(), false);
-				}
-
-				logger::debug("FaceGen node reordering complete. Facial expressions restored.");
-			}
-		}
-
 		fixArmorNameMaps();
 
 		auto& skeleton = getSkeletonData(e->skeleton);

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -32,6 +32,28 @@ namespace Hooks
 			//
 			ApplyBoneLimitFix();
 
+			// Todo: Get the VR offset(s)/ID
+			if (!REL::Module::IsVR()) {
+				// Skyrim patch: This fixes facial morphs from getting broken by some SMP meshes (Commonly hairs, but also bodies)
+				// [BSFaceGenNiNode::sub, the producer that enqueues faces for morph updates]
+				// children[0] validation bails if the first child isn't a valid facegen BSDynamicTriShape
+				// Patch: redirect the failure JZ to skip the child dependent section
+				// and fall through to node checks instead of early bailing
+				//
+				// 1404332c0: 0F 84 8F 00 00 00  JZ 0x8F  140433355 (early bail)
+				// to: 0F 84 22 00 00 00  JZ 0x22   1404332e8 (actual node checks)
+
+				REL::Relocation<std::uintptr_t> func{ RELOCATION_ID(26417, 26998) };
+
+				logger::debug("Applying FaceMorphProducer patch!");
+
+				if (REL::Module::IsAE()) {
+					REL::safe_write(func.address() + 0x202, std::uint8_t{ 0x22 });
+				} else {
+					REL::safe_write(func.address() + 0x201, std::uint8_t{ 0x09 });
+				}
+			}
+
 			//
 			logger::debug("...success");
 		}


### PR DESCRIPTION
This will fix an annoying bug that causes Skyrim to just skip NPC's if they don't have a proper 

Bethesda's face morph system just grabs the first non-null child node off the face skeleton and checks if it's valid FaceGen geometry. If it's not, the whole NPC gets skipped for morph updates, so you get no expressions, no lip sync, and no blinking. SMP hair mods and similar stuff can stick static (or invalid BSDynamicTriShape) nodes in that first slot, which fails the check and kills the face. The fix just redirects the failure jump to land on the node-level checks instead, which look at the face node itself rather than whatever child happened to be first. All the other gating, like distance and visibility, still works fine. one byte patch per version.

Tested on:

- AE (Myself, Predator)
- SE (Myself)

VR will still require offsets, so for now I just excluded it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved facial animation and character geometry rendering quality, enhancing appearance and stability across different game configurations, particularly for non-VR versions.

* **Refactor**
  * Streamlined character model skinning and initialization processes by optimizing core geometry handling procedures and removing redundant logic, improving system performance while maintaining visual fidelity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->