### PR TITLE
fix: Install hooks at init

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -449,7 +449,6 @@ void MessageHandler(SKSE::MessagingInterface::Message* a_msg)
 		{
 			hdt::g_pluginInterface.onPostPostLoad();
 			checkOldPlugins();
-			Hooks::Install();
 		}
 		break;
 	}
@@ -547,7 +546,8 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 	//
 	SKSE::GetCameraEventSource()->AddEventSink(hdt::SkyrimPhysicsWorld::get());
 
-	//
+	Hooks::Install();
+
 	hdt::g_pluginInterface.init(a_skse);
 
 	//


### PR DESCRIPTION
Same behavior as FSMP 2.5.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted hook installation timing to occur earlier during plugin initialization, ensuring proper registration of event handlers and improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->