### PR TITLE
perf: Optimize SystemCreator

### DIFF
--- a/src/hdtSkinnedMesh/hdtCollider.cpp
+++ b/src/hdtSkinnedMesh/hdtCollider.cpp
@@ -4,10 +4,10 @@
 namespace hdt
 {
 
-	void ColliderTree::insertCollider(const std::vector<U32>& keys, const Collider& c)
+	void ColliderTree::insertCollider(const U32* keys, size_t keyCount, const Collider& c)
 	{
 		ColliderTree* p = this;
-		for (int i = 0; i < keys.size() && i < 4; ++i) {
+		for (size_t i = 0; i < keyCount && i < 4; ++i) {
 			auto f = std::find_if(p->children.begin(), p->children.end(), [=](const ColliderTree& n) { return n.key == keys[i]; });
 			if (f == p->children.end()) {
 				p->children.push_back(ColliderTree(keys[i]));

--- a/src/hdtSkinnedMesh/hdtCollider.h
+++ b/src/hdtSkinnedMesh/hdtCollider.h
@@ -65,7 +65,7 @@ namespace hdt
 		vectorA16<Collider> colliders;
 		U32 key;
 
-		void insertCollider(const std::vector<U32>& keys, const Collider& c);
+		void insertCollider(const U32* keys, size_t keyCount, const Collider& c);
 		void exportColliders(vectorA16<Collider>& exportTo);
 		void remapColliders(Collider* start, Aabb* startAabb);
 

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshShape.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshShape.cpp
@@ -86,7 +86,7 @@ namespace hdt
 				if (m_owner->m_vertices[i].m_weight[j] > FLT_EPSILON)
 					keys.push_back(m_owner->m_vertices[i].getBoneIdx(j));
 			}
-			m_tree.insertCollider(keys, Collider(i));
+			m_tree.insertCollider(keys.data(), keys.size(), Collider(i));
 		}
 	}
 
@@ -197,30 +197,54 @@ namespace hdt
 		assert(b < m_owner->m_vertices.size());
 		assert(c < m_owner->m_vertices.size());
 		Collider collider(a, b, c);
-		std::vector<U32> keys;
-		std::vector<float> w;
-		for (int i = 0; i < 12; ++i) {
-			auto weight = getColliderBoneWeight(&collider, i);
-			if (weight < FLT_EPSILON)
-				continue;
-			auto bone = getColliderBoneIndex(&collider, i);
-			auto iter = std::find(keys.begin(), keys.end(), (U32)bone);
-			if (iter != keys.end())
-				w[iter - keys.begin()] += weight;
-			else {
-				keys.push_back(bone);
-				w.push_back(weight);
+
+		// Stacklocal fixed arrays, max 12 unique bones (3 verts * 4 weights)
+		U32 keys[12];
+		float w[12];
+		int count = 0;
+
+		const auto& v0 = m_owner->m_vertices[a];
+		const auto& v1 = m_owner->m_vertices[b];
+		const auto& v2 = m_owner->m_vertices[c];
+		const Vertex* verts[3] = { &v0, &v1, &v2 };
+
+		for (int vi = 0; vi < 3; ++vi) {
+			for (int wi = 0; wi < 4; ++wi) {
+				float weight = verts[vi]->m_weight[wi];
+				if (weight < FLT_EPSILON)
+					continue;
+				U32 bone = verts[vi]->getBoneIdx(wi);
+
+				int found = -1;
+				for (int k = 0; k < count; ++k) {
+					if (keys[k] == bone) {
+						found = k;
+						break;
+					}
+				}
+				if (found >= 0) {
+					w[found] += weight;
+				} else {
+					keys[count] = bone;
+					w[count] = weight;
+					++count;
+				}
 			}
 		}
 
-		for (int i = 0; i < keys.size(); ++i)
-			for (int j = 1; j < keys.size(); ++j) {
-				if (w[j - 1] < w[j] || (w[j - 1] == w[j] && keys[j] < keys[j - 1])) {
-					std::swap(keys[j], keys[j - 1]);
-					std::swap(w[j], w[j - 1]);
-				}
+		for (int i = 1; i < count; ++i) {
+			float wTemp = w[i];
+			U32 kTemp = keys[i];
+			int j = i;
+			while (j > 0 && (w[j - 1] < wTemp || (w[j - 1] == wTemp && keys[j - 1] > kTemp))) {
+				w[j] = w[j - 1];
+				keys[j] = keys[j - 1];
+				--j;
 			}
+			w[j] = wTemp;
+			keys[j] = kTemp;
+		}
 
-		m_tree.insertCollider(keys, collider);
+		m_tree.insertCollider(keys, count, collider);
 	}
 }

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -5,38 +5,43 @@
 #include "XmlReader.h"
 #include "hdtSkyrimPhysicsWorld.h"
 
+// F16C isn't supported on super old processors. AVX2+ (AVX processors can have it, but not guaranteed)
+#if defined(__AVX2__) || defined(__AVX512F__)
+#	include <immintrin.h>
+#else
+// float32
+// Martin Kallman
+//
+// Fast half-precision to single-precision floating point conversion
+//  - Supports signed zero and denormals-as-zero (DAZ)
+//  - Does not support infinities or NaN
+//  - Few, partially pipelinable, non-branching instructions,
+//  - Core operations ~6 clock cycles on modern x86-64
+static void __float32(float* __restrict out, const uint16_t in)
+{
+	uint32_t t1;
+	uint32_t t2;
+	uint32_t t3;
+
+	t1 = in & 0x7fff;  // Non-sign bits
+	t2 = in & 0x8000;  // Sign bit
+	t3 = in & 0x7c00;  // Exponent
+
+	t1 <<= 13;  // Align mantissa on MSB
+	t2 <<= 16;  // Shift sign bit into position
+
+	t1 += 0x38000000;  // Adjust bias
+
+	t1 = (t3 == 0 ? 0 : t1);  // Denormals-as-zero
+
+	t1 |= t2;  // Re-insert sign bit
+
+	*((uint32_t*)out) = t1;
+};
+#endif
+
 namespace hdt
 {
-	// float32
-	// Martin Kallman
-	//
-	// Fast half-precision to single-precision floating point conversion
-	//  - Supports signed zero and denormals-as-zero (DAZ)
-	//  - Does not support infinities or NaN
-	//  - Few, partially pipelinable, non-branching instructions,
-	//  - Core operations ~6 clock cycles on modern x86-64
-	static void float32(float* __restrict out, const uint16_t in)
-	{
-		uint32_t t1;
-		uint32_t t2;
-		uint32_t t3;
-
-		t1 = in & 0x7fff;  // Non-sign bits
-		t2 = in & 0x8000;  // Sign bit
-		t3 = in & 0x7c00;  // Exponent
-
-		t1 <<= 13;  // Align mantissa on MSB
-		t2 <<= 16;  // Shift sign bit into position
-
-		t1 += 0x38000000;  // Adjust bias
-
-		t1 = (t3 == 0 ? 0 : t1);  // Denormals-as-zero
-
-		t1 |= t2;  // Re-insert sign bit
-
-		*((uint32_t*)out) = t1;
-	};
-
 	static constexpr float PI = 3.1415926535897932384626433832795f;
 
 	btEmptyShape SkyrimSystemCreator::BoneTemplate::emptyShape[1];
@@ -153,6 +158,17 @@ namespace hdt
 	{
 	}
 
+	void SkyrimSystemCreator::indexBone(SkyrimBone* bone)
+	{
+		m_boneIndex.emplace(bone->m_name.data(), bone);
+	}
+
+	SkyrimBone* SkyrimSystemCreator::findBoneFromIndex(const RE::BSFixedString& name) const
+	{
+		auto it = m_boneIndex.find(name.data());
+		return it != m_boneIndex.end() ? it->second : nullptr;
+	}
+
 	RE::NiNode* SkyrimSystemCreator::findObjectByName(const RE::BSFixedString& name)
 	{
 		// TODO check it's not a lurker skeleton
@@ -161,7 +177,7 @@ namespace hdt
 
 	SkyrimBone* SkyrimSystemCreator::getOrCreateBone(const RE::BSFixedString& name)
 	{
-		auto bone = static_cast<SkyrimBone*>(m_mesh->findBone(getRenamedBone(name)));
+		auto bone = findBoneFromIndex(getRenamedBone(name));
 		if (bone) {
 			return bone;
 		}
@@ -210,6 +226,7 @@ namespace hdt
 		auto meshNameMap = file->second;
 
 		m_mesh = RE::make_smart<SkyrimSystem>(skeleton);
+		m_boneIndex.clear();
 
 		// Store original locale
 		char saved_locale[32];
@@ -325,6 +342,24 @@ namespace hdt
 			logger::error("xml parse error - {}", err.c_str());
 			return nullptr;
 		}
+
+		if (m_deferredBuilds.size() > 2) {
+			concurrency::parallel_for_each(
+				m_deferredBuilds.begin(), m_deferredBuilds.end(),
+				[](const DeferredBuild& db) {
+					if (db.vertexShape)
+						db.vertexShape->autoGen();
+					db.body->finishBuild();
+				});
+		} else if (!m_deferredBuilds.empty()) {
+			for (const auto& db : m_deferredBuilds) {
+				if (db.vertexShape)
+					db.vertexShape->autoGen();
+				db.body->finishBuild();
+			}
+		}
+
+		m_deferredBuilds.clear();
 
 		// Restore original locale
 		std::setlocale(LC_NUMERIC, saved_locale);
@@ -611,7 +646,7 @@ namespace hdt
 	void SkyrimSystemCreator::readOrUpdateBone(SkyrimSystem* old_system)
 	{
 		RE::BSFixedString name = getRenamedBone(m_reader->getAttribute("name"));
-		if (m_mesh->findBone(name)) {
+		if (findBoneFromIndex(name)) {
 			logger::warn("Bone {} already exists, skipped", name.c_str());
 			return;
 		}
@@ -655,6 +690,7 @@ namespace hdt
 				bone->readTransform(RESET_PHYSICS);
 
 			m_mesh->m_bones.push_back(hdt::make_smart(bone));
+			indexBone(bone);
 			return bone;
 		}
 		logger::warn("Node named {} doesn't exist, skipped, no bone created", bodyName.c_str());
@@ -691,11 +727,13 @@ namespace hdt
 				auto boneData = &skinData->boneData[boneIdx];
 				auto boundingSphere = BoundingSphere(convertNi(boneData->bound.center), boneData->bound.radius);
 				const RE::BSFixedString& boneName = node->name;
-				auto bone = m_mesh->findBone(boneName);
+				auto bone = static_cast<SkinnedMeshBone*>(findBoneFromIndex(boneName));
 				if (!bone) {
 					auto defaultBoneInfo = getBoneTemplate("");
-					bone = new SkyrimBone(boneName, node->AsNode(), this->m_skeleton, defaultBoneInfo);
-					m_mesh->m_bones.push_back(hdt::make_smart(bone));
+					auto newBone = new SkyrimBone(boneName, node->AsNode(), this->m_skeleton, defaultBoneInfo);
+					m_mesh->m_bones.push_back(hdt::make_smart(newBone));
+					indexBone(newBone);
+					bone = newBone;
 					logger::info("Created bone {} added to body {}, created without default values", boneName.c_str(), name);
 				}
 
@@ -747,11 +785,24 @@ namespace hdt
 
 				SkyrimSystem::BoneData* boneData = reinterpret_cast<SkyrimSystem::BoneData*>(&vertexBlock[j * vSize + boneOffset]);
 
+#if defined(__AVX2__) || defined(__AVX512F__)
+				// batch convert all 4 bone weights FP16 to FP32 through F16C hardware instruction
+				__m128i halfWeights = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(boneData->boneWeights));
+				_mm_storeu_ps(body->m_vertices[j + vertexStart].m_weight, _mm_cvtph_ps(halfWeights));
+				// cleanse garbage NIF data for unused bones
+				for (int k = partition->bonesPerVertex; k < 4; ++k) {
+					body->m_vertices[j + vertexStart].m_weight[k] = 0.0f;
+				}
+#else
+				for (int k = 0; k < partition->bonesPerVertex && k < 4; ++k) {
+					__float32(&body->m_vertices[j + vertexStart].m_weight[k], boneData->boneWeights[k]);
+				}
+#endif
+
 				for (int k = 0; k < partition->bonesPerVertex && k < 4; ++k) {
 					auto localBoneIndex = boneData->boneIndices[k];
 					assert(localBoneIndex < body->m_skinnedBones.size());
 					body->m_vertices[j + vertexStart].m_boneIdx[k] = localBoneIndex + boneStart;
-					float32(&body->m_vertices[j + vertexStart].m_weight[k], boneData->boneWeights[k]);
 				}
 			}
 
@@ -844,8 +895,7 @@ namespace hdt
 			}
 		}
 
-		shape->autoGen();
-		body->finishBuild();
+		m_deferredBuilds.push_back({ body.get(), shape.get() });
 
 		return body;
 	}
@@ -942,7 +992,7 @@ namespace hdt
 			}
 		}
 
