### PR TITLE
feat: Add 'smp profile' to toggle profiling on/off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,25 +36,6 @@ set(BUILD_TESTS OFF)
 # default definitions
 add_definitions(-DBT_USE_SSE_IN_API)
 
-if(CMAKE_CONFIGURATION_TYPES AND NOT "Profile" IN_LIST CMAKE_CONFIGURATION_TYPES)
-	list(APPEND CMAKE_CONFIGURATION_TYPES Profile)
-	set(CMAKE_CONFIGURATION_TYPES
-		"${CMAKE_CONFIGURATION_TYPES}"
-		CACHE STRING "" FORCE)
-endif()
-foreach(_lang IN ITEMS C CXX)
-	set(CMAKE_${_lang}_FLAGS_PROFILE
-		"${CMAKE_${_lang}_FLAGS_RELEASE}"
-		CACHE STRING "" FORCE)
-endforeach()
-foreach(_kind IN ITEMS EXE SHARED MODULE STATIC)
-	set(CMAKE_${_kind}_LINKER_FLAGS_PROFILE
-		"${CMAKE_${_kind}_LINKER_FLAGS_RELEASE}"
-		CACHE STRING "" FORCE)
-endforeach()
-set(CMAKE_MAP_IMPORTED_CONFIG_PROFILE Release RelWithDebInfo MinSizeRel "")
-add_compile_definitions("$<$<CONFIG:Profile>:BT_ENABLE_PROFILE>")
-
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 add_subdirectory(src)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -208,12 +208,6 @@
       "displayName": "Release",
       "configurePreset": "vs2022-windows-avx2",
       "configuration": "Release"
-    },
-    {
-      "name": "avx2-profile",
-      "displayName": "Profile",
-      "configurePreset": "vs2022-windows-avx2",
-      "configuration": "Profile"
     }
   ],
   "version": 3

--- a/cmake/ports/bullet3/portfile.cmake
+++ b/cmake/ports/bullet3/portfile.cmake
@@ -101,6 +101,44 @@ string(
 			THREADS_CPP "${THREADS_CPP}")
 file(WRITE "${SOURCE_PATH}/src/LinearMath/btThreads.cpp" "${THREADS_CPP}")
 
+# Runtime profiler gate. Bullet still compiles the profiler support, but disabled BT_PROFILE scopes become a cheap
+# inline bool check instead of two indirect calls into empty profile callbacks.
+file(READ "${SOURCE_PATH}/src/LinearMath/btQuickprof.h" QUICKPROF_HEADER)
+string(
+	REPLACE
+		"void btSetCustomLeaveProfileZoneFunc(btLeaveProfileZoneFunc* leaveFunc);\n\n#ifndef BT_ENABLE_PROFILE"
+		"void btSetCustomLeaveProfileZoneFunc(btLeaveProfileZoneFunc* leaveFunc);\n\nvoid btEnterProfileZone(const char* name);\nvoid btLeaveProfileZone();\n\nextern bool gBtProfileEnabled;\nvoid btSetProfileEnabled(bool enabled);\nbool btGetProfileEnabled();\nSIMD_FORCE_INLINE bool btIsProfileEnabled()\n{\n\treturn gBtProfileEnabled;\n}\n\n#ifndef BT_ENABLE_PROFILE"
+		QUICKPROF_HEADER
+		"${QUICKPROF_HEADER}")
+string(
+	REPLACE
+		"void btSetCustomLeaveProfileZoneFunc(btLeaveProfileZoneFunc* leaveFunc);\n\nextern bool gBtProfileEnabled;"
+		"void btSetCustomLeaveProfileZoneFunc(btLeaveProfileZoneFunc* leaveFunc);\n\nvoid btEnterProfileZone(const char* name);\nvoid btLeaveProfileZone();\n\nextern bool gBtProfileEnabled;"
+		QUICKPROF_HEADER
+		"${QUICKPROF_HEADER}")
+string(
+	REPLACE
+		"class CProfileSample\n{\npublic:\n\tCProfileSample(const char* name);\n\n\t~CProfileSample(void);\n};"
+		"class CProfileSample\n{\npublic:\n\tCProfileSample(const char* name) :\n\t\tm_enabled(btIsProfileEnabled())\n\t{\n\t\tif (m_enabled)\n\t\t{\n\t\t\tbtEnterProfileZone(name);\n\t\t}\n\t}\n\n\t~CProfileSample(void)\n\t{\n\t\tif (m_enabled)\n\t\t{\n\t\t\tbtLeaveProfileZone();\n\t\t}\n\t}\n\nprivate:\n\tbool m_enabled;\n};"
+		QUICKPROF_HEADER
+		"${QUICKPROF_HEADER}")
+file(WRITE "${SOURCE_PATH}/src/LinearMath/btQuickprof.h" "${QUICKPROF_HEADER}")
+
+file(READ "${SOURCE_PATH}/src/LinearMath/btQuickprof.cpp" QUICKPROF_CPP)
+string(
+	REPLACE
+		"static btEnterProfileZoneFunc* bts_enterFunc = btEnterProfileZoneDefault;\nstatic btLeaveProfileZoneFunc* bts_leaveFunc = btLeaveProfileZoneDefault;"
+		"bool gBtProfileEnabled = false;\n\nstatic btEnterProfileZoneFunc* bts_enterFunc = btEnterProfileZoneDefault;\nstatic btLeaveProfileZoneFunc* bts_leaveFunc = btLeaveProfileZoneDefault;"
+		QUICKPROF_CPP
+		"${QUICKPROF_CPP}")
+string(
+	REPLACE
+		"void btSetCustomLeaveProfileZoneFunc(btLeaveProfileZoneFunc* leaveFunc)\n{\n\tbts_leaveFunc = leaveFunc;\n}\n\nCProfileSample::CProfileSample(const char* name)\n{\n\tbtEnterProfileZone(name);\n}\n\nCProfileSample::~CProfileSample(void)\n{\n\tbtLeaveProfileZone();\n}\n"
+		"void btSetCustomLeaveProfileZoneFunc(btLeaveProfileZoneFunc* leaveFunc)\n{\n\tbts_leaveFunc = leaveFunc;\n}\n\nvoid btSetProfileEnabled(bool enabled)\n{\n\tgBtProfileEnabled = enabled;\n}\n\nbool btGetProfileEnabled()\n{\n\treturn gBtProfileEnabled;\n}\n"
+		QUICKPROF_CPP
+		"${QUICKPROF_CPP}")
+file(WRITE "${SOURCE_PATH}/src/LinearMath/btQuickprof.cpp" "${QUICKPROF_CPP}")
+
 file(REMOVE_RECURSE "${SOURCE_PATH}/examples/ThirdPartyLibs")
 
 vcpkg_check_features(
@@ -141,13 +179,10 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" USE_MSVC_RUNTIME_LIBRARY_D
 string(APPEND VCPKG_CXX_FLAGS " /DBT_USE_SSE_IN_API")
 string(APPEND VCPKG_C_FLAGS " /DBT_USE_SSE_IN_API")
 
-# This builds with profiling permanently enabled - however since we gate the stubs in hdtSkyrimPhysicsWorld.cpp it has
-# virtually no performance impact. The profile function would just be empty The only thing /DBT_ENABLE_PROFILE does is
-# compile the CProfileManager classes into the .lib
-if("profile" IN_LIST FEATURES)
-	string(APPEND VCPKG_CXX_FLAGS " /DBT_ENABLE_PROFILE")
-	string(APPEND VCPKG_C_FLAGS " /DBT_ENABLE_PROFILE")
-endif()
+# Build Bullet's profiler symbols into every configuration. Runtime profiling stays disabled by default through the
+# btQuickprof gate above, so normal builds only pay the inline bool check in BT_PROFILE scopes.
+string(APPEND VCPKG_CXX_FLAGS " /DBT_ENABLE_PROFILE")
+string(APPEND VCPKG_C_FLAGS " /DBT_ENABLE_PROFILE")
 
 vcpkg_cmake_configure(
 	SOURCE_PATH

--- a/cmake/ports/bullet3/vcpkg.json
+++ b/cmake/ports/bullet3/vcpkg.json
@@ -33,6 +33,9 @@
       "description": "Build Bullet3OpenCL_clew library",
       "supports": "!uwp"
     },
+    "profile": {
+      "description": "Compatibility no-op; hdtSMP64 always builds Bullet profiling support with a runtime gate."
+    },
     "rtti": {
       "description": "Enable RTTI on windows"
     }

--- a/cmake/ports/bullet3/vcpkg.json
+++ b/cmake/ports/bullet3/vcpkg.json
@@ -33,9 +33,6 @@
       "description": "Build Bullet3OpenCL_clew library",
       "supports": "!uwp"
     },
