### PR TITLE
fix: Use detours instead to avoid breaking other mods

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -361,6 +361,9 @@ namespace Hooks
 		DetourUpdateThread(GetCurrentThread());
 		ActorEquipManagerHooks::Hook();
 		BSFaceGenNiNodeHooks::HookSetBoneName();
+		// We use a detour on this instead of modifying the vtable to avoid breaking compatibility with other mods like Mu Joint Fix
+		DetourAttach((PVOID*)&BSFaceGenNiNodeHooks::_SkinAllGeometry_Orig, (PVOID)BSFaceGenNiNodeHooks::SkinAllGeometry__Hook);
+
 		DetourTransactionCommit();
 
 		//

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -20,10 +20,11 @@ namespace Hooks
 			//
 			logger::debug("Applying BSFaceGenNiNodeHooks hooks!");
 
-			//
 			REL::Relocation<uintptr_t> BSFaceGenNiNode__vtbl{ RE::VTABLE_BSFaceGenNiNode[0] };
 			// VR adds SKYRIM_REL_VR_VIRTUAL FixSkinInstances at slot 0x3E, pushing SkinAllGeometry to 0x3F
-			BSFaceGenNiNode__vtbl.write_vfunc(REL::Module::IsVR() ? 0x3F : 0x3E, SkinAllGeometry__Hook);
+			size_t vtbl_idx = REL::Module::IsVR() ? 0x3F : 0x3E;
+			uintptr_t origFuncAddr = *reinterpret_cast<uintptr_t*>(BSFaceGenNiNode__vtbl.address() + (sizeof(void*) * vtbl_idx));
+			_SkinAllGeometry_Orig = reinterpret_cast<SkinAllGeometry_t>(origFuncAddr);
 
 			//
 			_SkinSingleGeometry = trampoline.write_call<5>(SkinSingleGeometryCode1.address(), SkinSingleGeometry__Hook);
@@ -69,6 +70,9 @@ namespace Hooks
 		// Complements the loop-count cap in ApplyBoneLimitFix.
 		static void HookSetBoneName();
 		static void SetBoneName_Hook(RE::BSFaceGenModelExtraData*, std::uint32_t, RE::BSFixedString*);
+
+		using SkinAllGeometry_t = decltype(&BSFaceGenNiNodeHooks::SkinAllGeometry__Hook);
+		static inline SkinAllGeometry_t _SkinAllGeometry_Orig{ nullptr };
 
 		static inline REL::Relocation<decltype(&BSFaceGenNiNodeHooks::SkinSingleGeometry__Hook)> _SkinSingleGeometry;
 


### PR DESCRIPTION
Instead of overwriting the vfunc, we just use the old detour hook like in 2.5.1. Avoids breaking mods that also hook that function, while still allowing the detour chain to run

This should fix the compatibility issue with Mu Joint Fix

## Testing
- [x] Verify it doesn't break anything (Tested on SE)
- [ ] Verify it even fixes the Mu Joint Fix compatibility issue