### PR TITLE
fix: Install the frame hooks later to avoid other mods breaking them

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -348,15 +348,21 @@ namespace Hooks
 		DetourAttach((PVOID*)&_SetBoneName, (PVOID)SetBoneName_Hook);
 	}
 
-	void Install()
+	void InstallHighPriority()
 	{
-		logger::trace("Hooking...");
+		logger::trace("Installing high-priority hooks...");
 
-		// generic hooks
-		BSFaceGenNiNodeHooks::Hook();
 		MainHooks::Hook();
 
-		//
+		logger::trace("...success");
+	}
+
+	void InstallLowPriority()
+	{
+		logger::trace("Installing low-priority hooks...");
+
+		BSFaceGenNiNodeHooks::Hook();
+
 		DetourTransactionBegin();
 		DetourUpdateThread(GetCurrentThread());
 		ActorEquipManagerHooks::Hook();
@@ -366,13 +372,11 @@ namespace Hooks
 
 		DetourTransactionCommit();
 
-		//
 		DetourTransactionBegin();
 		DetourUpdateThread(GetCurrentThread());
 		BipedAnimHooks::Hook();
 		DetourTransactionCommit();
 
-		//
 		logger::trace("...success");
 	}
 }

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -166,5 +166,9 @@ namespace Hooks
 		static inline func_t* _func{ (func_t*)REL::VariantID(15535, 15712, 0x01DB9E0).address() };  // 0x01CAFB0, 0x01D83B0, 0x01DB9E0 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
 	};
 
-	void Install();
+	// Intended for hooks that may get drowned out by other mods.
+	// In this case, MainHooks->UpdateHook1 was somehow being disabled by another mod
+	void InstallHighPriority();
+
+	void InstallLowPriority();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -495,6 +495,7 @@ void MessageHandler(SKSE::MessagingInterface::Message* a_msg)
 		break;
 	case SKSE::MessagingInterface::kPostPostLoad:
 		{
+			Hooks::InstallHighPriority();
 			hdt::g_pluginInterface.onPostPostLoad();
 			checkOldPlugins();
 		}
@@ -593,7 +594,7 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 	//
 	SKSE::GetCameraEventSource()->AddEventSink(hdt::SkyrimPhysicsWorld::get());
 
-	Hooks::Install();
+	Hooks::InstallLowPriority();
 
 	hdt::g_pluginInterface.init(a_skse);
 


### PR DESCRIPTION
This fixes a recently reported issue (By a handful of users) where the physics simulation just outright doesn't work.

Why? Somehow the Frame events are never called. Some plugin must either be hooking the same position as us and not forwarding the game call downstream, or it's doing some other magic. Regardless, delaying the frame registration later in the skyrim boot process fixes it. 

Divided the hook installs into two separate functions. One intended for High priority installs - where we'll more likely get called before other mod's hooks. And one that is intended for low priority hooks - where we want to give other plugins the opportunity to get the call before us since some of these hooks do not call the original function. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized hook installation system into two separate phases: high-priority and low-priority installation sequences. Installation timing adjustments may improve compatibility in certain scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaymareOn/hdtSMP64/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->