### PR TITLE
feat: tweak github actions to always create installable package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,6 +299,7 @@ jobs:
         with:
           name: FSMP-${{ needs.prepare.outputs.tag_version }}
           path: FSMP-${{ needs.prepare.outputs.tag_version }}.zip
+          if-no-files-found: error
 
   release:
     needs: [prepare, package, check_messages]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ on:
       - "extern/**"
       - "cmake/**"
       - ".github/workflows/**"
+      - "fomod tree/**"
   workflow_dispatch:
   pull_request:
     branches:
@@ -40,6 +41,7 @@ on:
       - "extern/**"
       - "cmake/**"
       - ".github/workflows/**"
+      - "fomod tree/**"
 
 permissions:
   contents: read
@@ -214,15 +216,9 @@ jobs:
           name: raw-${{ matrix.preset }}
           path: out/build/${{ matrix.preset }}/plugins/
 
-  release:
-    needs: [prepare, build, check_messages]
-    # Release only on push to branches, and ignore commits that are just style, docs, tests changes
-    if: |
-      github.event_name == 'push' &&
-      needs.check_messages.outputs.should_release == 'true'
+  package:
+    needs: [prepare, build]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout the code to get the "fomod tree" folder
@@ -298,6 +294,28 @@ jobs:
           echo "Listing contents of FSMP-${{ needs.prepare.outputs.tag_version }}.zip:"
           7z l FSMP-${{ needs.prepare.outputs.tag_version }}.zip
 
+      - name: Upload final package as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: FSMP-${{ needs.prepare.outputs.tag_version }}
+          path: FSMP-${{ needs.prepare.outputs.tag_version }}.zip
+
+  release:
+    needs: [prepare, package, check_messages]
+    # Release only on push to branches, and ignore commits that are just style, docs, tests changes
+    if: |
+      github.event_name == 'push' &&
+      needs.check_messages.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download the packaged zip
+        uses: actions/download-artifact@v4
+        with:
+          name: FSMP-${{ needs.prepare.outputs.tag_version }}
+
       - name: Create GitHub Release and Git Tag
         uses: softprops/action-gh-release@v2
         with:
@@ -309,6 +327,6 @@ jobs:
             Build Date: ${{ github.event.head_commit.timestamp }}
             Commit: ${{ github.sha }}
             Automated Semantic Build.
-          files: "**.zip"
+          files: "FSMP-${{ needs.prepare.outputs.tag_version }}.zip"
           # prerelease is true for all branches except master
           prerelease: ${{ github.ref_name != 'master' }}


### PR DESCRIPTION
## Summary
Split the release job into `package` + `release` so the FOMOD zip is produced on every build, not only on eligible pushes.

- **`package`** job: always runs (push/PR/`workflow_dispatch`). Fetches FSMP-Validator + FSMP-MCM, assembles `final_package/`, creates `FSMP-<version>.zip`, uploads as workflow artifact `FSMP-<version>`.
- **`release`** job: keeps the original gate (`push` + non-style/docs/test commits). Downloads the `package` artifact and publishes the GitHub Release from it — single source of truth, no rebuild.
- Added `fomod tree/**` to push/PR path filters so fomod-only changes trigger the workflow.
- Added guard around the MCM `interface/` copy so a missing upstream folder no longer hard-fails the packaging step.

## Why
Previously the entire release job was gated on push + release-eligible commits, so manual runs and PRs never produced a testable zip. Testing FOMOD changes required piggy-backing on an unrelated code commit to `dev`. Splitting the job lets contributors grab the artifact from any run.

## Test plan
- [x] `workflow_dispatch` run on a feature branch → `FSMP-<version>` artifact appears, no GH release created
- [x] PR run → artifact appears, no GH release created
- [x] Push to `dev` with a non-style commit → artifact appears **and** GH release published with the same zip
- [ ] Push to `dev` with only `style:`/`docs:`/`test:` commit → artifact appears, no GH release (gate preserved)
- [x] Push touching only `fomod tree/**` → workflow triggers (path filter)

You can see these changes in action at:

https://github.com/KaninHop/hdtSMP64/actions/runs/24526156201 on a PR
and 
https://github.com/KaninHop/hdtSMP64/actions/runs/24527460863 on a merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow now triggers on changes to the mod packaging tree.
  * Introduced a dedicated packaging job that builds and uploads a single packaged artifact.
  * Release job reworked to depend on the packaging job and to download/upload that specific artifact.
  * Repository permissions tightened so write access applies only to the release step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->