### PR TITLE
perf: Reduce auto-scaling aggression at low skeleton counts

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -526,7 +526,7 @@ namespace hdt
 				averageProcessingTimeInMainLoop,
 				maxBudgetTime);
 
-			if (m_autoAdjustMaxSkeletons) {
+			if (m_autoAdjustMaxSkeletons && m_maxActiveSkeletons > 3) {
 				// Deadzones to prevent constantly switching back and fourth
 				if (averageProcessingTimeInMainLoop > maxBudgetTime) {
 					// When few skeletons active, step down by 1 to avoid over-correction
@@ -541,7 +541,7 @@ namespace hdt
 					maxActiveSkeletons += std::clamp(canAdd, 0, 2);
 				}
 
-				// clamp the value to the m_maxActiveSkeletons value, never go below 3
+				// clamp the adjusted value between 3 and m_maxActiveSkeletons
 				maxActiveSkeletons = std::clamp(maxActiveSkeletons, 3, m_maxActiveSkeletons);
 				frameCount = 1;
 

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -531,8 +531,14 @@ namespace hdt
 				if (averageProcessingTimeInMainLoop > maxBudgetTime) {
 					// When few skeletons active, step down by 1 to avoid over-correction
 					maxActiveSkeletons -= (activeSkeletons < 10) ? 1 : 2;
-				} else if (averageProcessingTimeInMainLoop < maxBudgetTime * 0.9f) {  // under 90% of budget
-					maxActiveSkeletons += 2;
+				} else if (averageProcessingTimeInMainLoop < maxBudgetTime) {
+					// Scale up by however many skeletons fit within the remaining budget headroom, max of 2
+					// Falls back to +2 when no skeletons are active (timePerSkeleton == 0).
+					const float headroom = maxBudgetTime - averageProcessingTimeInMainLoop;
+					const int canAdd = (averageTimePerSkeletonInMainLoop > 0.f)
+					    ? static_cast<int>(headroom / averageTimePerSkeletonInMainLoop)
+					    : 2;
+					maxActiveSkeletons += std::clamp(canAdd, 0, 2);
 				}
 
 				// clamp the value to the m_maxActiveSkeletons value, never go below 3

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -535,9 +535,7 @@ namespace hdt
 					// Scale up by however many skeletons fit within the remaining budget headroom, max of 2
 					// Falls back to +2 when no skeletons are active (timePerSkeleton == 0).
 					const float headroom = maxBudgetTime - averageProcessingTimeInMainLoop;
-					const int canAdd = (averageTimePerSkeletonInMainLoop > 0.f)
-					    ? static_cast<int>(headroom / averageTimePerSkeletonInMainLoop)
-					    : 2;
+					const int canAdd = (averageTimePerSkeletonInMainLoop > 0.f) ? static_cast<int>(headroom / averageTimePerSkeletonInMainLoop) : 2;
 					maxActiveSkeletons += std::clamp(canAdd, 0, 2);
 				}
 

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -529,13 +529,14 @@ namespace hdt
 			if (m_autoAdjustMaxSkeletons) {
 				// Deadzones to prevent constantly switching back and fourth
 				if (averageProcessingTimeInMainLoop > maxBudgetTime) {
-					maxActiveSkeletons -= 2;
+					// When few skeletons active, step down by 1 to avoid over-correction
+					maxActiveSkeletons -= (activeSkeletons < 10) ? 1 : 2;
 				} else if (averageProcessingTimeInMainLoop < maxBudgetTime * 0.9f) {  // under 90% of budget
 					maxActiveSkeletons += 2;
 				}
 
-				// clamp the value to the m_maxActiveSkeletons value
-				maxActiveSkeletons = std::clamp(maxActiveSkeletons, 1, m_maxActiveSkeletons);
+				// clamp the value to the m_maxActiveSkeletons value, never go below 3
+				maxActiveSkeletons = std::clamp(maxActiveSkeletons, 3, m_maxActiveSkeletons);
 				frameCount = 1;
 
 			} else if (maxActiveSkeletons != m_maxActiveSkeletons)


### PR DESCRIPTION
### Problem

The previous auto-scaling logic used fixed step sizes (+2/-2) regardless of context:

- **Scale-down** was too aggressive at low skeleton counts — dropping by 2 at 5 active skeletons is a 40% reduction from a single slow frame, causing unnecessary pop-in and oscillation.
- **Scale-up** used a fixed 90% budget threshold with a fixed +2 step, ignoring how many skeletons would actually fit in the remaining headroom.
- The minimum floor of 1 meant physics could be reduced to a near-useless state.

### Changes

**Scale-down:**
- When `activeSkeletons < 10` and over budget, decrease by 1 instead of 2
- Minimum clamp raised from 1 → 3

**Scale-up:**
- Computes remaining budget headroom and divides by `averageTimePerSkeleton` to determine how many skeletons can be safely added
- Result clamped to `[0,2]` to prevent single-frame overcorrection
- Falls back to `+2` when no skeletons are active (no per-skeleton timing data available)

### Behaviour

| Condition | Before | After |
|---|---|---|
| Over budget, ≥10 active skeletons | `-= 2` | `-= 2` (unchanged) |
| Over budget, <10 active skeletons | `-= 2` | `-= 1` |
| Under budget | `+= 2` (fixed) | `+= floor(headroom / timePerSkeleton)`, clamped `[0, 2]` |
| Minimum floor | `1` | `3` |

### Notes

The per-skeleton timing data (`averageTimePerSkeletonInMainLoop`) was already being computed each metrics cycle — no additional overhead. The auto-scaling check runs once per `min_fps` frames (~1Hz at 60fps), so the extra division is negligible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Performance Improvements
* Improved automatic resource allocation for managing active actors to better adapt to system performance constraints and optimize responsiveness under varying loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->