### PR TITLE
fix: Properly read the game pause var

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -212,7 +212,7 @@ namespace Hooks
 			Events::Sources::ShutdownEventEventSource::GetSingleton()->SendEvent(&e);
 		} else {
 			Events::FrameEvent e;
-			e.gamePaused = a_this->freezeTime;
+			e.gamePaused = REL::RelocateMember<bool>(a_this, 0x16, 0x0E);
 			Events::Sources::FrameEventSource::GetSingleton()->SendEvent(&e);
 		}
 	}


### PR DESCRIPTION
Same issue as the quitGame variable - this isn't runtime resolved properly (yet) on Commonlib NG. So we need to manually insert the offsets. 

Fixes the issue where if the game is paused with "tfc 1" SMP physics doesn't pause. I believe this is a very old issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pause state detection mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->