### PR TITLE
fix: null-check dynamicData

### DIFF
--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -765,7 +765,7 @@ namespace hdt
 			for (uint32_t j = 0; j < skinPartition->vertexCount; ++j) {
 				RE::NiPoint3* vertexPos;
 
-				if (dynamicShape)
+				if (dynamicShape && dynamicVData)
 					vertexPos = reinterpret_cast<RE::NiPoint3*>(&dynamicVData[j * 16]);
 				else
 					vertexPos = reinterpret_cast<RE::NiPoint3*>(&vertexBlock[j * vSize]);


### PR DESCRIPTION
BSDynamicTriShape::dynamicData can be null if the mesh hasn't been rendered yet and the GPU buffer hasn't been populated. The previous check only tested that the shape itself was non-null, causing a null pointer dereference when iterating vertex positions in generateMeshBody.

Fall back to rawVertexData (static rest-pose positions) when dynamicData is not yet available — valid for physics body initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced mesh generation robustness by implementing validation checks for dynamic vertex data. The system now properly validates data availability and safely falls back to alternative buffers when required conditions are not met, preventing potential errors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaymareOn/hdtSMP64/pull/326)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->