### PR TITLE
fix: Fix logging, remove unused imports

### DIFF
--- a/src/PCH.h
+++ b/src/PCH.h
@@ -12,12 +12,7 @@
 #endif
 #pragma warning(pop)
 
-//
 #include <algorithm>
-#include <amp.h>
-#include <amp_graphics.h>
-#include <amp_math.h>
-#include <amp_short_vectors.h>
 #include <atomic>
 #include <cinttypes>
 #include <clocale>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -72,6 +72,7 @@ namespace hdt
 					// Inverted so: 0 = critical, 1 = err, 2 = warn, 3 = info, 4 = debug, 5 = trace.
 					g_logLevel = 5 - std::clamp(reader.readInt(), 0, 5);
 					spdlog::set_level(static_cast<spdlog::level::level_enum>(g_logLevel));
+					spdlog::flush_on(static_cast<spdlog::level::level_enum>(g_logLevel));
 				} else if (reader.GetLocalName() == "backupNodeByName") {
 					// Parse the string return value from reader.readText(); so we can have single strings instead of the group, example text -> "Virtual Hands, Virtual Body, Virtual Belly"... said text in a array like so -> { "Virtual Hands", "Virtual Body", "Virtual Belly"
 

--- a/src/hdtSkinnedMesh/hdtBulletHelper.h
+++ b/src/hdtSkinnedMesh/hdtBulletHelper.h
@@ -113,15 +113,14 @@ namespace hdt
 		return _mm_cvtss_f32(_mm_andnot_ps(_mm_set_ss(-0.f), _mm_set_ss(rhs)));
 	}
 
-	// Todo: Do we even need the amp library?
 	template <class T>
-	T min(const T& a, const T& b) restrict(cpu, amp)
+	T min(const T& a, const T& b)
 	{
 		return a < b ? a : b;
 	}
 
 	template <class T>
-	T max(const T& a, const T& b) restrict(cpu, amp)
+	T max(const T& a, const T& b)
 	{
 		return a < b ? b : a;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -402,16 +402,15 @@ namespace
 		*path /= fmt::format("{}.log"sv, Plugin::NAME);
 		auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(path->string(), true);
 #endif
-		//
+
 		const auto level = static_cast<spdlog::level::level_enum>(hdt::g_logLevel);
 
-		//
 		auto log = std::make_shared<spdlog::logger>("global log"s, std::move(sink));
 		log->set_level(level);
 		log->flush_on(level);
 
 		spdlog::set_default_logger(std::move(log));
-		spdlog::set_pattern("%g(%#): [%^%l%$] %v"s);
+		spdlog::set_pattern("[%H:%M:%S.%e] [%L] %v"s);
 	}
 }
 
@@ -503,17 +502,16 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 	}
 #endif
 
-	//
-	hdt::loadConfig();
-	//
-	InitializeLog();
-
 	SKSE::Init(a_skse);
 
+	hdt::loadConfig();
+
+	InitializeLog();
+
 	if constexpr (Plugin::BUILD_INFO.empty()) {
-		logger::info("{} v{} ({})"sv, Plugin::NAME, Plugin::VERSION.string(), Plugin::AVX_VARIANT);
+		logger::critical("{} v{} ({})"sv, Plugin::NAME, Plugin::VERSION.string(), Plugin::AVX_VARIANT);
 	} else {
-		logger::info("{} v{}-{} ({})"sv, Plugin::NAME, Plugin::VERSION.string(), Plugin::BUILD_INFO, Plugin::AVX_VARIANT);
+		logger::critical("{} v{}-{} ({})"sv, Plugin::NAME, Plugin::VERSION.string(), Plugin::BUILD_INFO, Plugin::AVX_VARIANT);
 	}
 
 	hdt::logConfig();


### PR DESCRIPTION
Our logging was being overwritten by skse. 

Also I changed the logging format to:
[15:06:55.522] [D] ...success
[15:06:55.522] [T] ...success


We don't use those amp imports. I assume they were added way back when OpenCL support was attempted? 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Log output now displays timestamps for improved traceability.

* **Bug Fixes**
  * Enhanced logging reliability with improved flushing behavior.

* **Refactor**
  * Removed deprecated dependencies.
  * Streamlined utility function declarations.
  * Optimized initialization sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->