### PR TITLE
fix: smp off bug corrected

### DIFF
--- a/src/hdtSkyrimPhysicsWorld.cpp
+++ b/src/hdtSkyrimPhysicsWorld.cpp
@@ -144,6 +144,7 @@ namespace hdt
 		stepSimulation(remainingTimeStep, 0, tick);
 		restoreTranslationOffset(offset);
 		m_accumulatedInterval = 0;
+		m_pendingTransformUpdate = true;
 
 		g_pluginInterface.onPostStep({ getCollisionObjectArray(), remainingTimeStep });
 
@@ -368,9 +369,10 @@ namespace hdt
 			QueryPerformanceCounter(&ticks);
 			int64_t t1 = ticks.QuadPart;
 
-			{
+			if (m_pendingTransformUpdate) {
 				std::lock_guard<decltype(m_lock)> l(m_lock);
 				writeTransform();
+				m_pendingTransformUpdate = false;
 			}
 
 			QueryPerformanceCounter(&ticks);
@@ -413,9 +415,10 @@ namespace hdt
 				avgTotalCpuWork);
 		} else {
 			m_tasks.wait();
-			{
+			if (m_pendingTransformUpdate) {
 				std::lock_guard<decltype(m_lock)> l(m_lock);
 				writeTransform();
+				m_pendingTransformUpdate = false;
 			}
 		}
 

--- a/src/hdtSkyrimPhysicsWorld.h
+++ b/src/hdtSkyrimPhysicsWorld.h
@@ -68,6 +68,7 @@ namespace hdt
 
 		concurrency::task_group m_tasks;
 
+		bool m_pendingTransformUpdate = false;
 		bool m_useRealTime = false;
 		int min_fps = 60;
 		float m_budgetMs = 3.5f;


### PR DESCRIPTION
Fixes "smp off" translating the bones while physics is disabled. 

Could of just checked the disabled bool, but this implements the same behavior as 2.5.1 and avoids other issues like writing transforms when we never readTransforms. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized physics transform updates to apply conditionally based on pending status, improving efficiency of the simulation cycle. Transform writes now occur only when necessary rather than unconditionally during each sync operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->