### PR TITLE
fix: Do not allow kinematic objects to solve

### DIFF
--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -289,7 +289,7 @@ namespace hdt
 			return;
 
 		// Kinematic objects should never be able to collide, or move. Because: They're kinematic?
-		// This avoids broken configs, API misuse - etc. Better to check it every cycle for saftey
+		// This avoids broken configs, API misuse - etc. Better to check it every cycle for safety
 		for (int i = 0; i < m_constraints.size(); i++) {
 			btTypedConstraint* constraint = m_constraints[i];
 			if (constraint->isEnabled()) {

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -295,7 +295,7 @@ namespace hdt
 			if (constraint->isEnabled()) {
 				if (constraint->getRigidBodyA().isStaticOrKinematicObject() &&
 					constraint->getRigidBodyB().isStaticOrKinematicObject()) {
-					constraint->setEnabled(false); 
+					constraint->setEnabled(false);
 				}
 			}
 		}

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -288,6 +288,18 @@ namespace hdt
 		if (!m_collisionObjects.size())
 			return;
 
+		// Kinematic objects should never be able to collide, or move. Because: They're kinematic?
+		// This avoids broken configs, API misuse - etc. Better to check it every cycle for saftey
+		for (int i = 0; i < m_constraints.size(); i++) {
+			btTypedConstraint* constraint = m_constraints[i];
+			if (constraint->isEnabled()) {
+				if (constraint->getRigidBodyA().isStaticOrKinematicObject() &&
+					constraint->getRigidBodyB().isStaticOrKinematicObject()) {
+					constraint->setEnabled(false); 
+				}
+			}
+		}
+
 		btDiscreteDynamicsWorldMt::solveConstraints(solverInfo);
 
 		// the HDT manifolds are still recreated every frame, clear to prevent stale data.


### PR DESCRIPTION
There's some broken configs out there or just weird API use that results in fully kinematic constraints running through the solver. This can lead to race issues/ctd due to improper island dispatching, and just redundant work. 

It's a really cheap check, so might as well run every tick cycle rather than just when adding. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Physics solver now automatically disables constraints connecting two non-dynamic (static or kinematic) bodies, reducing unnecessary work during simulation and improving performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->