### PR TITLE
feat: Add wind-factor option to the .xml config

### DIFF
--- a/src/hdtSkinnedMesh/hdtSkinnedMeshBone.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshBone.h
@@ -20,7 +20,7 @@ namespace hdt
 		float m_marginMultipler;
 		float m_boudingSphereMultipler = 1.0f;
 		float m_gravityFactor = 1.0f;
-		float m_windFactor = 1.0f;  // wind factor for each skinnedmeshbody; currently not changed, this may have been intended to be m_windEffect e.g., (wind-effect in xml)
+		float m_windFactor = 1.0f;  // Mapped to <wind-factor> in the XML. Acts as a multiplier for the global wind force applied to this bone (0.0 = no wind, 2.0 = double wind)
 
 		btRigidBody m_rig;
 		btTransform m_localToRig;

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshShape.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshShape.h
@@ -39,7 +39,6 @@ namespace hdt
 		vectorA16<Aabb> m_aabb;
 		vectorA16<Collider> m_colliders;
 		ColliderTree m_tree;
-		float m_windEffect = 0.f;  //effect from xml m_windEffect
 	};
 
 	class PerVertexShape : public SkinnedMeshShape

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -172,7 +172,7 @@ namespace hdt
 				continue;
 			for (auto& j : i->m_bones) {
 				auto body = &j->m_rig;
-				if (!body->isStaticOrKinematicObject() && (rand() % 5))  // apply randomly 80% of the time to desync wind across bones
+				if (!body->isStaticOrKinematicObject() && j->m_windFactor != 0.0f && (rand() % 5))  // apply randomly 80% of the time to desync wind across bones
 				{
 					body->applyCentralForce(m_windSpeed * j->m_windFactor * system->m_windFactor);
 				}

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -482,6 +482,8 @@ namespace hdt
 					cinfo.m_noCollideWithBone.push_back(m_reader->readText());
 				} else if (name == "gravity-factor") {
 					cinfo.m_gravityFactor = btClamped(m_reader->readFloat(), 0.0f, 1.0f);
+				} else if (name == "wind-factor") {
+					cinfo.m_windFactor = std::max(m_reader->readFloat(), 0.0f);
 				} else {
 					logger::warn("unknown element - {}", name.c_str());
 					m_reader->skipCurrentElement();
@@ -669,6 +671,7 @@ namespace hdt
 			bone->m_rigToLocal = boneTemplate.m_centerOfMassTransform.inverse();
 			bone->m_marginMultipler = boneTemplate.m_marginMultipler;
 			bone->m_gravityFactor = boneTemplate.m_gravityFactor;
+			bone->m_windFactor = boneTemplate.m_windFactor;
 
 			if (old_system) {
 				auto old_b = old_system->findBone(bodyName);
@@ -884,8 +887,6 @@ namespace hdt
 					body->m_disableTag = m_reader->readText();
 				} else if (nodeName == "disable-priority") {
 					body->m_disablePriority = m_reader->readInt();
-				} else if (nodeName == "wind-effect") {
-					shape->m_windEffect = m_reader->readFloat();
 				} else {
 					logger::warn("unknown element - {}", name.c_str());
 					m_reader->skipCurrentElement();
@@ -981,8 +982,6 @@ namespace hdt
 					body->m_disableTag = m_reader->readText();
 				} else if (nodeName == "disable-priority") {
 					body->m_disablePriority = m_reader->readInt();
-				} else if (nodeName == "wind-effect") {
-					shape->m_windEffect = m_reader->readFloat();
 				} else {
 					logger::warn("unknown element - {}", nodeName.c_str());
 					m_reader->skipCurrentElement();

--- a/src/hdtSkyrimSystem.h
+++ b/src/hdtSkyrimSystem.h
@@ -94,6 +94,7 @@ namespace hdt
 			btTransform m_centerOfMassTransform;
 			float m_marginMultipler;
 			float m_gravityFactor = 1.0f;
+			float m_windFactor = 1.0f;
 			U32 m_collisionFilter = 0;
 		};
 


### PR DESCRIPTION
This adds <wind-factor> to the outfit xmls. So users can disable, or tweak the wind influence on their outfits on a per-bone basis. 

Interesting discovery, this m_windFactor has ALWAYS existed. It was just always 1.0, and was never read from the config. "wind-effect" existed in the .xml reading, but was never used by the code. 

So all this commit realistically does is allows the m_windFactor to be changed by the outfit config. Technically zero logic changed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Changes**
  * Wind configuration structure updated: per-bone wind-factor control replaces global wind-effect setting. XML configuration files must update `wind-effect` references to per-bone `wind-factor`.

* **Improvements**
  * Wind force calculations now skip when wind factor is disabled (set to zero), reducing unnecessary physics processing overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->