### PR TITLE
feat: Add two new functions to the papyrus API + thread saftey 

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -1120,35 +1120,53 @@ namespace hdt
 	// Reload meshes without entirely wiping their physics
 	void ActorManager::Skeleton::softReloadMeshes()
 	{
-		for (auto& i : armors) {
-			RE::BSTSmartPointer<SkyrimSystem> oldSystem = i.m_physics;
+		auto reloadPhysicsItem = [&](auto& item, RE::NiAVObject* model, const auto& renameMapSrc, bool itemActive) {
+			RE::BSTSmartPointer<SkyrimSystem> oldSystem = item.m_physics;
+			item.clearPhysics();
 
-			i.clearPhysics();
+			if (!model || isFirstPersonSkeleton(skeleton.get()) || item.physicsFile.first.empty()) {
+				return;
+			}
 
-			if (!isFirstPersonSkeleton(skeleton.get())) {
-				auto renameMap = i.renameMap;
-				auto system = SkyrimSystemCreator().createOrUpdateSystem(
-					npc.get(),
-					i.armorWorn.get(),
-					&i.physicsFile,
-					std::move(renameMap),
-					oldSystem.get());
+			auto renameMap = renameMapSrc;
+			auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), model, &item.physicsFile, std::move(renameMap), nullptr);
 
-				if (system) {
-					system->block_resetting = true;
-
-					if (oldSystem) {
-						hdt::util::transferCurrentPosesBetweenSystems(
-							oldSystem.get(), system.get());
-					}
-
-					i.setPhysics(system, isActive);
-					hasPhysics = true;
-					system->block_resetting = false;
+			if (system) {
+				system->block_resetting = true;
+				if (oldSystem) {
+					hdt::util::transferCurrentPosesBetweenSystems(oldSystem.get(), system.get());
 				}
+
+				item.setPhysics(system, itemActive);
+				hasPhysics = true;
+				system->block_resetting = false;
+			}
+		};
+
+		for (auto& armor : armors) {
+			reloadPhysicsItem(armor, armor.armorWorn.get(), armor.renameMap, isActive);
+		}
+
+		if (isFirstPersonSkeleton(skeleton.get()) || !head.headNode) {
+			return;
+		}
+
+		if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
+			if (auto actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID)) {
+				setHeadActiveIfNoHairArmor(actor, this);
 			}
 		}
-		scanHead();
+
+		std::unordered_set<std::string> physicsDupes;
+		for (auto& headPart : head.headParts) {
+			// Skip duplicate physics files, but ensure we clear their old physics
+			if (!headPart.physicsFile.first.empty() && !physicsDupes.insert(headPart.physicsFile.first).second) {
+				headPart.clearPhysics();
+				continue;
+			}
+
+			reloadPhysicsItem(headPart, head.headNode.get(), head.renameMap, isActive && head.isActive);
+		}
 	}
 
 	void ActorManager::Skeleton::scanHead()

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -1132,7 +1132,7 @@ namespace hdt
 					i.armorWorn.get(),
 					&i.physicsFile,
 					std::move(renameMap),
-					oldSystem.get()); 
+					oldSystem.get());
 
 				if (system) {
 					system->block_resetting = true;

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -1117,6 +1117,40 @@ namespace hdt
 		scanHead();
 	}
 
