### PR TITLE
feat: include interface folder from mcm so background image is installed

### DIFF
--- a/fomod tree/fomod/ModuleConfig.xml
+++ b/fomod tree/fomod/ModuleConfig.xml
@@ -136,6 +136,7 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 								<folder source="FSMPM\Scripts" destination="Scripts" priority="1" />
 								<folder source="FSMPM\SKSE" destination="SKSE" priority="1" />
 								<folder source="FSMPM\Source" destination="Source" priority="1" />
+								<folder source="FSMPM\interface" destination="interface" priority="1" />
 								<file source="FSMPM\FSMPM - The FSMP MCM.esp" destination=".\FSMPM - The FSMP MCM.esp" priority="1" />
 								<file source="FSMPV\hdtSMP64.xsd" destination="SKSE\Plugins\hdtSMP64.xsd" priority="1" />
 							</files>


### PR DESCRIPTION
## Summary
FOMOD now installs `FSMPM\interface` → `interface/`, so `Logo.dds` lands in `Data/interface/FSMP/` and the MCM welcome page renders its banner.

Without this, `LoadCustomContent("interface/FSMP/Logo.dds")` in the MCM script silently fails — users get a blank welcome page despite the asset being present in the release zip.

## Context
FSMP-MCM 3.0.2 added `interface/FSMP/Logo.dds` for the MCM splash. Release zip already packages it under `FSMPM/interface/`, but FOMOD had no install entry for the folder.

## Test plan
- [ ] Install FOMOD via MO2/Vortex
- [ ] Verify `Data/interface/FSMP/Logo.dds` exists post-install
- [ ] Launch game, open MCM, confirm logo on welcome page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mod installation package to include additional interface components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->