### PR TITLE
fix: Fix dhdt breaking game saves

### DIFF
--- a/src/dhdtOverrideManager.cpp
+++ b/src/dhdtOverrideManager.cpp
@@ -69,16 +69,19 @@ std::stringstream hdt::Override::OverrideManager::Serialize()
 	if (!checkPapyrusExtension())
 		return data_stream;
 
-	for (auto& e : m_ActorPhysicsFileSwapList) {
-		char buff[16];
-		sprintf_s(buff, "%08X", e.first);
-		data_stream << std::hex << buff << " " << std::dec << e.second.size() << std::endl;
-		for (auto& e1 : e.second) {
-			if (e1.second.empty()) {
-				continue;
-			}
+	for (const auto& [formID, overrides] : m_ActorPhysicsFileSwapList) {
+		auto count = std::ranges::count_if(overrides, [](const auto& p) { return !p.second.empty(); });
 
-			data_stream << e1.first << "\t" << e1.second << std::endl;
+		if (count == 0)
+			continue;
+
+		data_stream << std::format("{:08X} {}\n", formID, count);
+
+		for (const auto& [orig, override_path] : overrides) {
+			if (override_path.empty())
+				continue;
+
+			data_stream << orig << "\t" << override_path << std::endl;
 		}
 	}
 
@@ -87,26 +90,36 @@ std::stringstream hdt::Override::OverrideManager::Serialize()
 
 void hdt::Override::OverrideManager::Deserialize(std::stringstream& data_stream)
 {
-	if (!checkPapyrusExtension()) {
+	if (!checkPapyrusExtension())
 		return;
-	}
 
 	m_ActorPhysicsFileSwapList.clear();
 	try {
-		while (!data_stream.eof()) {
-			uint32_t actor_formID, override_size = 0;
-			data_stream >> std::hex >> actor_formID >> override_size;
+		std::string line;
+		while (std::getline(data_stream, line)) {
+			if (line.empty())
+				continue;
+
+			std::istringstream header(line);
+			uint32_t actor_formID = 0, override_size = 0;
+			header >> std::hex >> actor_formID >> std::dec >> override_size;
+			if (header.fail())
+				return;
+
 			for (auto i = 0u; i < override_size; ++i) {
-				std::string orig_physics_file, override_physics_file;
-				data_stream >> orig_physics_file >> override_physics_file;
-				//this->registerOverride(actor_formID, orig_physics_file, override_physics_file);
-				hdt::papyrus::impl::SwapPhysicsFileImpl(actor_formID, orig_physics_file, override_physics_file, true, false);
+				std::string pathLine;
+				if (!std::getline(data_stream, pathLine))
+					return;
+
+				auto tabPos = pathLine.find('\t');
+				if (tabPos == std::string::npos)
+					return;
+
+				hdt::papyrus::impl::SwapPhysicsFileImpl(actor_formID, pathLine.substr(0, tabPos), pathLine.substr(tabPos + 1), true, false);
 			}
 		}
 	} catch (std::exception& e) {
 		RE::ConsoleLog::GetSingleton()->Print("[DynamicHDT] ERROR! -- Failed parsing override data.");
 		RE::ConsoleLog::GetSingleton()->Print("[DynamicHDT] Error(): {}\nWhat():\n\t{}", typeid(e).name(), e.what());
-
-		return;
 	}
 }


### PR DESCRIPTION
Fixes this bug reported by samirloon:

> Will the Dynamic HDT still be supported in future versions? It has a problem: When I make dynamic HDT save the configuration file, the game save file will not be able to be loaded. The save file could be loaded only after I deleted the xxx.DHDT file located in SKSE\Plugins\hdtOverrideSaves. Just like this: DynamicHDT.ReloadPhysicsFile(akTarget, arma, currentNewBodyPath, true, false)
> 
> The physical preset selection spell will be added to your spell bar.
> Just leave the PC naked and use the physical switch magic to hit yourself.
> Then, manually save the game. The file xxxx.dhdt will be located in the path SKSE\Plugins\hdtOverrideSaves.


Also implements much safer de-serialization to avoid potential future issues. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Revised override save/load logic to record only non-empty entries and produce cleaner override files.
* **Bug Fix**
  * Improved parsing and error handling when reading override configurations to reduce failures and increase reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->