### PR TITLE
fix: restore Improved Camera compatibility

### DIFF
--- a/src/hdtSkyrimBone.cpp
+++ b/src/hdtSkyrimBone.cpp
@@ -99,6 +99,9 @@ namespace hdt
 
 		m_node->world.rotate = convertBt(transform.getBasis());
 		m_node->world.translate = convertBt(transform.getOrigin());
+		if (m_node->parent) {
+			m_node->local = m_node->parent->world.Invert() * m_node->world;
+		}
 		// Todo: Look into why the hell we're doing this lol?
 		m_node->world = m_node->world;
 


### PR DESCRIPTION
A small tweak to "detect" body node updates we're doing related to shadow altering on Improved Camera's side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured bone local transforms are recalculated when parents exist, keeping local and world transform states consistent. This improves skeletal animation accuracy and prevents transform-related visual glitches during physics-driven updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->