-		body->finishBuild();
+		m_deferredBuilds.push_back({ body.get(), nullptr });
 
 		return body;
 	}
@@ -1072,8 +1122,8 @@ namespace hdt
 
 	bool SkyrimSystemCreator::findBones(const RE::BSFixedString& bodyAName, const RE::BSFixedString& bodyBName, SkyrimBone*& bodyA, SkyrimBone*& bodyB)
 	{
-		bodyA = static_cast<SkyrimBone*>(m_mesh->findBone(bodyAName));
-		bodyB = static_cast<SkyrimBone*>(m_mesh->findBone(bodyBName));
+		bodyA = findBoneFromIndex(bodyAName);
+		bodyB = findBoneFromIndex(bodyBName);
 
 		if (!bodyA) {
 			logger::warn("constraint {} <-> {} : bone for bodyA doesn't exist, will try to create it", bodyAName.c_str(), bodyBName.c_str());

--- a/src/hdtSkyrimSystem.h
+++ b/src/hdtSkyrimSystem.h
@@ -11,7 +11,7 @@
 
 namespace hdt
 {
-	class PerVertexShape; 
+	class PerVertexShape;
 	class SkyrimSystem : public SkinnedMeshSystem
 	{
 		friend class SkyrimSystemCreator;

--- a/src/hdtSkyrimSystem.h
+++ b/src/hdtSkyrimSystem.h
@@ -11,6 +11,7 @@
 
 namespace hdt
 {
+	class PerVertexShape; 
 	class SkyrimSystem : public SkinnedMeshSystem
 	{
 		friend class SkyrimSystemCreator;
@@ -52,6 +53,30 @@ namespace hdt
 		RE::BSTSmartPointer<SkyrimSystem> createOrUpdateSystem(RE::NiNode* skeleton, RE::NiAVObject* model, DefaultBBP::PhysicsFile_t* file, std::unordered_map<RE::BSFixedString, RE::BSFixedString>&& renameMap, SkyrimSystem* old_system);
 
 	protected:
+		// O(1) bone lookup index. These are just to speed up the hashmap more since BSStrings are pooled
+		struct PooledStringHash
+		{
+			size_t operator()(const char* p) const noexcept { return reinterpret_cast<size_t>(p); }
+		};
+
+		struct PooledStringEqual
+		{
+			bool operator()(const char* a, const char* b) const noexcept { return a == b; }
+		};
+
+		std::unordered_map<const char*, SkyrimBone*, PooledStringHash, PooledStringEqual> m_boneIndex;
+
+		void indexBone(SkyrimBone* bone);
+		SkyrimBone* findBoneFromIndex(const RE::BSFixedString& name) const;
+
+		struct DeferredBuild
+		{
+			SkinnedMeshBody* body;
+			PerVertexShape* vertexShape;
+		};
+
+		std::vector<DeferredBuild> m_deferredBuilds;
+
 		struct BoneTemplate : public btRigidBody::btRigidBodyConstructionInfo
 		{
 			static btEmptyShape emptyShape[1];


### PR DESCRIPTION
Significantly optimizes SkyrimSystemCreator::createOrUpdateSystem by around 2-4x depending on the complexity. This makes it a lot less annoying to select hairs in racemenu and speeds up game loads a bit. Should help a ton with the papyrus API too since they can dynamically swap out physics which calls this function in the process too. 

Key Changes:
- O(1) Bone Lookups: Replaced slow linear searches with a fast hash map utilizing Skyrim's pooled string pointers.
 - Zero-Allocation Triangles: Removed the spammy heap allocations in the addTriangles. Was taking up a significant amount of time for no reason
- Parallel Shape Builds: Deferred collision shape generation to run concurrently across multiple threads (parallel_for_each).
 - AVX2+ Weight Conversion: Added F16C hardware instructions to batch-convert NIF bone weights in a single CPU cycle 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized collider insertion and bone indexing mechanisms for improved physics simulation performance
  * Enhanced bone lookup efficiency to reduce calculation overhead
  * Streamlined shape building process during system initialization for faster load times

<!-- end of auto-generated comment: release notes by coderabbit.ai -->