### PR TITLE
perf: Optimized the mesh collision loop, and early exit on broken/complex collisions

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -14,8 +14,7 @@ namespace hdt
 			case XMLReader::Inspected::StartTag:
 				if (reader.GetLocalName() == "numIterations") {
 					SkyrimPhysicsWorld::get()->getSolverInfo().m_numIterations = btClamped(reader.readInt(), 4, 128);
-				}
-				else if (reader.GetLocalName() == "erp") {
+				} else if (reader.GetLocalName() == "erp") {
 					SkyrimPhysicsWorld::get()->getSolverInfo().m_erp = btClamped(reader.readFloat(), 0.01f, 1.0f);
 				} else if (reader.GetLocalName() == "min-fps") {
 					SkyrimPhysicsWorld::get()->min_fps = (btClamped(reader.readInt(), 1, 300));

--- a/src/hdtSkinnedMesh/hdtCollider.cpp
+++ b/src/hdtSkinnedMesh/hdtCollider.cpp
@@ -40,6 +40,10 @@ namespace hdt
 		stack.clear();
 		stack.push_back({ this, r, L });
 		while (!stack.empty()) {
+			if (ret.size() > MaxCollisionPairs) {
+				break;
+			}
+
 			auto e = stack.back();
 			stack.pop_back();
 

--- a/src/hdtSkinnedMesh/hdtCollider.h
+++ b/src/hdtSkinnedMesh/hdtCollider.h
@@ -5,6 +5,8 @@
 
 namespace hdt
 {
+	static const int MaxCollisionPairs = 4024;
+
 	struct alignas(16) Collider
 	{
 		Collider()

--- a/src/hdtSkinnedMesh/hdtDispatcher.cpp
+++ b/src/hdtSkinnedMesh/hdtDispatcher.cpp
@@ -141,7 +141,7 @@ namespace hdt
 			BT_PROFILE("HDTSMP_collision_pair_checks");
 
 			tbb::parallel_for_each(m_pairs.begin(), m_pairs.end(), [&, this](const std::pair<SkinnedMeshBody*, SkinnedMeshBody*>& i) {
-				// collapseCollideL is a canidate for optimizations since we'll re-traverse the tree in checkCollisionL. However,
+				// collapseCollideL is a candidate for optimizations since we'll re-traverse the tree in checkCollisionL. However,
 				// it's a bit tricky since collapse has an early-exit, and avoiding boilerplate is ideal. A traversal resume maybe?
 				if (i.first->m_shape->m_tree.collapseCollideL(&i.second->m_shape->m_tree)) {
 					BT_PROFILE("HDTSMP_processCollision");

--- a/src/hdtSkinnedMesh/hdtDispatcher.cpp
+++ b/src/hdtSkinnedMesh/hdtDispatcher.cpp
@@ -138,11 +138,15 @@ namespace hdt
 		}
 
 		{
-			BT_PROFILE("HDTSMP_processCollision");
+			BT_PROFILE("HDTSMP_collision_pair_checks");
 
 			tbb::parallel_for_each(m_pairs.begin(), m_pairs.end(), [&, this](const std::pair<SkinnedMeshBody*, SkinnedMeshBody*>& i) {
-				if (i.first->m_shape->m_tree.collapseCollideL(&i.second->m_shape->m_tree))
+				// collapseCollideL is a canidate for optimizations since we'll re-traverse the tree in checkCollisionL. However,
+				// it's a bit tricky since collapse has an early-exit, and avoiding boilerplate is ideal. A traversal resume maybe?
+				if (i.first->m_shape->m_tree.collapseCollideL(&i.second->m_shape->m_tree)) {
+					BT_PROFILE("HDTSMP_processCollision");
 					SkinnedMeshAlgorithm::processCollision(i.first, i.second, this);
+				}
 			});
 		}
 

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
@@ -219,8 +219,9 @@ namespace hdt
 			CollisionChecker<T, SwapResults>(std::forward<Ts>(ts)...)
 		{}
 
-		// Modern Fast Dynamic 1D Sweep and Prune Algorithm eliminating O(N*M) tests
-		void dispatch(ColliderTree* a, ColliderTree* b, std::vector<Aabb*>& listA, std::vector<Aabb*>& listB)
+		// We intentionally don't use a 'Dynamic 1D Sweep and Prune Algorithm' here. 
+		// O(N*M) is nearly always faster or within a margin of error. Not worth the extra boilerplate code
+		void dispatch(ColliderTree* a, ColliderTree* b, std::vector<Aabb*>& listA, std::vector<Aabb*>& listB, const Aabb& refinedBForPruningA)
 		{
 			CollisionResult result;
 			CollisionResult temp;
@@ -231,6 +232,8 @@ namespace hdt
 
 			if (listA.size() && listB.size()) {
 				for (auto i : listA) {
+					if (!i->collideWith(refinedBForPruningA))
+						continue;
 					for (auto j : listB) {
 						if (!i->collideWith(*j))
 							continue;
@@ -265,6 +268,12 @@ namespace hdt
 			this->c0->checkCollisionL(this->c1, pairs);
 			if (pairs.empty())
 				return 0;
+
+			// The collision is just too complex to solve. We must quit before we explode the user's computer
+			// If this DOES solve, it seems to only cause the collision to become significantly more tangles up
+			if (pairs.size() >= MaxCollisionPairs) {
+				return 0;
+			}
 
 			decltype(auto) func = [this](const std::pair<ColliderTree*, ColliderTree*>& pair) {
 				if (this->numResults >= SkinnedMeshAlgorithm::MaxCollisionCount)
@@ -311,20 +320,11 @@ namespace hdt
 					}
 				}
 
-				// Remove any colliders from A that don't intersect the new bounding box for B
-				if (listB.size()) {
-					listA.erase(std::remove_if(listA.begin(), listA.end(), [&](Aabb* aabb) { return !aabb->collideWith(aabbB); }), listA.end());
-				}
-
 				// Now go through both lists and do the real collision (if needed).
-				this->dispatch(a, b, listA, listB);
-
-				listA.clear();
-				listB.clear();
+				this->dispatch(a, b, listA, listB, aabbB);
 			};
 
 			if (pairs.size() >= 32)
-				// FIXME PROFILING This is the line where we spend the most time in the whole mod.
 				// isolate: thread parked here waiting for inner work must not steal an outer
 				// processCollision task — that would alias thread_local MergeBuffer/listA/listB.
 				tbb::this_task_arena::isolate([&] { tbb::parallel_for_each(pairs.begin(), pairs.end(), func); });
@@ -386,6 +386,16 @@ namespace hdt
 						continue;
 
 					auto c = getAndTrack(boneIdx0, boneIdx1);
+
+					// If we already have a primary direction (weight > 0),
+					// and this new contact pushes in the opposite direction (dot < 0),
+					// reject it entirely. This prevents the vector cancellation that creates
+					// unpredictable movement, and preserves the depth/weight ratio
+					// [If we get jitter, try removing this]
+					if (c->weight > FLT_EPSILON && c->normal.dot(normScaled) < 0) {
+						continue;
+					}
+
 					c->weight += w2;
 					c->normal += normScaled;
 					c->pos[0] += posAScaled;
@@ -436,7 +446,6 @@ namespace hdt
 
 			if (depth >= -FLT_EPSILON)
 				continue;
-
 			btManifoldPoint newPt(localA, localB, normal, depth);
 			newPt.m_positionWorldOnA = worldA;
 			newPt.m_positionWorldOnB = worldB;

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
@@ -271,7 +271,7 @@ namespace hdt
 
 			// The collision is just too complex to solve. We must quit before we explode the user's computer
 			// If this DOES solve, it seems to only cause the collision to become significantly more tangles up
-			if (pairs.size() >= MaxCollisionPairs) {
+			if (pairs.size() > MaxCollisionPairs) {
 				return 0;
 			}
 

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
@@ -219,7 +219,7 @@ namespace hdt
 			CollisionChecker<T, SwapResults>(std::forward<Ts>(ts)...)
 		{}
 
-		// We intentionally don't use a 'Dynamic 1D Sweep and Prune Algorithm' here. 
+		// We intentionally don't use a 'Dynamic 1D Sweep and Prune Algorithm' here.
 		// O(N*M) is nearly always faster or within a margin of error. Not worth the extra boilerplate code
 		void dispatch(ColliderTree* a, ColliderTree* b, std::vector<Aabb*>& listA, std::vector<Aabb*>& listB, const Aabb& refinedBForPruningA)
 		{

--- a/src/hdtSkyrimPhysicsWorld.cpp
+++ b/src/hdtSkyrimPhysicsWorld.cpp
@@ -52,6 +52,7 @@ namespace hdt
 		// SOLVER_SIMD nets a small performance uplift
 		// SOLVER_RANDMIZE_ORDER is also possible, but I clocked a pretty heavy performance hit. Maybe make it a config option
 		getSolverInfo().m_solverMode = SOLVER_SIMD;
+		getSolverInfo().m_leastSquaresResidualThreshold = 0.0001f;
 
 		m_averageInterval = m_timeTick;
 		m_accumulatedInterval = 0;


### PR DESCRIPTION
This does the following:

- Prevents complex collisions (Like two actors being stuck inside eachother) from exploding, or just consuming tons of CPU. We don't have the capability to even solve these collisions, so might as well just early exit. 4024 is a very high number. Very complex SMP outfits will usually never exceed 2,000.
- `m_leastSquaresResidualThreshold` tells Bullet that it's allowed to early exit if iterations stop making `movements > m_leastSquaresResidualThreshold ` - This is likely 0.0 by default for very complex shapes, but our system is so basic it'll likely never produce a false early-exit. I only really noticed early exits beyond ~12+ iterations so it's not going to make a MASSIVE change for the average user. However if you're running at 128 iterations, it's light and day. 
- Removed my old "1D Sweep and Prune.." comment. I had tested that algorithm for more complex collisions, but the net performance gain was noisy and pointless given the extra boilerplate code. Must of forgot to remove the comment.
- Improved the metrics for processCollision, so now we actually know the total cpu time spent rather than just the wait period. 
- I stopped accumulating all forces in the depth code. Since this is only for one pair, and we only make one contact point, it really doesn't seem to help much with physics stability. My original goal was to allow some level of normalization, but that seems to have backfired in times when the collision is a bit too complicated. Might as well simplify it
- Removed the listA.erase(... - it's better to just skip rather than physically removing entries from a vector. Saves on a lot of overhead. 

**Testing**:

- [x] Fixes predator's reported problem with breasts twisting up
- [ ] Does not produce additional clipping
- [ ] Does not produce additional jitter
- [ ] Does not cause performance regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Introduced a cap on reported collision pairs and early-exit guards to keep processing bounded.
  * Improved collision filtering/pruning so fewer unnecessary pair checks reach narrowphase.

* **Bug Fixes**
  * Prevented contact accumulation cancellations by skipping opposing contributions.

* **Stability**
  * Tuned physics solver termination threshold for more consistent accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->