-    "profile": {
-      "description": "Compile Bullet with BT_ENABLE_PROFILE so CProfileNode/CProfileManager symbols are available to consumers"
-    },
     "rtti": {
       "description": "Enable RTTI on windows"
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -14,8 +14,7 @@ namespace hdt
 			case XMLReader::Inspected::StartTag:
 				if (reader.GetLocalName() == "numIterations") {
 					SkyrimPhysicsWorld::get()->getSolverInfo().m_numIterations = btClamped(reader.readInt(), 4, 128);
-				}
-				else if (reader.GetLocalName() == "erp") {
+				} else if (reader.GetLocalName() == "erp") {
 					SkyrimPhysicsWorld::get()->getSolverInfo().m_erp = btClamped(reader.readFloat(), 0.01f, 1.0f);
 				} else if (reader.GetLocalName() == "min-fps") {
 					SkyrimPhysicsWorld::get()->min_fps = (btClamped(reader.readInt(), 1, 300));

--- a/src/hdtPhysicsProfiler.cpp
+++ b/src/hdtPhysicsProfiler.cpp
@@ -18,507 +18,518 @@ namespace hdt::physicsprofiler
 {
 	using Clock = std::chrono::steady_clock;
 
-	struct Node
+	namespace
 	{
-		std::string m_name;
-		std::uint64_t m_totalNs{};
-		std::uint64_t m_calls{};
-		std::vector<std::unique_ptr<Node>> m_children;
-
-		explicit Node(std::string a_name) :
-			m_name(std::move(a_name))
-		{}
-
-		Node& child(std::string_view a_name)
+		struct DumpOptions
 		{
-			if (auto it = std::ranges::find_if(m_children, [&](const auto& a_entry) { return a_entry->m_name == a_name; }); it != m_children.end()) {
-				return **it;
+			double m_minScopeMs = 0.001;
+			std::uint32_t m_maxDepth = 64;
+			std::uint32_t m_flatLimit = 32;
+			bool m_logTree = true;
+			bool m_logFlat = true;
+			bool m_logThreads = true;
+		};
+
+		struct Node
+		{
+			std::string m_name;
+			std::uint64_t m_totalNs{};
+			std::uint64_t m_calls{};
+			std::vector<std::unique_ptr<Node>> m_children;
+
+			explicit Node(std::string a_name) :
+				m_name(std::move(a_name))
+			{}
+
+			Node& child(std::string_view a_name)
+			{
+				if (auto it = std::ranges::find_if(m_children, [&](const auto& a_entry) { return a_entry->m_name == a_name; }); it != m_children.end()) {
+					return **it;
+				}
+
+				m_children.emplace_back(std::make_unique<Node>(std::string(a_name)));
+				return *m_children.back();
 			}
 
-			m_children.emplace_back(std::make_unique<Node>(std::string(a_name)));
-			return *m_children.back();
-		}
+			void resetStats()
+			{
+				m_totalNs = 0;
+				m_calls = 0;
 
-		void resetStats()
-		{
-			m_totalNs = 0;
-			m_calls = 0;
-
-			for (auto& child : m_children) {
-				child->resetStats();
+				for (auto& child : m_children) {
+					child->resetStats();
+				}
 			}
-		}
-	};
+		};
 
-	struct Frame
-	{
-		Node* m_node{};
-		Clock::time_point m_start{};
-	};
-
-	struct ThreadState
-	{
-		std::uint32_t m_index{};
-		Node m_root{ "Root" };
-		std::vector<Frame> m_stack;
-
-		explicit ThreadState(std::uint32_t a_index) :
-			m_index(a_index)
-		{}
-	};
-
-	struct AggregateNode
-	{
-		std::string m_name;
-		std::uint64_t m_totalNs{};
-		std::uint64_t m_calls{};
-		std::vector<std::unique_ptr<AggregateNode>> m_children;
-
-		explicit AggregateNode(std::string a_name) :
-			m_name(std::move(a_name))
-		{}
-
-		AggregateNode& child(std::string_view a_name)
+		struct Frame
 		{
-			if (auto it = std::ranges::find_if(m_children, [&](const auto& a_entry) { return a_entry->m_name == a_name; }); it != m_children.end()) {
-				return **it;
+			Node* m_node{};
+			Clock::time_point m_start{};
+		};
+
+		struct ThreadState
+		{
+			std::uint32_t m_index{};
+			Node m_root{ "Root" };
+			std::vector<Frame> m_stack;
+
+			explicit ThreadState(std::uint32_t a_index) :
+				m_index(a_index)
+			{}
+		};
+
+		struct AggregateNode
+		{
+			std::string m_name;
+			std::uint64_t m_totalNs{};
+			std::uint64_t m_calls{};
+			std::vector<std::unique_ptr<AggregateNode>> m_children;
+
+			explicit AggregateNode(std::string a_name) :
+				m_name(std::move(a_name))
+			{}
+
+			AggregateNode& child(std::string_view a_name)
+			{
+				if (auto it = std::ranges::find_if(m_children, [&](const auto& a_entry) { return a_entry->m_name == a_name; }); it != m_children.end()) {
+					return **it;
+				}
+
+				m_children.emplace_back(std::make_unique<AggregateNode>(std::string(a_name)));
+				return *m_children.back();
+			}
+		};
+
+		struct FlatRow
+		{
+			std::string m_name;
+			std::uint64_t m_totalNs{};
+			std::uint64_t m_calls{};
+		};
+
+		struct ThreadRow
+		{
+			std::uint32_t m_index{};
+			std::uint64_t m_totalNs{};
+			std::uint64_t m_calls{};
+		};
+
+		std::mutex g_threadsLock;
+		std::vector<std::unique_ptr<ThreadState>> g_threads;
+		std::atomic_uint32_t g_nextThreadIndex{ 0 };
+		std::atomic_uint32_t g_activeScopes{ 0 };
+		std::uint64_t g_windowFrames{ 0 };
+		std::uint64_t g_totalFrames{ 0 };
+		std::uint64_t g_sampleWindowFrames{ 0 };
+		bool g_captureEnabled = false;
+		std::uint64_t g_printIntervalFrames = 0;
+		Clock::time_point g_windowStart = Clock::now();
+
+		thread_local ThreadState* g_threadState = nullptr;
+
+		void enter(const char* a_name) noexcept;
+		void leave() noexcept;
+
+		void emptyEnter(const char*) noexcept
+		{}
+
+		void emptyLeave() noexcept
+		{}
+
+		double nsToMs(std::uint64_t a_ns)
+		{
+			return static_cast<double>(a_ns) / 1'000'000.0;
+		}
+
+		std::uint64_t elapsedNs(Clock::time_point a_start, Clock::time_point a_end)
+		{
+			return static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(a_end - a_start).count());
+		}
+
+		ThreadState& getThreadState()
+		{
+			if (g_threadState) {
+				return *g_threadState;
 			}
 
-			m_children.emplace_back(std::make_unique<AggregateNode>(std::string(a_name)));
-			return *m_children.back();
-		}
-	};
+			auto threadState = std::make_unique<ThreadState>(g_nextThreadIndex.fetch_add(1, std::memory_order_relaxed));
+			g_threadState = threadState.get();
 
-	struct FlatRow
-	{
-		std::string m_name;
-		std::uint64_t m_totalNs{};
-		std::uint64_t m_calls{};
-	};
+			std::scoped_lock lock(g_threadsLock);
+			g_threads.emplace_back(std::move(threadState));
 
-	struct ThreadRow
-	{
-		std::uint32_t m_index{};
-		std::uint64_t m_totalNs{};
-		std::uint64_t m_calls{};
-	};
-
-	static std::mutex g_threadsLock;
-	static std::vector<std::unique_ptr<ThreadState>> g_threads;
-	static std::atomic_uint32_t g_nextThreadIndex{ 0 };
-	static std::atomic_uint32_t g_activeScopes{ 0 };
-	static std::atomic_uint64_t g_windowFrames{ 0 };
-	static std::atomic_uint64_t g_totalFrames{ 0 };
-	static std::atomic_uint64_t g_profileHistory{ 0 };
-	static Clock::time_point g_windowStart = Clock::now();
-
-	static thread_local ThreadState* g_threadState = nullptr;
-
-	static void emptyEnter(const char*) noexcept
-	{}
-
-	static void emptyLeave() noexcept
-	{}
-
-	static double nsToMs(std::uint64_t a_ns)
-	{
-		return static_cast<double>(a_ns) / 1'000'000.0;
-	}
-
-	static std::uint64_t elapsedNs(Clock::time_point a_start, Clock::time_point a_end)
-	{
-		return static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(a_end - a_start).count());
-	}
-
-	static ThreadState& getThreadState()
-	{
-		if (g_threadState) {
 			return *g_threadState;
 		}
 
-		auto threadState = std::make_unique<ThreadState>(g_nextThreadIndex.fetch_add(1, std::memory_order_relaxed));
-		g_threadState = threadState.get();
-
-		std::scoped_lock lock(g_threadsLock);
-		g_threads.emplace_back(std::move(threadState));
-
-		return *g_threadState;
-	}
-
-	static std::uint64_t getChildTotal(const Node& a_node)
-	{
-		std::uint64_t total = 0;
-
-		for (const auto& child : a_node.m_children) {
-			total += child->m_totalNs;
-		}
-
-		return total;
-	}
-
-	static std::uint64_t getChildCalls(const Node& a_node)
-	{
-		std::uint64_t calls = 0;
-
-		for (const auto& child : a_node.m_children) {
-			calls += child->m_calls;
-		}
-
-		return calls;
-	}
-
-	static std::uint64_t getChildTotal(const AggregateNode& a_node)
-	{
-		std::uint64_t total = 0;
-
-		for (const auto& child : a_node.m_children) {
-			total += child->m_totalNs;
-		}
-
-		return total;
-	}
-
-	static void mergeNode(AggregateNode& a_dst, const Node& a_src)
-	{
-		a_dst.m_totalNs += a_src.m_totalNs;
-		a_dst.m_calls += a_src.m_calls;
-
-		for (const auto& child : a_src.m_children) {
-			mergeNode(a_dst.child(child->m_name), *child);
-		}
-	}
-
-	static void mergeRoot(AggregateNode& a_dst, const Node& a_root)
-	{
-		for (const auto& child : a_root.m_children) {
-			mergeNode(a_dst.child(child->m_name), *child);
-		}
-	}
-
-	static void addFlatRows(std::unordered_map<std::string, FlatRow>& a_rows, const AggregateNode& a_node)
-	{
-		if (a_node.m_name != "Recorded CPU") {
-			auto& row = a_rows[a_node.m_name];
-			row.m_name = a_node.m_name;
-			row.m_totalNs += a_node.m_totalNs;
-			row.m_calls += a_node.m_calls;
-		}
-
-		for (const auto& child : a_node.m_children) {
-			addFlatRows(a_rows, *child);
-		}
-	}
-
-	static void logRow(std::string_view a_scope, std::uint64_t a_ns, std::uint64_t a_parentNs, std::uint64_t a_calls, std::uint64_t a_frames)
-	{
-		const auto totalMs = nsToMs(a_ns);
-		const auto msPerFrame = a_frames > 0 ? totalMs / static_cast<double>(a_frames) : 0.0;
-		const auto msPerCall = a_calls > 0 ? totalMs / static_cast<double>(a_calls) : 0.0;
-		const auto pct = a_parentNs > 0 ? static_cast<double>(a_ns) * 100.0 / static_cast<double>(a_parentNs) : 0.0;
-
-		if (a_calls > 0) {
-			logger::info("{:<80} {:>12.3f} ms {:>10.3f} ms/frame {:>10.3f} ms/call {:>8.2f}% {:>8}", a_scope, totalMs, msPerFrame, msPerCall, pct, a_calls);
-		} else {
-			logger::info("{:<80} {:>12.3f} ms {:>10.3f} ms/frame {:>17} {:>8.2f}% {:>8}", a_scope, totalMs, msPerFrame, "-", pct, "-");
-		}
-	}
-
-	static void logTreeRecursive(const AggregateNode& a_node, std::string a_prefix, std::uint32_t a_depth, std::uint64_t a_frames, const DumpOptions& a_options)
-	{
-		if (a_depth >= a_options.m_maxDepth) {
-			return;
-		}
-
-		std::vector<const AggregateNode*> children;
-		children.reserve(a_node.m_children.size());
-
-		for (const auto& child : a_node.m_children) {
-			if (nsToMs(child->m_totalNs) >= a_options.m_minScopeMs) {
-				children.emplace_back(child.get());
-			}
-		}
-
-		std::ranges::sort(children, [](const auto* a_lhs, const auto* a_rhs) {
-			return a_lhs->m_totalNs > a_rhs->m_totalNs;
-		});
-
-		for (std::size_t i = 0; i < children.size(); ++i) {
-			const auto* child = children[i];
-			const bool last = i + 1 == children.size();
-			const auto scope = a_prefix + (last ? "`-- " : "|-- ") + child->m_name;
-
-			logRow(scope, child->m_totalNs, a_node.m_totalNs, child->m_calls, a_frames);
-			logTreeRecursive(*child, a_prefix + (last ? "    " : "|   "), a_depth + 1, a_frames, a_options);
-		}
-
-		if (a_node.m_name == "Recorded CPU") {
-			return;
-		}
-
-		const auto accounted = getChildTotal(a_node);
-
-		if (a_node.m_totalNs > accounted) {
-			const auto self = a_node.m_totalNs - accounted;
-
-			if (nsToMs(self) >= a_options.m_minScopeMs) {
-				logRow(a_prefix + "`-- [self]", self, a_node.m_totalNs, 0, a_frames);
-			}
-		}
-	}
-
-	static void logTreeHeader(const AggregateNode& a_root, std::uint64_t a_frames, Clock::time_point a_windowStart)
-	{
-		const auto wallNs = elapsedNs(a_windowStart, Clock::now());
-		const auto wallMs = nsToMs(wallNs);
-		const auto cpuMs = nsToMs(a_root.m_totalNs);
-		const auto parallelism = wallNs > 0 ? static_cast<double>(a_root.m_totalNs) / static_cast<double>(wallNs) : 0.0;
-
-		logger::info("Physics profile: {} frames, {:.3f} ms wall, {:.3f} ms recorded CPU, {:.2f}x recorded parallelism", a_frames, wallMs, cpuMs, parallelism);
-		logger::info("{:<80} {:>16} {:>18} {:>18} {:>9} {:>8}", "Scope", "Total CPU", "Avg/frame", "Avg/call", "Parent%", "Calls");
-		logger::info("{:-<154}", "");
-
-		logRow("Recorded CPU", a_root.m_totalNs, a_root.m_totalNs, 0, a_frames);
-	}
-
-	static void logFlatRows(const AggregateNode& a_root, std::uint64_t a_frames, const DumpOptions& a_options)
-	{
-		std::unordered_map<std::string, FlatRow> map;
-		addFlatRows(map, a_root);
-
-		std::vector<FlatRow> rows;
-		rows.reserve(map.size());
-
-		for (auto& [name, row] : map) {
-			if (nsToMs(row.m_totalNs) >= a_options.m_minScopeMs) {
-				rows.emplace_back(std::move(row));
-			}
-		}
-
-		std::ranges::sort(rows, [](const auto& a_lhs, const auto& a_rhs) {
-			return a_lhs.m_totalNs > a_rhs.m_totalNs;
-		});
-
-		logger::info("Physics profile flat hotspots");
-		logger::info("{:<60} {:>12} {:>18} {:>18} {:>8}", "Scope", "Total CPU", "Avg/frame", "Avg/call", "Calls");
-		logger::info("{:-<122}", "");
-
-		for (std::size_t i = 0; i < std::min<std::size_t>(rows.size(), a_options.m_flatLimit); ++i) {
-			const auto& row = rows[i];
-			const auto totalMs = nsToMs(row.m_totalNs);
-			const auto msPerFrame = a_frames > 0 ? totalMs / static_cast<double>(a_frames) : 0.0;
-			const auto msPerCall = row.m_calls > 0 ? totalMs / static_cast<double>(row.m_calls) : 0.0;
-
-			logger::info("{:<60} {:>10.3f} ms {:>10.3f} ms/frame {:>10.3f} ms/call {:>8}", row.m_name, totalMs, msPerFrame, msPerCall, row.m_calls);
-		}
-	}
-
-	static void logThreads(std::vector<ThreadRow>& a_rows, std::uint64_t a_frames)
-	{
-		std::ranges::sort(a_rows, [](const auto& a_lhs, const auto& a_rhs) {
-			return a_lhs.m_totalNs > a_rhs.m_totalNs;
-		});
-
-		logger::info("Physics profile threads");
-		logger::info("{:<12} {:>12} {:>18} {:>8}", "Thread", "Total CPU", "Avg/frame", "Calls");
-		logger::info("{:-<62}", "");
-
-		for (const auto& row : a_rows) {
-			const auto totalMs = nsToMs(row.m_totalNs);
-			const auto msPerFrame = a_frames > 0 ? totalMs / static_cast<double>(a_frames) : 0.0;
-
-			logger::info("T{:<10} {:>10.3f} ms {:>10.3f} ms/frame {:>8}", row.m_index, totalMs, msPerFrame, row.m_calls);
-		}
-	}
-
-	static void resetUnlocked(bool a_resetTotalFrames)
-	{
-		for (auto& thread : g_threads) {
-			thread->m_root.resetStats();
-			thread->m_stack.clear();
-		}
-
-		g_windowFrames.store(0, std::memory_order_relaxed);
-
-		if (a_resetTotalFrames) {
-			g_totalFrames.store(0, std::memory_order_relaxed);
-		}
-
-		g_windowStart = Clock::now();
-	}
-
-	void install()
-	{
+		std::uint64_t getChildTotal(const Node& a_node)
 		{
-			std::scoped_lock lock(g_threadsLock);
-			resetUnlocked(true);
+			std::uint64_t total = 0;
+
+			for (const auto& child : a_node.m_children) {
+				total += child->m_totalNs;
+			}
+
+			return total;
 		}
 
-		btSetCustomEnterProfileZoneFunc(&enter);
-		btSetCustomLeaveProfileZoneFunc(&leave);
-	}
+		std::uint64_t getChildCalls(const Node& a_node)
+		{
+			std::uint64_t calls = 0;
 
-	void uninstall()
-	{
-		btSetCustomEnterProfileZoneFunc(&emptyEnter);
-		btSetCustomLeaveProfileZoneFunc(&emptyLeave);
-	}
+			for (const auto& child : a_node.m_children) {
+				calls += child->m_calls;
+			}
 
-	void enter(const char* a_name) noexcept
-	{
-		if (!a_name) {
-			return;
+			return calls;
 		}
 
-		g_activeScopes.fetch_add(1, std::memory_order_acq_rel);
+		std::uint64_t getChildTotal(const AggregateNode& a_node)
+		{
+			std::uint64_t total = 0;
 
-		try {
-			auto& thread = getThreadState();
-			auto& parent = thread.m_stack.empty() ? thread.m_root : *thread.m_stack.back().m_node;
-			auto& node = parent.child(a_name);
+			for (const auto& child : a_node.m_children) {
+				total += child->m_totalNs;
+			}
 
-			++node.m_calls;
-			thread.m_stack.emplace_back(&node, Clock::now());
-		} catch (...) {
-			g_activeScopes.fetch_sub(1, std::memory_order_acq_rel);
+			return total;
 		}
-	}
 
-	void leave() noexcept
-	{
-		try {
-			auto* thread = g_threadState;
+		void mergeNode(AggregateNode& a_dst, const Node& a_src)
+		{
+			a_dst.m_totalNs += a_src.m_totalNs;
+			a_dst.m_calls += a_src.m_calls;
 
-			if (!thread || thread->m_stack.empty()) {
+			for (const auto& child : a_src.m_children) {
+				mergeNode(a_dst.child(child->m_name), *child);
+			}
+		}
+
+		void mergeRoot(AggregateNode& a_dst, const Node& a_root)
+		{
+			for (const auto& child : a_root.m_children) {
+				mergeNode(a_dst.child(child->m_name), *child);
+			}
+		}
+
+		void addFlatRows(std::unordered_map<std::string, FlatRow>& a_rows, const AggregateNode& a_node)
+		{
+			if (a_node.m_name != "Recorded CPU") {
+				auto& row = a_rows[a_node.m_name];
+				row.m_name = a_node.m_name;
+				row.m_totalNs += a_node.m_totalNs;
+				row.m_calls += a_node.m_calls;
+			}
+
+			for (const auto& child : a_node.m_children) {
+				addFlatRows(a_rows, *child);
+			}
+		}
+
+		void logRow(std::string_view a_scope, std::uint64_t a_ns, std::uint64_t a_parentNs, std::uint64_t a_calls, std::uint64_t a_frames)
+		{
+			const auto totalMs = nsToMs(a_ns);
+			const auto msPerFrame = a_frames > 0 ? totalMs / static_cast<double>(a_frames) : 0.0;
+			const auto msPerCall = a_calls > 0 ? totalMs / static_cast<double>(a_calls) : 0.0;
+			const auto pct = a_parentNs > 0 ? static_cast<double>(a_ns) * 100.0 / static_cast<double>(a_parentNs) : 0.0;
+
+			if (a_calls > 0) {
+				logger::info("{:<80} {:>12.3f} ms {:>10.3f} ms/frame {:>10.3f} ms/call {:>8.2f}% {:>8}", a_scope, totalMs, msPerFrame, msPerCall, pct, a_calls);
+			} else {
+				logger::info("{:<80} {:>12.3f} ms {:>10.3f} ms/frame {:>17} {:>8.2f}% {:>8}", a_scope, totalMs, msPerFrame, "-", pct, "-");
+			}
+		}
+
+		void logTreeRecursive(const AggregateNode& a_node, std::string a_prefix, std::uint32_t a_depth, std::uint64_t a_frames, const DumpOptions& a_options)
+		{
+			if (a_depth >= a_options.m_maxDepth) {
 				return;
 			}
 
-			const auto now = Clock::now();
-			const auto frame = thread->m_stack.back();
+			std::vector<const AggregateNode*> children;
+			children.reserve(a_node.m_children.size());
 
-			thread->m_stack.pop_back();
-			frame.m_node->m_totalNs += elapsedNs(frame.m_start, now);
-
-			g_activeScopes.fetch_sub(1, std::memory_order_acq_rel);
-		} catch (...) {
-		}
-	}
-
-	void endFrame()
-	{
-		g_windowFrames.fetch_add(1, std::memory_order_relaxed);
-		g_totalFrames.fetch_add(1, std::memory_order_relaxed);
-	}
-
-	std::uint64_t frameCountSinceReset()
-	{
-		return g_windowFrames.load(std::memory_order_relaxed);
-	}
-
-	std::uint64_t totalFrameCount()
-	{
-		return g_totalFrames.load(std::memory_order_relaxed);
-	}
-
-	void setProfileHistory(std::uint64_t a_frames)
-	{
-		g_profileHistory.store(a_frames, std::memory_order_relaxed);
-	}
-
-	std::uint64_t getProfileHistory()
-	{
-		return g_profileHistory.load(std::memory_order_relaxed);
-	}
-
-	bool reset()
-	{
-		if (g_activeScopes.load(std::memory_order_acquire) != 0) {
-			return false;
-		}
-
-		std::scoped_lock lock(g_threadsLock);
-		resetUnlocked(true);
-
-		return true;
-	}
-
-	bool dumpAndReset(const DumpOptions& a_options)
-	{
-		const auto activeScopes = g_activeScopes.load(std::memory_order_acquire);
-
-		if (activeScopes != 0) {  // Just debug in case we fucked up somewhere
-			logger::warn("Physics profile dump skipped because {} profile scopes are still active", activeScopes);
-			return false;
-		}
-
-		AggregateNode root{ "Recorded CPU" };
-		std::vector<ThreadRow> threads;
-		std::uint64_t frames = 0;
-		Clock::time_point windowStart;
-
-		{
-			std::scoped_lock lock(g_threadsLock);
-
-			frames = std::max<std::uint64_t>(1, g_windowFrames.load(std::memory_order_relaxed));
-			windowStart = g_windowStart;
-
-			for (const auto& thread : g_threads) {
-				const auto total = getChildTotal(thread->m_root);
-				const auto calls = getChildCalls(thread->m_root);
-
-				if (total == 0 && calls == 0) {
-					continue;
+			for (const auto& child : a_node.m_children) {
+				if (nsToMs(child->m_totalNs) >= a_options.m_minScopeMs) {
+					children.emplace_back(child.get());
 				}
-
-				threads.emplace_back(thread->m_index, total, calls);
-				mergeRoot(root, thread->m_root);
 			}
 
-			root.m_totalNs = getChildTotal(root);
-			resetUnlocked(false);
+			std::ranges::sort(children, [](const auto* a_lhs, const auto* a_rhs) {
+				return a_lhs->m_totalNs > a_rhs->m_totalNs;
+			});
+
+			for (std::size_t i = 0; i < children.size(); ++i) {
+				const auto* child = children[i];
+				const bool last = i + 1 == children.size();
+				const auto scope = a_prefix + (last ? "`-- " : "|-- ") + child->m_name;
+
+				logRow(scope, child->m_totalNs, a_node.m_totalNs, child->m_calls, a_frames);
+				logTreeRecursive(*child, a_prefix + (last ? "    " : "|   "), a_depth + 1, a_frames, a_options);
+			}
+
+			if (a_node.m_name == "Recorded CPU") {
+				return;
+			}
+
+			const auto accounted = getChildTotal(a_node);
+
+			if (a_node.m_totalNs > accounted) {
+				const auto self = a_node.m_totalNs - accounted;
+
+				if (nsToMs(self) >= a_options.m_minScopeMs) {
+					logRow(a_prefix + "`-- [self]", self, a_node.m_totalNs, 0, a_frames);
+				}
+			}
 		}
 
-		if (root.m_totalNs == 0) {
-			logger::info("Physics profile had no recorded scopes");
+		void logTreeHeader(const AggregateNode& a_root, std::uint64_t a_frames, Clock::time_point a_windowStart)
+		{
+			const auto wallNs = elapsedNs(a_windowStart, Clock::now());
+			const auto wallMs = nsToMs(wallNs);
+			const auto cpuMs = nsToMs(a_root.m_totalNs);
+			const auto parallelism = wallNs > 0 ? static_cast<double>(a_root.m_totalNs) / static_cast<double>(wallNs) : 0.0;
+
+			logger::info("Physics profile: {} frames, {:.3f} ms wall, {:.3f} ms recorded CPU, {:.2f}x recorded parallelism", a_frames, wallMs, cpuMs, parallelism);
+			logger::info("{:<80} {:>16} {:>18} {:>18} {:>9} {:>8}", "Scope", "Total CPU", "Avg/frame", "Avg/call", "Parent%", "Calls");
+			logger::info("{:-<154}", "");
+
+			logRow("Recorded CPU", a_root.m_totalNs, a_root.m_totalNs, 0, a_frames);
+		}
+
+		void logFlatRows(const AggregateNode& a_root, std::uint64_t a_frames, const DumpOptions& a_options)
+		{
+			std::unordered_map<std::string, FlatRow> map;
+			addFlatRows(map, a_root);
+
+			std::vector<FlatRow> rows;
+			rows.reserve(map.size());
+
+			for (auto& [name, row] : map) {
+				if (nsToMs(row.m_totalNs) >= a_options.m_minScopeMs) {
+					rows.emplace_back(std::move(row));
+				}
+			}
+
+			std::ranges::sort(rows, [](const auto& a_lhs, const auto& a_rhs) {
+				return a_lhs.m_totalNs > a_rhs.m_totalNs;
+			});
+
+			logger::info("Physics profile flat hotspots");
+			logger::info("{:<60} {:>12} {:>18} {:>18} {:>8}", "Scope", "Total CPU", "Avg/frame", "Avg/call", "Calls");
+			logger::info("{:-<122}", "");
+
+			for (std::size_t i = 0; i < std::min<std::size_t>(rows.size(), a_options.m_flatLimit); ++i) {
+				const auto& row = rows[i];
+				const auto totalMs = nsToMs(row.m_totalNs);
+				const auto msPerFrame = a_frames > 0 ? totalMs / static_cast<double>(a_frames) : 0.0;
+				const auto msPerCall = row.m_calls > 0 ? totalMs / static_cast<double>(row.m_calls) : 0.0;
+
+				logger::info("{:<60} {:>10.3f} ms {:>10.3f} ms/frame {:>10.3f} ms/call {:>8}", row.m_name, totalMs, msPerFrame, msPerCall, row.m_calls);
+			}
+		}
+
+		void logThreads(std::vector<ThreadRow>& a_rows, std::uint64_t a_frames)
+		{
+			std::ranges::sort(a_rows, [](const auto& a_lhs, const auto& a_rhs) {
+				return a_lhs.m_totalNs > a_rhs.m_totalNs;
+			});
+
+			logger::info("Physics profile threads");
+			logger::info("{:<12} {:>12} {:>18} {:>8}", "Thread", "Total CPU", "Avg/frame", "Calls");
+			logger::info("{:-<62}", "");
+
+			for (const auto& row : a_rows) {
+				const auto totalMs = nsToMs(row.m_totalNs);
+				const auto msPerFrame = a_frames > 0 ? totalMs / static_cast<double>(a_frames) : 0.0;
+
+				logger::info("T{:<10} {:>10.3f} ms {:>10.3f} ms/frame {:>8}", row.m_index, totalMs, msPerFrame, row.m_calls);
+			}
+		}
+
+		void resetUnlocked(bool a_resetTotalFrames)
+		{
+			for (auto& thread : g_threads) {
+				thread->m_root.resetStats();
+				thread->m_stack.clear();
+			}
+
+			g_windowFrames = 0;
+
+			if (a_resetTotalFrames) {
+				g_totalFrames = 0;
+			}
+
+			g_windowStart = Clock::now();
+		}
+
+		void install()
+		{
+			{
+				std::scoped_lock lock(g_threadsLock);
+				resetUnlocked(true);
+			}
+
+			btSetCustomEnterProfileZoneFunc(&enter);
+			btSetCustomLeaveProfileZoneFunc(&leave);
+		}
+
+		void uninstall()
+		{
+			btSetCustomEnterProfileZoneFunc(&emptyEnter);
+			btSetCustomLeaveProfileZoneFunc(&emptyLeave);
+		}
+
+		void enter(const char* a_name) noexcept
+		{
+			if (!a_name) {
+				return;
+			}
+
+			g_activeScopes.fetch_add(1, std::memory_order_acq_rel);
+
+			try {
+				auto& thread = getThreadState();
+				auto& parent = thread.m_stack.empty() ? thread.m_root : *thread.m_stack.back().m_node;
+				auto& node = parent.child(a_name);
+
+				++node.m_calls;
+				thread.m_stack.emplace_back(&node, Clock::now());
+			} catch (...) {
+				g_activeScopes.fetch_sub(1, std::memory_order_acq_rel);
+			}
+		}
+
+		void leave() noexcept
+		{
+			try {
+				auto* thread = g_threadState;
+
+				if (!thread || thread->m_stack.empty()) {
+					return;
+				}
+
+				const auto now = Clock::now();
+				const auto frame = thread->m_stack.back();
+
+				thread->m_stack.pop_back();
+				frame.m_node->m_totalNs += elapsedNs(frame.m_start, now);
+
+				g_activeScopes.fetch_sub(1, std::memory_order_acq_rel);
+			} catch (...) {
+			}
+		}
+
+		bool dumpAndReset(const DumpOptions& a_options)
+		{
+			const auto activeScopes = g_activeScopes.load(std::memory_order_acquire);
+
+			if (activeScopes != 0) {  // Just debug in case we fucked up somewhere
+				logger::warn("Physics profile dump skipped because {} profile scopes are still active", activeScopes);
+				return false;
+			}
+
+			AggregateNode root{ "Recorded CPU" };
+			std::vector<ThreadRow> threads;
+			std::uint64_t frames = 0;
+			Clock::time_point windowStart;
+
+			{
+				std::scoped_lock lock(g_threadsLock);
+
+				frames = std::max<std::uint64_t>(1, g_windowFrames);
+				windowStart = g_windowStart;
+
+				for (const auto& thread : g_threads) {
+					const auto total = getChildTotal(thread->m_root);
+					const auto calls = getChildCalls(thread->m_root);
+
+					if (total == 0 && calls == 0) {
+						continue;
+					}
+
+					threads.emplace_back(thread->m_index, total, calls);
+					mergeRoot(root, thread->m_root);
+				}
+
+				root.m_totalNs = getChildTotal(root);
+				resetUnlocked(false);
+			}
+
+			if (root.m_totalNs == 0) {
+				logger::info("Physics profile had no recorded scopes");
+				return true;
+			}
+
+			if (a_options.m_logTree) {
+				logTreeHeader(root, frames, windowStart);
+				logTreeRecursive(root, "", 0, frames, a_options);
+			}
+
+			if (a_options.m_logFlat) {
+				logFlatRows(root, frames, a_options);
+			}
+
+			if (a_options.m_logThreads) {
+				logThreads(threads, frames);
+			}
+
 			return true;
 		}
 
-		if (a_options.m_logTree) {
-			logTreeHeader(root, frames, windowStart);
-			logTreeRecursive(root, "", 0, frames, a_options);
-		}
+		bool dumpEvery(std::uint64_t a_printIntervalFrames, const DumpOptions& a_options)
+		{
+			if (a_printIntervalFrames == 0) {
+				return false;
+			}
 
-		if (a_options.m_logFlat) {
-			logFlatRows(root, frames, a_options);
-		}
+			if (g_totalFrames != 0 && g_totalFrames % a_printIntervalFrames == 0) {
+				return dumpAndReset(a_options);
+			}
 
-		if (a_options.m_logThreads) {
-			logThreads(threads, frames);
-		}
+			if (g_sampleWindowFrames != 0 && g_windowFrames >= g_sampleWindowFrames) {
+				if (g_activeScopes.load(std::memory_order_acquire) == 0) {
+					std::scoped_lock lock(g_threadsLock);
+					resetUnlocked(false);
+				}
+			}
 
-		return true;
-	}
-
-	bool dumpEvery(std::uint64_t a_frames, const DumpOptions& a_options)
-	{
-		if (a_frames == 0) {
 			return false;
 		}
+	}
 
-		const auto totalFrames = totalFrameCount();
+	void setCapture(bool a_enabled, std::uint64_t a_sampleFrames, std::uint64_t a_printFrames)
+	{
+		if (a_enabled) {
+			const auto sampleFrames = std::max<std::uint64_t>(1, a_sampleFrames);
+			const auto printFrames = std::max<std::uint64_t>(1, a_printFrames);
 
-		if (totalFrames != 0 && totalFrames % a_frames == 0) {
-			return dumpAndReset(a_options);
+			btSetProfileEnabled(false);
+			g_sampleWindowFrames = sampleFrames;
+			g_printIntervalFrames = printFrames;
+			install();
+			g_captureEnabled = true;
+			btSetProfileEnabled(true);
+		} else {
+			btSetProfileEnabled(false);
+			g_captureEnabled = false;
+			g_printIntervalFrames = 0;
+			g_sampleWindowFrames = 0;
+			uninstall();
+
+			std::scoped_lock lock(g_threadsLock);
+			resetUnlocked(true);
+		}
+	}
+
+	void advanceFrame()
+	{
+		if (!g_captureEnabled) {
+			return;
 		}
 
-		const auto profileHistory = getProfileHistory();
-
-		if (profileHistory != 0 && frameCountSinceReset() >= profileHistory) {
-			if (g_activeScopes.load(std::memory_order_acquire) == 0) {
-				std::scoped_lock lock(g_threadsLock);
-				resetUnlocked(false);
-			}
-		}
-
-		return false;
+		++g_windowFrames;
+		++g_totalFrames;
+		dumpEvery(g_printIntervalFrames, {});
 	}
 }

--- a/src/hdtPhysicsProfiler.h
+++ b/src/hdtPhysicsProfiler.h
@@ -1,31 +1,9 @@
 #pragma once
 
+#include <cstdint>
+
 namespace hdt::physicsprofiler
 {
-	struct DumpOptions
-	{
-		double m_minScopeMs = 0.001;
-		std::uint32_t m_maxDepth = 64;
-		std::uint32_t m_flatLimit = 32;
-		bool m_logTree = true;
-		bool m_logFlat = true;
-		bool m_logThreads = true;
-	};
-
-	void install();
-	void uninstall();
-
-	void enter(const char* a_name) noexcept;
-	void leave() noexcept;
-
-	void endFrame();
-	std::uint64_t frameCountSinceReset();
-	std::uint64_t totalFrameCount();
-
-	void setProfileHistory(std::uint64_t a_frames);
-	std::uint64_t getProfileHistory();
-
-	bool reset();
-	bool dumpAndReset(const DumpOptions& a_options = {});
-	bool dumpEvery(std::uint64_t a_frames, const DumpOptions& a_options = {});
+	void setCapture(bool a_enabled, std::uint64_t a_sampleFrames, std::uint64_t a_printFrames);
+	void advanceFrame();
 }

--- a/src/hdtSkyrimPhysicsWorld.cpp
+++ b/src/hdtSkyrimPhysicsWorld.cpp
@@ -1,12 +1,9 @@
 #include "hdtSkyrimPhysicsWorld.h"
 #include "PluginInterfaceImpl.h"
 #include "WeatherManager.h"
+#include "hdtPhysicsProfiler.h"
 
-#ifdef BT_ENABLE_PROFILE
-#	pragma message("BT_ENABLE_PROFILE is enabled.")
-#	include "hdtPhysicsProfiler.h"
-#	include <LinearMath/btQuickprof.h>
-#endif
+#include <LinearMath/btQuickprof.h>
 
 namespace hdt
 {
@@ -14,11 +11,6 @@ namespace hdt
 
 	SkyrimPhysicsWorld::SkyrimPhysicsWorld(void)
 	{
-#ifdef BT_ENABLE_PROFILE
-		physicsprofiler::install();
-		physicsprofiler::setProfileHistory(240);
-#endif
-
 		gDisableDeactivation = true;
 		setGravity(btVector3(0, 0, -9.8f * scaleSkyrim));
 
@@ -55,6 +47,12 @@ namespace hdt
 
 		m_averageInterval = m_timeTick;
 		m_accumulatedInterval = 0;
+	}
+
+	void SkyrimPhysicsWorld::setProfilerCapture(bool a_enabled, std::uint64_t a_sampleFrames, std::uint64_t a_printFrames)
+	{
+		auto simulationLock = lockSimulation();
+		physicsprofiler::setCapture(a_enabled, a_sampleFrames, a_printFrames);
 	}
 
 	SkyrimPhysicsWorld::~SkyrimPhysicsWorld(void) noexcept
@@ -171,10 +169,7 @@ namespace hdt
 			m_2ndStepAverageProcessingTime = (m_2ndStepAverageProcessingTime + lastProcessingTime) * 0.5f;
 		}
 
-#ifdef BT_ENABLE_PROFILE
-		physicsprofiler::endFrame();
-		physicsprofiler::dumpEvery(240);
-#endif
+		physicsprofiler::advanceFrame();
 	}
 
 	std::unique_lock<std::mutex> SkyrimPhysicsWorld::lockSimulation()

--- a/src/hdtSkyrimPhysicsWorld.h
+++ b/src/hdtSkyrimPhysicsWorld.h
@@ -22,6 +22,7 @@ namespace hdt
 		void doUpdate(float delta);
 		void doUpdate2ndStep(float delta, const float tick, const float remainingTimeStep);
 		void updateActiveState();
+		void setProfilerCapture(bool a_enabled, std::uint64_t a_sampleFrames = 240, std::uint64_t a_printFrames = 240);
 
 		void addSkinnedMeshSystem(SkinnedMeshSystem* system) override;
 		void removeSkinnedMeshSystem(SkinnedMeshSystem* system) override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,29 @@
 #include "dhdtPapyrusFunctions.h"
 #include "hdtSkyrimPhysicsWorld.h"
 
+#include <charconv>
+#include <cstdint>
+#include <string_view>
+
+namespace
+{
+	std::uint64_t ParsePositiveDecimal(std::string_view a_value, std::uint64_t a_fallback)
+	{
+		if (a_value.empty()) {
+			return a_fallback;
+		}
+
+		std::uint64_t parsed = 0;
+		const auto [end, error] = std::from_chars(a_value.data(), a_value.data() + a_value.size(), parsed);
+
+		if (error != std::errc{} || end != a_value.data() + a_value.size() || parsed == 0) {
+			return a_fallback;
+		}
+
+		return static_cast<std::uint64_t>(parsed);
+	}
+}
+
 void checkOldPlugins()
 {
 	auto framework = GetModuleHandleA("hdtSSEFramework");
@@ -282,12 +305,14 @@ bool SMPDebug_Execute(
 	memset(buffer, 0, MAX_PATH);
 	char buffer2[MAX_PATH];
 	memset(buffer2, 0, MAX_PATH);
+	char buffer3[MAX_PATH];
+	memset(buffer3, 0, MAX_PATH);
 
-	if (!RE::Script::ParseParameters(a_paramInfo, a_scriptData, a_opcodeOffsetPtr, a_thisObj, a_containingObj, a_scriptObj, a_locals, buffer, buffer2)) {
+	if (!RE::Script::ParseParameters(a_paramInfo, a_scriptData, a_opcodeOffsetPtr, a_thisObj, a_containingObj, a_scriptObj, a_locals, buffer, buffer2, buffer3)) {
 		return false;
 	}
 
-	logger::debug("SMPCommand: {} {}"sv, buffer, buffer2);
+	logger::debug("SMPCommand: {} {} {}"sv, buffer, buffer2, buffer3);
 
 	if (_strnicmp(buffer, "reset", MAX_PATH) == 0) {
 		logger::debug("smp reset: reloading config and resetting physics world"sv);
@@ -319,6 +344,30 @@ bool SMPDebug_Execute(
 
 	if (_strnicmp(buffer, "list", MAX_PATH) == 0) {
 		SMPDebug_PrintDetailed(false);
+		return true;
+	}
+
+	if (_strnicmp(buffer, "profile", MAX_PATH) == 0) {
+		static bool profilerCaptureRequested = false;
+
+		profilerCaptureRequested = !profilerCaptureRequested;
+
+		const auto sampleFrames = ParsePositiveDecimal(buffer2, 240);
+		const auto printFrames = ParsePositiveDecimal(buffer3, 240);
+
+		hdt::SkyrimPhysicsWorld::get()->setProfilerCapture(profilerCaptureRequested, sampleFrames, printFrames);
+
+		if (profilerCaptureRequested) {
+			RE::ConsoleLog::GetSingleton()->Print(
+				"HDT-SMP physics profiler enabled: sample %llu frames, print every %llu frames",
+				static_cast<unsigned long long>(sampleFrames),
+				static_cast<unsigned long long>(printFrames));
+			RE::ConsoleLog::GetSingleton()->Print("Check your hdtsmp64.log file for results.");
+
+		} else {
+			RE::ConsoleLog::GetSingleton()->Print("HDT-SMP physics profiler disabled");
+		}
+
 		return true;
 	}
 
@@ -552,16 +601,22 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 	//
 	auto unusedCommand = RE::SCRIPT_FUNCTION::LocateConsoleCommand("ShowRenderPasses");
 	if (unusedCommand) {
-		static RE::SCRIPT_PARAMETER params[1];
+		static RE::SCRIPT_PARAMETER params[3];
 		params[0].paramType = RE::SCRIPT_PARAM_TYPE::kChar;
 		params[0].paramName = "String (optional)";
 		params[0].optional = 1;
+		params[1].paramType = RE::SCRIPT_PARAM_TYPE::kChar;
+		params[1].paramName = "String (optional)";
+		params[1].optional = 1;
+		params[2].paramType = RE::SCRIPT_PARAM_TYPE::kChar;
+		params[2].paramName = "String (optional)";
+		params[2].optional = 1;
 
 		unusedCommand->functionName = "SMPDebug";
 		unusedCommand->shortName = "smp";
 		unusedCommand->helpString = "smp <reset>";
 		unusedCommand->referenceFunction = 0;
-		unusedCommand->numParams = 1;
+		unusedCommand->numParams = 3;
 		unusedCommand->params = params;
 		unusedCommand->executeFunction = SMPDebug_Execute;
 		unusedCommand->editorFilter = 0;


### PR DESCRIPTION
Following changes:

- Makes Bullet use a bool for gating rather than empty calls (Faster, better branch prediction, easier on the compiler to optimize). I verified there was zero compiler optimizations being done to the empty calls. Micro optimization, but cleaner
- Removed "Profile" profile. Just gating behind "smp profile <sample> <print every x frames>" instead
- Cleaned up hdtPhysicsProfiler.cpp, was a bit messy before and exposed stuff it didn't need to. Also added 'cstdint' to make the bot stfu
- Adds smp profile <sample> <print every x frames> command. 

The Bullet bool optimization is a micro optimization, so we can cut that part off if people want. Reason I added it is because my CPU was not playing nice with the empty calls and it was using ~20-30 cycles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profiler capture control functionality enabling runtime toggles of profiling
  * Added "profile" console command for configuring and enabling profiling capture with adjustable frame counts

* **Refactor**
  * Simplified profiler API with streamlined, capture-based control mechanism
  * Transitioned profiling from compile-time configuration to runtime control gates
  * Removed dedicated Profile build configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->