+	// Reload meshes without entirely wiping their physics
+	void ActorManager::Skeleton::softReloadMeshes()
+	{
+		for (auto& i : armors) {
+			RE::BSTSmartPointer<SkyrimSystem> oldSystem = i.m_physics;
+
+			i.clearPhysics();
+
+			if (!isFirstPersonSkeleton(skeleton.get())) {
+				auto renameMap = i.renameMap;
+				auto system = SkyrimSystemCreator().createOrUpdateSystem(
+					npc.get(),
+					i.armorWorn.get(),
+					&i.physicsFile,
+					std::move(renameMap),
+					oldSystem.get()); 
+
+				if (system) {
+					system->block_resetting = true;
+
+					if (oldSystem) {
+						hdt::util::transferCurrentPosesBetweenSystems(
+							oldSystem.get(), system.get());
+					}
+
+					i.setPhysics(system, isActive);
+					hasPhysics = true;
+					system->block_resetting = false;
+				}
+			}
+		}
+		scanHead();
+	}
+
 	void ActorManager::Skeleton::scanHead()
 	{
 		if (isFirstPersonSkeleton(this->skeleton.get())) {

--- a/src/ActorManager.h
+++ b/src/ActorManager.h
@@ -229,6 +229,7 @@ namespace hdt
 
 		bool skeletonNeedsParts(RE::NiNode* skeleton);
 		std::vector<Skeleton>& getSkeletons();  //Altered by Dynamic HDT
+		std::unique_lock<std::recursive_mutex> lockGuard() { return std::unique_lock(m_lock); }
 
 		bool m_skinNPCFaceParts = true;
 		bool m_disableSMPHairWhenWigEquipped = false;

--- a/src/ActorManager.h
+++ b/src/ActorManager.h
@@ -143,6 +143,7 @@ namespace hdt
 
 			// bool deactivate(); // FIXME useless?
 			void reloadMeshes();
+			void softReloadMeshes();
 
 			void scanHead();
 			void processGeometry(RE::BSFaceGenNiNode* head, RE::BSGeometry* geometry);

--- a/src/dhdtPapyrusFunctions.cpp
+++ b/src/dhdtPapyrusFunctions.cpp
@@ -148,7 +148,12 @@ void hdt::papyrus::ResetPhysics(RE::StaticFunctionTag*, RE::Actor* actor, bool f
 	if (!actor) {
 		return;
 	}
-	impl::ResetPhysicsImpl(actor, full);
+
+	SKSE::GetTaskInterface()->AddTask([handle = RE::ActorHandle(actor), full] {
+		if (auto a = handle.get()) {
+			impl::ResetPhysicsImpl(a.get(), full);
+		}
+	});
 }
 
 void hdt::papyrus::impl::ResetPhysicsImpl(RE::Actor* actor, bool full)

--- a/src/dhdtPapyrusFunctions.cpp
+++ b/src/dhdtPapyrusFunctions.cpp
@@ -273,7 +273,7 @@ bool hdt::papyrus::impl::ReloadPhysicsFileImpl(uint32_t on_actor_formID, uint32_
 					bool wasActive = (armor.state() == hdt::ActorManager::ItemState::e_Active);
 					RE::BSTSmartPointer<SkyrimSystem> oldSystem = armor.m_physics;
 
-					// Gotta detach it from Bullet to safetly transferCurrentPosesBetweenSystems
+					// Gotta detach it from Bullet to safely transferCurrentPosesBetweenSystems
 					if (armor.hasPhysics()) {
 						armor.clearPhysics();
 					}
@@ -380,7 +380,7 @@ bool hdt::papyrus::impl::SwapPhysicsFileImpl(uint32_t on_actor_formID, std::stri
 					bool wasActive = (armor.state() == hdt::ActorManager::ItemState::e_Active);
 					RE::BSTSmartPointer<SkyrimSystem> oldSystem = armor.m_physics;
 
-					// Gotta detach it from Bullet to safetly transferCurrentPosesBetweenSystems
+					// Gotta detach it from Bullet to safely transferCurrentPosesBetweenSystems
 					if (armor.hasPhysics()) {
 						armor.clearPhysics();
 					}

--- a/src/dhdtPapyrusFunctions.cpp
+++ b/src/dhdtPapyrusFunctions.cpp
@@ -8,7 +8,8 @@ bool RegisterFuncs(RE::BSScript::IVirtualMachine* registry)
 	registry->RegisterFunction("ReloadPhysicsFile", "DynamicHDT", hdt::papyrus::ReloadPhysicsFile);
 	registry->RegisterFunction("SwapPhysicsFile", "DynamicHDT", hdt::papyrus::SwapPhysicsFile);
 	registry->RegisterFunction("QueryCurrentPhysicsFile", "DynamicHDT", hdt::papyrus::QueryCurrentPhysicsFile);
-
+	registry->RegisterFunction("TogglePhysics", "DynamicHDT", hdt::papyrus::TogglePhysics);
+	registry->RegisterFunction("ResetPhysics", "DynamicHDT", hdt::papyrus::ResetPhysics);
 	//
 	return true;
 }
@@ -56,6 +57,106 @@ RE::BSFixedString hdt::papyrus::QueryCurrentPhysicsFile(RE::StaticFunctionTag*, 
 	}
 
 	return impl::QueryCurrentPhysicsFileImpl(on_actor->formID, on_item->formID, verbose_log).c_str();
+}
+
+std::vector<bool> hdt::papyrus::TogglePhysics(RE::StaticFunctionTag*, RE::Actor* actor, std::vector<RE::BSFixedString> boneNames, bool on)
+{
+	if (!actor || boneNames.empty()) {
+		return std::vector<bool>();
+	}
+	return impl::TogglePhysicsImpl(actor, boneNames, on);
+}
+
+std::vector<bool> hdt::papyrus::impl::TogglePhysicsImpl(RE::Actor* actor, std::vector<RE::BSFixedString>& boneNames, bool on)
+{
+	std::vector<bool> result(boneNames.size(), false);
+
+	const auto AM = hdt::ActorManager::instance();
+	auto& skeletons = AM->getSkeletons();
+
+	for (auto& skeleton : skeletons) {
+		if (!skeleton.skeleton) {
+			continue;
+		}
+		auto owner = skeleton.skeleton->GetUserData();
+		if (!owner || owner->formID != actor->formID) {
+			continue;
+		}
+
+		hdt::SkyrimPhysicsWorld::get()->suspendSimulationUntilFinished([&]() {
+			for (size_t i = 0; i < boneNames.size(); ++i) {
+				bool foundAny = false;
+
+				auto processBone = [&](SkinnedMeshBone* bone) {
+					if (!bone)
+						return;
+
+					// Record previous state on first find for this bone name
+					if (!foundAny) {
+						result[i] = !bone->m_rig.isStaticOrKinematicObject();
+						foundAny = true;
+					}
+
+					if (on) {
+						bone->m_rig.setCollisionFlags(bone->m_rig.getCollisionFlags() & ~btCollisionObject::CF_KINEMATIC_OBJECT);
+					} else {
+						bone->m_rig.setCollisionFlags(bone->m_rig.getCollisionFlags() | btCollisionObject::CF_KINEMATIC_OBJECT);
+					}
+
+					bone->m_rig.setLinearVelocity(btVector3(0, 0, 0));
+					bone->m_rig.setAngularVelocity(btVector3(0, 0, 0));
+				};
+
+				for (auto& armor : skeleton.getArmors()) {
+					if (!armor.m_physics)
+						continue;
+					processBone(armor.m_physics->findBone(boneNames[i]));
+				}
+
+				for (auto& headPart : skeleton.head.headParts) {
+					if (!headPart.m_physics)
+						continue;
+					processBone(headPart.m_physics->findBone(boneNames[i]));
+				}
+			}
+		});
+	}
+
+	return result;
+}
+
+void hdt::papyrus::ResetPhysics(RE::StaticFunctionTag*, RE::Actor* actor, bool full)
+{
+	if (!actor) {
+		return;
+	}
+	impl::ResetPhysicsImpl(actor, full);
+}
+
+void hdt::papyrus::impl::ResetPhysicsImpl(RE::Actor* actor, bool full)
+{
+	const auto AM = hdt::ActorManager::instance();
+	auto& skeletons = AM->getSkeletons();
+
+	for (auto& skeleton : skeletons) {
+		if (!skeleton.skeleton) {
+			continue;
+		}
+		auto owner = skeleton.skeleton->GetUserData();
+		if (!owner || owner->formID != actor->formID) {
+			continue;
+		}
+
+		hdt::SkyrimPhysicsWorld::get()->suspendSimulationUntilFinished([&]() {
+			if (full) {
+				skeleton.reloadMeshes();
+			} else {
+				skeleton.softReloadMeshes();
+			}
+		});
+
+		break;
+	}
 }
 
 //

--- a/src/dhdtPapyrusFunctions.cpp
+++ b/src/dhdtPapyrusFunctions.cpp
@@ -79,6 +79,7 @@ std::vector<bool> hdt::papyrus::impl::TogglePhysicsImpl(RE::Actor* actor, std::v
 		if (!skeleton.skeleton) {
 			continue;
 		}
+
 		auto owner = skeleton.skeleton->GetUserData();
 		if (!owner || owner->formID != actor->formID) {
 			continue;
@@ -94,34 +95,46 @@ std::vector<bool> hdt::papyrus::impl::TogglePhysicsImpl(RE::Actor* actor, std::v
 					if (!bone)
 						return;
 
-					if (!foundAny) {
-						result[i] = !bone->m_rig.isStaticOrKinematicObject();
-						foundAny = true;
+					const bool currentlyDynamic = !bone->m_rig.isStaticOrKinematicObject();
+
+					if (!std::exchange(foundAny, true)) {
+						result[i] = currentlyDynamic;
 					}
 
-					if (on) {
-						bone->m_rig.setCollisionFlags(bone->m_rig.getCollisionFlags() & ~btCollisionObject::CF_KINEMATIC_OBJECT);
-					} else {
-						bone->m_rig.setCollisionFlags(bone->m_rig.getCollisionFlags() | btCollisionObject::CF_KINEMATIC_OBJECT);
+					// Early out: Already in desired state, OR trying to make a 0 mass bone dynamic
+					if (currentlyDynamic == on || (on && bone->m_rig.getInvMass() <= 0.0f)) {
+						return;
 					}
 
-					bone->m_rig.setLinearVelocity(btVector3(0, 0, 0));
-					bone->m_rig.setAngularVelocity(btVector3(0, 0, 0));
+					// Toggle the kinematic flag on/off
+					// Note: Because we don't use CF_STATIC_OBJECT, we can get away with this without removing/re-adding the object.
+					// Static objects receive very different treatment in Bullet!
+					const auto flags = bone->m_rig.getCollisionFlags();
+					bone->m_rig.setCollisionFlags(on ? (flags & ~btCollisionObject::CF_KINEMATIC_OBJECT) : (flags | btCollisionObject::CF_KINEMATIC_OBJECT));
+
+					// Wipe velocities/forces so the bone doesn't jump or explode when toggled
+					static const btVector3 zero(0, 0, 0);
+					bone->m_rig.clearForces();
+					bone->m_rig.setLinearVelocity(zero);
+					bone->m_rig.setAngularVelocity(zero);
+					bone->m_rig.setInterpolationLinearVelocity(zero);
+					bone->m_rig.setInterpolationAngularVelocity(zero);
 				};
 
 				for (auto& armor : skeleton.getArmors()) {
-					if (!armor.m_physics)
-						continue;
-					processBone(armor.m_physics->findBone(boneNames[i]));
+					if (armor.m_physics) {
+						processBone(armor.m_physics->findBone(boneNames[i]));
+					}
 				}
 
 				for (auto& headPart : skeleton.head.headParts) {
-					if (!headPart.m_physics)
-						continue;
-					processBone(headPart.m_physics->findBone(boneNames[i]));
+					if (headPart.m_physics) {
+						processBone(headPart.m_physics->findBone(boneNames[i]));
+					}
 				}
 			}
 		}
+		break;
 	}
 
 	return result;
@@ -150,13 +163,10 @@ void hdt::papyrus::impl::ResetPhysicsImpl(RE::Actor* actor, bool full)
 			continue;
 		}
 
-		{
-			auto simLock = hdt::SkyrimPhysicsWorld::get()->lockSimulation();
-			if (full) {
-				skeleton.reloadMeshes();
-			} else {
-				skeleton.softReloadMeshes();
-			}
+		if (full) {
+			skeleton.reloadMeshes();
+		} else {
+			skeleton.softReloadMeshes();
 		}
 
 		break;
@@ -257,31 +267,34 @@ bool hdt::papyrus::impl::ReloadPhysicsFileImpl(uint32_t on_actor_formID, uint32_
 						return false;
 					}
 
+					bool wasActive = (armor.state() == hdt::ActorManager::ItemState::e_Active);
+					RE::BSTSmartPointer<SkyrimSystem> oldSystem = armor.m_physics;
+
+					// Gotta detach it from Bullet to safetly transferCurrentPosesBetweenSystems
+					if (armor.hasPhysics()) {
+						armor.clearPhysics();
+					}
+
+					auto renameMap = armor.renameMap;
+
 					RE::BSTSmartPointer<SkyrimSystem> system;
 
-					{
-						auto simLock = hdt::SkyrimPhysicsWorld::get()->lockSimulation();
-						system = SkyrimSystemCreator().createOrUpdateSystem(skeleton.npc.get(), armor.armorWorn.get(), &armor.physicsFile, std::move(armor.renameMap), armor.m_physics.get());
+					system = SkyrimSystemCreator().createOrUpdateSystem(skeleton.npc.get(), armor.armorWorn.get(), &armor.physicsFile, std::move(renameMap), oldSystem.get());
 
-						if (!system) {
-							if (armor.hasPhysics()) {
-								armor.clearPhysics();
-							}
-						} else {
-							system->block_resetting = true;
+					if (system) {
+						system->block_resetting = true;
 
-							if (armor.hasPhysics()) {
-								util::transferCurrentPosesBetweenSystems(armor.m_physics.get(), system.get());
-							}
-
-							armor.setPhysics(system, true);
-
-							system->block_resetting = false;
+						if (oldSystem) {
+							util::transferCurrentPosesBetweenSystems(oldSystem.get(), system.get());
 						}
+
+						armor.setPhysics(system, wasActive);
+
+						system->block_resetting = false;
 					}
 
 					if (verbose_log) {
-						RE::ConsoleLog::GetSingleton()->Print("[DynamicHDT] -- Physics file path switched, now is: \"{}\".", armor.physicsFile.first.c_str());
+						RE::ConsoleLog::GetSingleton()->Print("[DynamicHDT] -- Physics file path switched, now is: \"%s\".", armor.physicsFile.first.c_str());
 					}
 
 					succeeded = true;
@@ -290,14 +303,13 @@ bool hdt::papyrus::impl::ReloadPhysicsFileImpl(uint32_t on_actor_formID, uint32_
 		}
 	}
 
-	//Push into global override data
 	if (persist) {
 		auto OM = Override::OverrideManager::GetSingleton();
 		OM->registerOverride(on_actor_formID, old_physics_file_path, std::string(physics_file_path));
 	}
 
 	if (verbose_log) {
-		RE::ConsoleLog::GetSingleton()->Print("[DynamicHDT] -- Character (%08X) {}, ArmorAddon (%08X) {}.", on_actor_formID, character_found ? "found" : "not found", on_item_formID, armor_addon_found ? "found" : "not found");
+		RE::ConsoleLog::GetSingleton()->Print("[DynamicHDT] -- Character (%08X) %s, ArmorAddon (%08X) %s.", on_actor_formID, character_found ? "found" : "not found", on_item_formID, armor_addon_found ? "found" : "not found");
 	}
 
 	if (verbose_log && succeeded) {
@@ -362,30 +374,26 @@ bool hdt::papyrus::impl::SwapPhysicsFileImpl(uint32_t on_actor_formID, std::stri
 						return false;
 					}
 
-					RE::BSTSmartPointer<SkyrimSystem> system;
+					bool wasActive = (armor.state() == hdt::ActorManager::ItemState::e_Active);
+					RE::BSTSmartPointer<SkyrimSystem> oldSystem = armor.m_physics;
 
-					{
-						auto simLock = SkyrimPhysicsWorld::get()->lockSimulation();
-						system = SkyrimSystemCreator().createOrUpdateSystem(skeleton.npc.get(), armor.armorWorn.get(), &armor.physicsFile, std::move(armor.renameMap), armor.m_physics.get());
-
-						if (!system) {
-							if (armor.hasPhysics()) {
-								armor.clearPhysics();
-							}
-						} else {
-							system->block_resetting = true;
-
-							if (armor.hasPhysics()) {
-								util::transferCurrentPosesBetweenSystems(armor.m_physics.get(), system.get());
-							}
-
-							armor.setPhysics(system, true);
-							system->block_resetting = false;
-						}
+					// Gotta detach it from Bullet to safetly transferCurrentPosesBetweenSystems
+					if (armor.hasPhysics()) {
+						armor.clearPhysics();
 					}
 
-					if (verbose_log) {
-						RE::ConsoleLog::GetSingleton()->Print("[DynamicHDT] -- Physics file path switched, now is: \"{}\".", armor.physicsFile.first.c_str());
+					auto renameMap = armor.renameMap;
+					RE::BSTSmartPointer<SkyrimSystem> system = SkyrimSystemCreator().createOrUpdateSystem(skeleton.npc.get(), armor.armorWorn.get(), &armor.physicsFile, std::move(renameMap), oldSystem.get());
+
+					if (system) {
+						system->block_resetting = true;
+
+						if (oldSystem) {
+							util::transferCurrentPosesBetweenSystems(oldSystem.get(), system.get());
+						}
+
+						armor.setPhysics(system, wasActive);
+						system->block_resetting = false;
 					}
 
 					succeeded = true;

--- a/src/dhdtPapyrusFunctions.cpp
+++ b/src/dhdtPapyrusFunctions.cpp
@@ -86,7 +86,8 @@ std::vector<bool> hdt::papyrus::impl::TogglePhysicsImpl(RE::Actor* actor, std::v
 		}
 
 		{
-			auto simLock = hdt::SkyrimPhysicsWorld::get()->lockSimulation();
+			auto world = hdt::SkyrimPhysicsWorld::get();
+			auto simLock = world->lockSimulation();
 
 			for (size_t i = 0; i < boneNames.size(); ++i) {
 				bool foundAny = false;
@@ -119,6 +120,8 @@ std::vector<bool> hdt::papyrus::impl::TogglePhysicsImpl(RE::Actor* actor, std::v
 					bone->m_rig.setAngularVelocity(zero);
 					bone->m_rig.setInterpolationLinearVelocity(zero);
 					bone->m_rig.setInterpolationAngularVelocity(zero);
+
+					world->updateConstraintsForBone(bone);
 				};
 
 				for (auto& armor : skeleton.getArmors()) {

--- a/src/dhdtPapyrusFunctions.cpp
+++ b/src/dhdtPapyrusFunctions.cpp
@@ -72,6 +72,7 @@ std::vector<bool> hdt::papyrus::impl::TogglePhysicsImpl(RE::Actor* actor, std::v
 	std::vector<bool> result(boneNames.size(), false);
 
 	const auto AM = hdt::ActorManager::instance();
+	auto guard = AM->lockGuard();
 	auto& skeletons = AM->getSkeletons();
 
 	for (auto& skeleton : skeletons) {
@@ -83,7 +84,9 @@ std::vector<bool> hdt::papyrus::impl::TogglePhysicsImpl(RE::Actor* actor, std::v
 			continue;
 		}
 
-		hdt::SkyrimPhysicsWorld::get()->suspendSimulationUntilFinished([&]() {
+		{
+			auto simLock = hdt::SkyrimPhysicsWorld::get()->lockSimulation();
+
 			for (size_t i = 0; i < boneNames.size(); ++i) {
 				bool foundAny = false;
 
@@ -91,7 +94,6 @@ std::vector<bool> hdt::papyrus::impl::TogglePhysicsImpl(RE::Actor* actor, std::v
 					if (!bone)
 						return;
 
-					// Record previous state on first find for this bone name
 					if (!foundAny) {
 						result[i] = !bone->m_rig.isStaticOrKinematicObject();
 						foundAny = true;
@@ -119,7 +121,7 @@ std::vector<bool> hdt::papyrus::impl::TogglePhysicsImpl(RE::Actor* actor, std::v
 					processBone(headPart.m_physics->findBone(boneNames[i]));
 				}
 			}
-		});
+		}
 	}
 
 	return result;
@@ -136,6 +138,7 @@ void hdt::papyrus::ResetPhysics(RE::StaticFunctionTag*, RE::Actor* actor, bool f
 void hdt::papyrus::impl::ResetPhysicsImpl(RE::Actor* actor, bool full)
 {
 	const auto AM = hdt::ActorManager::instance();
+	auto guard = AM->lockGuard();
 	auto& skeletons = AM->getSkeletons();
 
 	for (auto& skeleton : skeletons) {
@@ -147,13 +150,14 @@ void hdt::papyrus::impl::ResetPhysicsImpl(RE::Actor* actor, bool full)
 			continue;
 		}
 
-		hdt::SkyrimPhysicsWorld::get()->suspendSimulationUntilFinished([&]() {
+		{
+			auto simLock = hdt::SkyrimPhysicsWorld::get()->lockSimulation();
 			if (full) {
 				skeleton.reloadMeshes();
 			} else {
 				skeleton.softReloadMeshes();
 			}
-		});
+		}
 
 		break;
 	}
@@ -194,6 +198,7 @@ bool hdt::papyrus::impl::ReloadPhysicsFileImpl(uint32_t on_actor_formID, uint32_
 {
 	const auto& AM = hdt::ActorManager::instance();
 
+	auto guard = AM->lockGuard();
 	auto& skeletons = AM->getSkeletons();
 
 	bool character_found = false, armor_addon_found = false, succeeded = false;
@@ -254,7 +259,8 @@ bool hdt::papyrus::impl::ReloadPhysicsFileImpl(uint32_t on_actor_formID, uint32_
 
 					RE::BSTSmartPointer<SkyrimSystem> system;
 
-					hdt::SkyrimPhysicsWorld::get()->suspendSimulationUntilFinished([&]() {
+					{
+						auto simLock = hdt::SkyrimPhysicsWorld::get()->lockSimulation();
 						system = SkyrimSystemCreator().createOrUpdateSystem(skeleton.npc.get(), armor.armorWorn.get(), &armor.physicsFile, std::move(armor.renameMap), armor.m_physics.get());
 
 						if (!system) {
@@ -272,7 +278,7 @@ bool hdt::papyrus::impl::ReloadPhysicsFileImpl(uint32_t on_actor_formID, uint32_
 
 							system->block_resetting = false;
 						}
-					});
+					}
 
 					if (verbose_log) {
 						RE::ConsoleLog::GetSingleton()->Print("[DynamicHDT] -- Physics file path switched, now is: \"{}\".", armor.physicsFile.first.c_str());
@@ -305,6 +311,7 @@ bool hdt::papyrus::impl::SwapPhysicsFileImpl(uint32_t on_actor_formID, std::stri
 {
 	const auto& AM = hdt::ActorManager::instance();
 
+	auto guard = AM->lockGuard();
 	auto& skeletons = AM->getSkeletons();
 
 	bool character_found = false, armor_addon_found = false, succeeded = false;
@@ -357,7 +364,8 @@ bool hdt::papyrus::impl::SwapPhysicsFileImpl(uint32_t on_actor_formID, std::stri
 
 					RE::BSTSmartPointer<SkyrimSystem> system;
 
-					SkyrimPhysicsWorld::get()->suspendSimulationUntilFinished([&]() {
+					{
+						auto simLock = SkyrimPhysicsWorld::get()->lockSimulation();
 						system = SkyrimSystemCreator().createOrUpdateSystem(skeleton.npc.get(), armor.armorWorn.get(), &armor.physicsFile, std::move(armor.renameMap), armor.m_physics.get());
 
 						if (!system) {
@@ -374,7 +382,7 @@ bool hdt::papyrus::impl::SwapPhysicsFileImpl(uint32_t on_actor_formID, std::stri
 							armor.setPhysics(system, true);
 							system->block_resetting = false;
 						}
-					});
+					}
 
 					if (verbose_log) {
 						RE::ConsoleLog::GetSingleton()->Print("[DynamicHDT] -- Physics file path switched, now is: \"{}\".", armor.physicsFile.first.c_str());
@@ -406,6 +414,7 @@ std::string hdt::papyrus::impl::QueryCurrentPhysicsFileImpl(uint32_t on_actor_fo
 {
 	const auto& AM = hdt::ActorManager::instance();
 
+	auto guard = AM->lockGuard();
 	auto& skeletons = AM->getSkeletons();
 
 	bool character_found = false, armor_addon_found = false, succeeded = false;

--- a/src/dhdtPapyrusFunctions.h
+++ b/src/dhdtPapyrusFunctions.h
@@ -14,6 +14,17 @@ namespace hdt
 
 		RE::BSFixedString QueryCurrentPhysicsFile(RE::StaticFunctionTag* base, RE::Actor* on_actor, RE::TESObjectARMA* on_item, bool verbose_log);
 
+		// Toggle bones between kinematic and dynamic
+		// Returns array of bools, each entry is the PREVIOUS state of that bone index:
+		// - true  = bone was dynamic (physics was ON)
+		// - false = bone was kinematic (physics was OFF / not found)
+		std::vector<bool> TogglePhysics(RE::StaticFunctionTag* base, RE::Actor* actor, std::vector<RE::BSFixedString> boneNames, bool on);
+
+		// Reset an actor's SMP physics systems
+		// - full = true  -> complete reset, bones snap to reference pose
+		// - full = false -> soft reset, current bone poses are preserved
+		void ResetPhysics(RE::StaticFunctionTag* base, RE::Actor* actor, bool full);
+
 		namespace impl
 		{
 			bool ReloadPhysicsFileImpl(uint32_t on_actor_formID, uint32_t on_item_formID, std::string physics_file_path, bool persist, bool verbose_log);
@@ -21,6 +32,10 @@ namespace hdt
 			bool SwapPhysicsFileImpl(uint32_t on_actor_formID, std::string old_physics_file_path, std::string new_physics_file_path, bool persist, bool verbose_log);
 
 			std::string QueryCurrentPhysicsFileImpl(uint32_t on_actor_formID, uint32_t on_item_formID, bool verbose_log);
+
+			std::vector<bool> TogglePhysicsImpl(RE::Actor* actor, std::vector<RE::BSFixedString>& boneNames, bool on);
+
+			void ResetPhysicsImpl(RE::Actor* actor, bool full);
 		}
 
 		// uint32_t FindOrCreateAnonymousSystem(RE::StaticFunctionTag* base, RE::TESObjectARMA* system_model, bool verbose_log);

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -114,6 +114,25 @@ namespace hdt
 		system->m_world = nullptr;
 	}
 
+	void SkinnedMeshWorld::updateConstraintsForBone(SkinnedMeshBone* bone)
+	{
+		if (!bone)
+			return;
+
+		int numConstraints = int(m_constraints.size());
+		for (int i = 0; i < numConstraints; i++) {
+			btTypedConstraint* constraint = m_constraints[i];
+
+			if (&constraint->getRigidBodyA() == &bone->m_rig ||
+				&constraint->getRigidBodyB() == &bone->m_rig) {
+				bool bothKinematic = constraint->getRigidBodyA().isStaticOrKinematicObject() &&
+				                     constraint->getRigidBodyB().isStaticOrKinematicObject();
+
+				constraint->setEnabled(!bothKinematic);
+			}
+		}
+	}
+
 	int SkinnedMeshWorld::stepSimulation(btScalar remainingTimeStep, int, btScalar fixedTimeStep)
 	{
 		applyGravity();

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
@@ -16,6 +16,8 @@ namespace hdt
 		virtual void addSkinnedMeshSystem(SkinnedMeshSystem* system);
 		virtual void removeSkinnedMeshSystem(SkinnedMeshSystem* system);
 
+		void updateConstraintsForBone(SkinnedMeshBone* bone);
+
 		int stepSimulation(btScalar remainingTimeStep, int maxSubSteps = 1,
 			btScalar fixedTimeStep = btScalar(1.) / btScalar(60.)) override;
 

--- a/src/hdtSkyrimPhysicsWorld.cpp
+++ b/src/hdtSkyrimPhysicsWorld.cpp
@@ -123,7 +123,7 @@ namespace hdt
 
 	void SkyrimPhysicsWorld::doUpdate2ndStep(float, const float tick, const float remainingTimeStep)
 	{
-		if (m_suspended || m_isStasis)
+		if (m_suspended)
 			return;
 
 		std::lock_guard<decltype(m_lock)> l(m_lock);
@@ -157,11 +157,10 @@ namespace hdt
 		}
 	}
 
-	void SkyrimPhysicsWorld::suspendSimulationUntilFinished(std::function<void(void)> process)
+	std::unique_lock<std::mutex> SkyrimPhysicsWorld::lockSimulation()
 	{
-		this->m_isStasis = true;
-		process();
-		this->m_isStasis = false;
+		m_tasks.wait();
+		return std::unique_lock(m_lock);
 	}
 
 	btVector3 SkyrimPhysicsWorld::applyTranslationOffset()
@@ -339,9 +338,9 @@ namespace hdt
 
 		float interval = (m_useRealTime ? RE::BSTimer::GetSingleton()->realTimeDelta : RE::BSTimer::GetSingleton()->delta);
 
-		if (interval > FLT_EPSILON && !m_suspended && !m_isStasis && !m_systems.empty()) {
+		if (interval > FLT_EPSILON && !m_suspended && !m_systems.empty()) {
 			doUpdate(interval);
-		} else if (m_isStasis || (m_suspended && !m_loading)) {
+		} else if (m_suspended && !m_loading) {
 			writeTransform();
 		}
 

--- a/src/hdtSkyrimPhysicsWorld.h
+++ b/src/hdtSkyrimPhysicsWorld.h
@@ -26,6 +26,7 @@ namespace hdt
 		void addSkinnedMeshSystem(SkinnedMeshSystem* system) override;
 		void removeSkinnedMeshSystem(SkinnedMeshSystem* system) override;
 		void removeSystemByNode(void* root);
+		using SkinnedMeshWorld::updateConstraintsForBone;
 
 		void resetTransformsToOriginal();
 		void resetSystems();

--- a/src/hdtSkyrimPhysicsWorld.h
+++ b/src/hdtSkyrimPhysicsWorld.h
@@ -52,8 +52,9 @@ namespace hdt
 			}
 		}
 
-		void suspendSimulationUntilFinished(std::function<void(void)> process);
-		std::atomic_bool m_isStasis = false;
+		// This is used for when you want to mutate some physics objects without causing problems
+		// Bullet is VERY sensitive to changes during simulation!
+		std::unique_lock<std::mutex> lockSimulation();
 
 		btVector3 applyTranslationOffset();
 		void restoreTranslationOffset(const btVector3&);


### PR DESCRIPTION
This PR adds two additional useful functions to DynamicHDT`
```cpp
// Toggle bones between kinematic and dynamic
// Returns array of bools, each entry is the PREVIOUS state of that bone index:
// - true  = bone was dynamic (physics was ON)
// - false = bone was kinematic (physics was OFF / not found)
std::vector<bool> TogglePhysics(RE::StaticFunctionTag* base, RE::Actor* actor, std::vector<RE::BSFixedString> boneNames, bool on);

// Reset an actor's SMP physics systems
// - full = true  -> complete reset, bones snap to reference pose
// - full = false -> soft reset, current bone poses are preserved
void ResetPhysics(RE::StaticFunctionTag* base, RE::Actor* actor, bool full);
```

Also I made the API actually thread safe. Before it was playing Russian roulette lol. The physics suspension system was also... Redundant? Likely never got fully implemented or was broken by future update. It served no purpose other than a false hope of thread safety.  

Draft Checklist:
- [x] Test further
- [x] Test using SKSE and Papyrus externally 
- [x] samirloon test  
- [x] Include the Papyrus scripts

Later commit notes:

- Soft reload schedules the reset to avoid 1 frame t-pose flickers. Grantees the mesh reload is invisible to the user - which is the whole point of the soft reload