### PR TITLE
refactor: Removed flawed original position reset system

### DIFF
--- a/src/DynamicHDT.cpp
+++ b/src/DynamicHDT.cpp
@@ -63,8 +63,6 @@ void hdt::util::transferCurrentPosesBetweenSystems(hdt::SkyrimSystem* src, hdt::
 				b2->m_rig.setInterpolationWorldTransform(newRigTrans);
 
 				b2->m_currentTransform = b1->m_currentTransform;
-				b2->m_origToSkeletonTransform = b1->m_origToSkeletonTransform;
-				b2->m_origTransform = b1->m_origTransform;
 				btVector3 oldCoM = b1->m_rig.getWorldTransform().getOrigin();
 				btVector3 newCoM = newRigTrans.getOrigin();
 				btVector3 comShift = newCoM - oldCoM;

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshBone.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshBone.h
@@ -26,13 +26,10 @@ namespace hdt
 		btTransform m_localToRig;
 		btTransform m_rigToLocal;
 		btQsTransform m_currentTransform;
-		btQsTransform m_origTransform;
-		btQsTransform m_origToSkeletonTransform;
 
 		std::vector<RE::BSFixedString> m_canCollideWithBone;
 		std::vector<RE::BSFixedString> m_noCollideWithBone;
 
-		virtual void resetTransformToOriginal() = 0;
 		virtual void readTransform(float timeStep) = 0;
 		virtual void writeTransform() = 0;
 

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.cpp
@@ -6,12 +6,6 @@
 
 namespace hdt
 {
-	void SkinnedMeshSystem::resetTransformsToOriginal()
-	{
-		for (int i = 0; i < m_bones.size(); ++i)
-			m_bones[i]->resetTransformToOriginal();
-	}
-
 	void SkinnedMeshSystem::readTransform(float timeStep)
 	{
 		if (this->block_resetting)

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.h
@@ -21,7 +21,6 @@ namespace hdt
 		virtual ~SkinnedMeshSystem() = default;
 
 		virtual float prepareForRead(float timeStep) { return timeStep; }
-		virtual void resetTransformsToOriginal();
 		virtual void readTransform(float timeStep);
 		virtual void writeTransform();
 

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
@@ -27,11 +27,6 @@ namespace hdt
 	protected:
 		std::vector<float> m_timeSteps;
 
-		void resetTransformsToOriginal()
-		{
-			for (int i = 0; i < m_systems.size(); ++i) m_systems[i]->resetTransformsToOriginal();
-		}
-
 		void readTransform(float timeStep)
 		{
 			const size_t n = m_systems.size();

--- a/src/hdtSkyrimBone.cpp
+++ b/src/hdtSkyrimBone.cpp
@@ -20,12 +20,6 @@ namespace hdt
 		this->m_forceUpdateType = hdt::ForceUpdateList::GetSingleton()->isAmong(m_name);
 	}
 
-	void SkyrimBone::resetTransformToOriginal()
-	{
-		m_node->local = convertBt(m_origTransform);
-		updateTransformUpDown(m_node.get(), false);
-	}
-
 	void SkyrimBone::readTransform(float timeStep)
 	{
 		auto oldScale = m_currentTransform.getScale();
@@ -57,8 +51,6 @@ namespace hdt
 		auto dest = m_currentTransform.asTransform() * m_localToRig;
 		if (timeStep <= RESET_PHYSICS) {
 			static const btVector3 zero(0, 0, 0);
-			m_origToSkeletonTransform = convertNi(m_skeleton->world).inverse() * m_currentTransform;
-			m_origTransform = convertNi(m_node->local);
 			m_rig.setWorldTransform(dest);
 			m_rig.setInterpolationWorldTransform(dest);
 			m_rig.setLinearVelocity(zero);

--- a/src/hdtSkyrimBone.h
+++ b/src/hdtSkyrimBone.h
@@ -10,7 +10,6 @@ namespace hdt
 	public:
 		SkyrimBone(const RE::BSFixedString& name, RE::NiNode* node, RE::NiNode* skeleton, btRigidBody::btRigidBodyConstructionInfo& ci);
 
-		void resetTransformToOriginal() override;
 		void readTransform(float timeStep) override;
 		void writeTransform() override;
 

--- a/src/hdtSkyrimPhysicsWorld.cpp
+++ b/src/hdtSkyrimPhysicsWorld.cpp
@@ -300,12 +300,6 @@ namespace hdt
 		}
 	}
 
-	void SkyrimPhysicsWorld::resetTransformsToOriginal()
-	{
-		std::lock_guard<decltype(m_lock)> l(m_lock);
-		SkinnedMeshWorld::resetTransformsToOriginal();
-	}
-
 	void SkyrimPhysicsWorld::resetSystems()
 	{
 		std::lock_guard<decltype(m_lock)> l(m_lock);

--- a/src/hdtSkyrimPhysicsWorld.h
+++ b/src/hdtSkyrimPhysicsWorld.h
@@ -28,7 +28,6 @@ namespace hdt
 		void removeSystemByNode(void* root);
 		using SkinnedMeshWorld::updateConstraintsForBone;
 
-		void resetTransformsToOriginal();
 		void resetSystems();
 
 		RE::BSEventNotifyControl ProcessEvent(const Events::FrameEvent* e, RE::BSTEventSource<Events::FrameEvent>*) override;

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -271,7 +271,7 @@ namespace hdt
 				if (m_reader->GetInspected() == XMLReader::Inspected::StartTag) {
 					const auto name = m_reader->GetName();
 					if (name == "bone") {
-						readOrUpdateBone(old_system);
+						readOrUpdateBone();
 					} else if (name == "bone-default") {
 						auto clsname = m_reader->getAttribute("name", "");
 						auto extends = m_reader->getAttribute("extends", "");
@@ -645,7 +645,7 @@ namespace hdt
 		return nullptr;
 	}
 
-	void SkyrimSystemCreator::readOrUpdateBone(SkyrimSystem* old_system)
+	void SkyrimSystemCreator::readOrUpdateBone()
 	{
 		RE::BSFixedString name = getRenamedBone(m_reader->getAttribute("name"));
 		if (findBoneFromIndex(name)) {
@@ -654,11 +654,11 @@ namespace hdt
 		}
 
 		RE::BSFixedString cls = m_reader->getAttribute("template", "");
-		if (!createBoneFromNodeName(name, cls, true, old_system))
+		if (!createBoneFromNodeName(name, cls, true))
 			m_reader->skipCurrentElement();
 	}
 
-	SkyrimBone* SkyrimSystemCreator::createBoneFromNodeName(const RE::BSFixedString& bodyName, const RE::BSFixedString& templateName, const bool readTemplate, SkyrimSystem* old_system)
+	SkyrimBone* SkyrimSystemCreator::createBoneFromNodeName(const RE::BSFixedString& bodyName, const RE::BSFixedString& templateName, const bool readTemplate)
 	{
 		auto node = findObjectByName(bodyName);
 		if (node) {
@@ -673,24 +673,7 @@ namespace hdt
 			bone->m_gravityFactor = boneTemplate.m_gravityFactor;
 			bone->m_windFactor = boneTemplate.m_windFactor;
 
-			if (old_system) {
-				auto old_b = old_system->findBone(bodyName);
-				if (old_b) {
-					bone->m_currentTransform = convertNi(bone->m_skeleton->world) * old_b->m_origToSkeletonTransform;
-					auto dest = bone->m_currentTransform.asTransform() * bone->m_localToRig;
-					bone->m_origToSkeletonTransform = old_b->m_origToSkeletonTransform;
-					bone->m_origTransform = old_b->m_origTransform;
-					bone->m_rig.setWorldTransform(dest);
-					bone->m_rig.setInterpolationWorldTransform(dest);
-					bone->m_rig.setLinearVelocity(btVector3(0, 0, 0));
-					bone->m_rig.setAngularVelocity(btVector3(0, 0, 0));
-					bone->m_rig.setInterpolationLinearVelocity(btVector3(0, 0, 0));
-					bone->m_rig.setInterpolationAngularVelocity(btVector3(0, 0, 0));
-					bone->m_rig.updateInertiaTensor();
-				} else
-					bone->readTransform(RESET_PHYSICS);
-			} else
-				bone->readTransform(RESET_PHYSICS);
+			bone->readTransform(RESET_PHYSICS);
 
 			m_mesh->m_bones.push_back(hdt::make_smart(bone));
 			indexBone(bone);

--- a/src/hdtSkyrimSystem.h
+++ b/src/hdtSkyrimSystem.h
@@ -208,8 +208,8 @@ namespace hdt
 		const StiffSpringConstraintTemplate& getStiffSpringConstraintTemplate(const RE::BSFixedString& name);
 		const ConeTwistConstraintTemplate& getConeTwistConstraintTemplate(const RE::BSFixedString& name);
 
-		SkyrimBone* createBoneFromNodeName(const RE::BSFixedString& bodyName, const RE::BSFixedString& templateName = "", const bool readTemplate = false, SkyrimSystem* old_system = nullptr);
-		void readOrUpdateBone(SkyrimSystem* old_system = nullptr);
+		SkyrimBone* createBoneFromNodeName(const RE::BSFixedString& bodyName, const RE::BSFixedString& templateName = "", const bool readTemplate = false);
+		void readOrUpdateBone();
 		RE::BSTSmartPointer<SkyrimBody> readPerVertexShape(DefaultBBP::NameMap_t meshNameMap);
 		RE::BSTSmartPointer<SkyrimBody> readPerTriangleShape(DefaultBBP::NameMap_t* meshNameMap);
 		RE::BSTSmartPointer<Generic6DofConstraint> readGenericConstraint();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,7 +295,6 @@ bool SMPDebug_Execute(
 		hdt::loadConfig();
 		hdt::logConfig();
 
-		hdt::SkyrimPhysicsWorld::get()->resetTransformsToOriginal();
 		const RE::MenuOpenCloseEvent e{ "", false };
 		hdt::ActorManager::instance()->ProcessEvent(&e, nullptr);
 		hdt::SkyrimPhysicsWorld::get()->resetSystems();


### PR DESCRIPTION
This PR removes the old seemingly extremely flawed reset system. I have no idea what the original author's intent was with writing this code, I assume it was written on the presumption that the bones would still be in the last position SMP set it to? 

**Issues this fixes:**

- Sometimes your SMP clothing gets permanently stuck, and doing "smp reset" does not fix it
- Fixes issues with dynamically scaled nodes being reset (Animation scales a bone after we captured the original, smp reset then resets it back to 1.0)
- Fixes the actor T pose on smp reset - now only physics items will be reset
- Fixes lots of pointless overhead (Wont make a notable performance difference, but gains are gains!)

**Why the original system is flawed:**
This system unconditionally captures whatever state the bone is in only during physics resets. So not only does that mean this is NOT a neutral position, it can actually lead to many of the issues I mentioned above. This is especially dangerous because often times nodes are scaled during game load, which also happens to be the time the MCM executes "smp reset". So we can easily capture a very stale transform, and instantly force-restore it. 

**Why this works:**
Our FrameEvent is positioned right at the end of the tick. After havok publishes it's state to the skyrim skeleton (And a few more calls run..). This means we naturally reset our physics simulation bones to Skyrim's intended positions without having to capture anything or do any tricks. 

**Testing checklist:**

- [x] Perform basic tests: Use SMP reset, run around populated areas, unequip/equip armors/hairs
- [x] Verify DynamicHDT works as intended still (I removed flawed code from SkyrimSystem)
- [ ] Verify the original author's true intent - was this a fix for a rare problem? (Doubt it)
- [x] Force samirloon and other SMP heavy mod users to test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined physics system reset operations by removing redundant transform state tracking across the framework.
  * Redesigned bone and mesh system initialization to eliminate unnecessary state transfer during physics resets.
  * Simplified the reset command execution path by consolidating reset functionality across simulation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->