### PR TITLE
fix: Keep nearby NPCs active when auto-adjust shrinks the skeleton budget

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -425,8 +425,13 @@ namespace hdt
 		const bool windEnabled = world->m_enableWind && !btFuzzyZero(wind.Length());
 
 		activeSkeletons = 0;
+		const float minCullingDistance2 = m_minCullingDistance * m_minCullingDistance;
 		for (auto& i : m_skeletons) {
-			if (!i.hasPhysics || !i.updateAttachedState(playerCell, activeSkeletons >= maxActiveSkeletons))
+			// Skeletons inside the minimum culling distance are kept active even when the budget cap
+			// is exceeded, so a shrinking auto-adjust cap can't strip physics from NPCs next to the camera.
+			const bool forceKeepNear = i.m_distanceFromCamera2 < minCullingDistance2;
+			const bool overBudget = activeSkeletons >= maxActiveSkeletons;
+			if (!i.hasPhysics || !i.updateAttachedState(playerCell, overBudget && !forceKeepNear))
 				continue;
 
 			activeSkeletons++;


### PR DESCRIPTION
### Problem
With Auto Adjust Max Skeletons enabled, physics on some NPCs visibly toggles on and off every ~5 seconds — including NPCs standing right next to the player. With the setting disabled, the toggling stops. Users reported stiff hair/armor periodically snapping back to life on close NPCs in crowded scenes.

### Root cause
The culling algorithm is identical in both modes; what differs is the value of maxActiveSkeletons it runs against.

In ActorManager::onEvent, each metrics tick (every min_fps frames) runs an auto-adjust controller:

```
if (averageProcessingTimeInMainLoop > maxBudgetTime)
    maxActiveSkeletons -= 2;
else if (averageProcessingTimeInMainLoop < maxBudgetTime * 0.9f)
    maxActiveSkeletons += 2;
```

The ±2 step combined with the 10% hysteresis deadzone is too coarse: shrinking the cap removes the cost of the borderline skeletons, the next sample lands under 90% of budget, the cap grows back, cost returns, the sample lands over budget, and the cap shrinks again. The cap oscillates on a multi-sample cadence (~5s wall-clock).

Physics activation is a pure rank-vs-cap test:

`i.updateAttachedState(playerCell, activeSkeletons >= maxActiveSkeletons)`

Any skeleton whose sort rank lands inside the oscillating band has deactivate flipped on/off each cycle. The sort key is distance² / cos(angle), so a close but off-axis NPC (someone next to the camera, slightly to the side) can easily sit in that band — which is why nearby NPCs are affected, not just distant ones.

The existing m_minCullingDistance setting was designed to force-keep close skeletons through geometric culling (frustum + LOS) inside isInPlayerView(), but isInPlayerView() is only consulted on the deactivate=false branch. It never sees the budget-cap branch, so the "always keep NPCs this close" guarantee doesn't extend to the auto-adjust path.

### Fix
In the main culling loop, short-circuit the cap check when a skeleton is inside m_minCullingDistance:

```
const bool forceKeepNear = i.m_distanceFromCamera2 < minCullingDistance2;
const bool overBudget = activeSkeletons >= maxActiveSkeletons;
if (!i.hasPhysics || !i.updateAttachedState(playerCell, overBudget && !forceKeepNear))
    continue;
activeSkeletons++;
```

Squared distance is compared against a hoisted squared threshold to match the existing convention in the file and avoid a per-skeleton sqrt.

### Behavior

- Close NPCs (inside minCullingDistance) are never deactivated by the budget cap, so cap oscillation can no longer strip physics from NPCs standing next to the player.
- They still count toward activeSkeletons, so the auto-adjust controller still sees their processing cost and compensates by reducing the cap further for distant NPCs.
- Behavior is unchanged when auto-adjust is off, and unchanged for NPCs outside minCullingDistance.
- In the (rare) pathological case where more than maxActiveSkeletons NPCs are all inside minCullingDistance, the cap becomes a soft floor rather than a hard ceiling — preferable to a stiff NPC in the player's face.
- Side benefit
- Previously, in crowd scenes where the cap saturates, m_minCullingDistance was effectively inert: the top-N skeletons by sort score are almost always in-frustum and unoccluded, so the frustum/LOS overrides it guards rarely fire. This change gives the setting meaningful reach in the regime where it matters most.

Files changed
src/ActorManager.cpp — main culling loop at ~line 427

Ai disclosure:  Used Claude Opus to understand the cause and create the fix.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved actor skeleton activation to prioritize skeletons near the camera when active skeleton limits are reached, ensuring better performance and visual quality for nearby objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->