### PR TITLE
fix: Guard against invalid nodes to avoid CTDs

### DIFF
--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -727,6 +727,9 @@ namespace hdt
 			RE::NiSkinData* skinData = skinInstance->skinData.get();
 			for (uint32_t boneIdx = 0; boneIdx < skinData->bones; ++boneIdx) {
 				auto node = skinInstance->bones[boneIdx];
+				if (!node) {
+					continue;
+				}
 				auto boneData = &skinData->boneData[boneIdx];
 				auto boundingSphere = BoundingSphere(convertNi(boneData->bound.center), boneData->bound.radius);
 				const RE::BSFixedString& boneName = node->name;
@@ -917,6 +920,9 @@ namespace hdt
 
 		for (auto entry : vertexOffsetMap) {
 			auto* g = castBSTriShape(findObject(m_model, entry.first.c_str()));
+			if (!g) {
+				continue;
+			}
 			if (g->GetGeometryRuntimeData().skinInstance) {
 				int offset = entry.second;
 				RE::NiSkinPartition* skinPartition = g->GetGeometryRuntimeData().skinInstance->skinPartition.get();


### PR DESCRIPTION
OpenAnimationReplacer creates dummy characters in the main menu which will lead to FSMP reading invalid data and crashing. 

This commit just guards against nulls.

In the future, a more robust implementation should probably be made in the ArmorAttachEvent (Or it's callers), but for now this will serve well and doesn't really introduce any overhead (Would likely be skipped 99% of the time due to cpu branching). 

Crash log: https://pastebin.com/vK8LV93t

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mesh and bone processing stability by implementing safeguards against missing or null node references. The system now gracefully skips absent nodes during geometry assembly and bone iteration operations, preventing crashes that could occur when handling incomplete mesh data or certain corrupted configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->