### PR TITLE
fix: manage null data and culling distance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
 	hdtsmp64
-	VERSION 3.0.2
+	VERSION 3.0.3
 	LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
 	hdtsmp64
-	VERSION 3.0.3
+	VERSION 3.0.4
 	LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
 	hdtsmp64
-	VERSION 3.0.1
+	VERSION 3.0.2
 	LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
 	hdtsmp64
-	VERSION 3.0.0
+	VERSION 3.0.1
 	LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/configs/configs.xml
+++ b/configs/configs.xml
@@ -181,14 +181,6 @@
     <!-- ##################### DISTANCE AND SCREEN SIZE CULLING ############ -->
 
     <!--
-      maxPhysicsDistance: (float) hard cutoff distance in world units beyond which
-      physics is never calculated for non-player skeletons, regardless of budget or
-      screen visibility. 0 disables the cutoff.
-      If no value is set, default is 0 (disabled).
-    -->
-    <maxPhysicsDistance>0</maxPhysicsDistance>
-
-    <!--
       minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons
       whose bounding sphere diameter, projected onto the screen, is smaller than this
       fraction of the screen height. For example, 0.02 skips skeletons that appear

--- a/configs/configs.xml
+++ b/configs/configs.xml
@@ -178,6 +178,25 @@
     -->
     <disable1stPersonViewPhysics>false</disable1stPersonViewPhysics>
 
+    <!-- ##################### DISTANCE AND SCREEN SIZE CULLING ############ -->
+
+    <!--
+      maxPhysicsDistance: (float) hard cutoff distance in world units beyond which
+      physics is never calculated for non-player skeletons, regardless of budget or
+      screen visibility. 0 disables the cutoff.
+      If no value is set, default is 0 (disabled).
+    -->
+    <maxPhysicsDistance>0</maxPhysicsDistance>
+
+    <!--
+      minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons
+      whose bounding sphere diameter, projected onto the screen, is smaller than this
+      fraction of the screen height. For example, 0.02 skips skeletons that appear
+      smaller than 2% of screen height. 0 disables the check.
+      If no value is set, default is 0 (disabled).
+    -->
+    <minScreenSizeFraction>0</minScreenSizeFraction>
+
     <!-- ##################### CUDA ####################################### -->
 
     <!--

--- a/configs/configs.xsd
+++ b/configs/configs.xsd
@@ -112,6 +112,22 @@
                   <xs:documentation>disable1stPersonViewPhysics: (boolean) if set to true, the physics of the PC won't be calculated when in 1st person view, to save performance. If no value is set, default is false.</xs:documentation>
                 </xs:annotation>
               </xs:element>
+              <xs:element name="maxPhysicsDistance" type="xs:float" minOccurs="0">
+                <xs:annotation>
+                  <xs:documentation>maxPhysicsDistance: (float) hard cutoff distance in world units beyond which physics is never calculated for non-player skeletons, regardless of budget or screen visibility. 0 disables the cutoff. If no value is set, default is 0 (disabled).</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="minScreenSizeFraction" minOccurs="0">
+                <xs:annotation>
+                  <xs:documentation>minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons whose bounding sphere diameter, projected onto the screen, is smaller than this fraction of the screen height. 0 disables the check. If no value is set, default is 0 (disabled).</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                  <xs:restriction base="xs:float">
+                    <xs:minInclusive value="0"/>
+                    <xs:maxInclusive value="1"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
               <xs:element name="enableCuda" type="booleanTextType" minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>enableCuda: (boolean) experimental GPU collision algorithm. Try this if you have a slow CPU and fast GPU. This setting will be ignored if you haven't installed the CUDA-enabled version. If no value is set, default is false.</xs:documentation>

--- a/configs/configs.xsd
+++ b/configs/configs.xsd
@@ -112,11 +112,6 @@
                   <xs:documentation>disable1stPersonViewPhysics: (boolean) if set to true, the physics of the PC won't be calculated when in 1st person view, to save performance. If no value is set, default is false.</xs:documentation>
                 </xs:annotation>
               </xs:element>
-              <xs:element name="maxPhysicsDistance" type="xs:float" minOccurs="0">
-                <xs:annotation>
-                  <xs:documentation>maxPhysicsDistance: (float) hard cutoff distance in world units beyond which physics is never calculated for non-player skeletons, regardless of budget or screen visibility. 0 disables the cutoff. If no value is set, default is 0 (disabled).</xs:documentation>
-                </xs:annotation>
-              </xs:element>
               <xs:element name="minScreenSizeFraction" minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons whose bounding sphere diameter, projected onto the screen, is smaller than this fraction of the screen height. 0 disables the check. If no value is set, default is 0 (disabled).</xs:documentation>

--- a/fomod tree/configs/configs-compatibility.xml
+++ b/fomod tree/configs/configs-compatibility.xml
@@ -173,7 +173,24 @@
     -->
     <disable1stPersonViewPhysics>false</disable1stPersonViewPhysics>
 
+    <!-- ##################### DISTANCE AND SCREEN SIZE CULLING ############ -->
 
+    <!--
+      maxPhysicsDistance: (float) hard cutoff distance in world units beyond which
+      physics is never calculated for non-player skeletons, regardless of budget or
+      screen visibility. 0 disables the cutoff.
+      If no value is set, default is 0 (disabled).
+    -->
+    <maxPhysicsDistance>0</maxPhysicsDistance>
+
+    <!--
+      minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons
+      whose bounding sphere diameter, projected onto the screen, is smaller than this
+      fraction of the screen height. For example, 0.02 skips skeletons that appear
+      smaller than 2% of screen height. 0 disables the check.
+      If no value is set, default is 0 (disabled).
+    -->
+    <minScreenSizeFraction>0</minScreenSizeFraction>
 
   </smp>
   <solver>

--- a/fomod tree/configs/configs-compatibility.xml
+++ b/fomod tree/configs/configs-compatibility.xml
@@ -176,14 +176,6 @@
     <!-- ##################### DISTANCE AND SCREEN SIZE CULLING ############ -->
 
     <!--
-      maxPhysicsDistance: (float) hard cutoff distance in world units beyond which
-      physics is never calculated for non-player skeletons, regardless of budget or
-      screen visibility. 0 disables the cutoff.
-      If no value is set, default is 0 (disabled).
-    -->
-    <maxPhysicsDistance>0</maxPhysicsDistance>
-
-    <!--
       minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons
       whose bounding sphere diameter, projected onto the screen, is smaller than this
       fraction of the screen height. For example, 0.02 skips skeletons that appear

--- a/fomod tree/configs/configs-performance.xml
+++ b/fomod tree/configs/configs-performance.xml
@@ -176,14 +176,6 @@
     <!-- ##################### DISTANCE AND SCREEN SIZE CULLING ############ -->
 
     <!--
-      maxPhysicsDistance: (float) hard cutoff distance in world units beyond which
-      physics is never calculated for non-player skeletons, regardless of budget or
-      screen visibility. 0 disables the cutoff.
-      If no value is set, default is 0 (disabled).
-    -->
-    <maxPhysicsDistance>4000</maxPhysicsDistance>
-
-    <!--
       minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons
       whose bounding sphere diameter, projected onto the screen, is smaller than this
       fraction of the screen height. For example, 0.02 skips skeletons that appear

--- a/fomod tree/configs/configs-performance.xml
+++ b/fomod tree/configs/configs-performance.xml
@@ -173,7 +173,24 @@
     -->
     <disable1stPersonViewPhysics>true</disable1stPersonViewPhysics>
 
+    <!-- ##################### DISTANCE AND SCREEN SIZE CULLING ############ -->
 
+    <!--
+      maxPhysicsDistance: (float) hard cutoff distance in world units beyond which
+      physics is never calculated for non-player skeletons, regardless of budget or
+      screen visibility. 0 disables the cutoff.
+      If no value is set, default is 0 (disabled).
+    -->
+    <maxPhysicsDistance>4000</maxPhysicsDistance>
+
+    <!--
+      minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons
+      whose bounding sphere diameter, projected onto the screen, is smaller than this
+      fraction of the screen height. For example, 0.02 skips skeletons that appear
+      smaller than 2% of screen height. 0 disables the check.
+      If no value is set, default is 0 (disabled).
+    -->
+    <minScreenSizeFraction>0.025</minScreenSizeFraction>
 
   </smp>
   <solver>

--- a/fomod tree/configs/configs-quality.xml
+++ b/fomod tree/configs/configs-quality.xml
@@ -173,7 +173,24 @@
     -->
     <disable1stPersonViewPhysics>true</disable1stPersonViewPhysics>
 
+    <!-- ##################### DISTANCE AND SCREEN SIZE CULLING ############ -->
 
+    <!--
+      maxPhysicsDistance: (float) hard cutoff distance in world units beyond which
+      physics is never calculated for non-player skeletons, regardless of budget or
+      screen visibility. 0 disables the cutoff.
+      If no value is set, default is 0 (disabled).
+    -->
+    <maxPhysicsDistance>0</maxPhysicsDistance>
+
+    <!--
+      minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons
+      whose bounding sphere diameter, projected onto the screen, is smaller than this
+      fraction of the screen height. For example, 0.02 skips skeletons that appear
+      smaller than 2% of screen height. 0 disables the check.
+      If no value is set, default is 0 (disabled).
+    -->
+    <minScreenSizeFraction>0</minScreenSizeFraction>
 
   </smp>
   <solver>

--- a/fomod tree/configs/configs-quality.xml
+++ b/fomod tree/configs/configs-quality.xml
@@ -176,14 +176,6 @@
     <!-- ##################### DISTANCE AND SCREEN SIZE CULLING ############ -->
 
     <!--
-      maxPhysicsDistance: (float) hard cutoff distance in world units beyond which
-      physics is never calculated for non-player skeletons, regardless of budget or
-      screen visibility. 0 disables the cutoff.
-      If no value is set, default is 0 (disabled).
-    -->
-    <maxPhysicsDistance>0</maxPhysicsDistance>
-
-    <!--
       minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons
       whose bounding sphere diameter, projected onto the screen, is smaller than this
       fraction of the screen height. For example, 0.02 skips skeletons that appear

--- a/fomod tree/configs/configs-reasonable.xml
+++ b/fomod tree/configs/configs-reasonable.xml
@@ -182,7 +182,7 @@
       smaller than 2% of screen height. 0 disables the check.
       If no value is set, default is 0 (disabled).
     -->
-    <minScreenSizeFraction>0</minScreenSizeFraction>
+    <minScreenSizeFraction>0.015</minScreenSizeFraction>
 
   </smp>
   <solver>

--- a/fomod tree/configs/configs-reasonable.xml
+++ b/fomod tree/configs/configs-reasonable.xml
@@ -173,7 +173,24 @@
     -->
     <disable1stPersonViewPhysics>false</disable1stPersonViewPhysics>
 
+    <!-- ##################### DISTANCE AND SCREEN SIZE CULLING ############ -->
 
+    <!--
+      maxPhysicsDistance: (float) hard cutoff distance in world units beyond which
+      physics is never calculated for non-player skeletons, regardless of budget or
+      screen visibility. 0 disables the cutoff.
+      If no value is set, default is 0 (disabled).
+    -->
+    <maxPhysicsDistance>0</maxPhysicsDistance>
+
+    <!--
+      minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons
+      whose bounding sphere diameter, projected onto the screen, is smaller than this
+      fraction of the screen height. For example, 0.02 skips skeletons that appear
+      smaller than 2% of screen height. 0 disables the check.
+      If no value is set, default is 0 (disabled).
+    -->
+    <minScreenSizeFraction>0</minScreenSizeFraction>
 
   </smp>
   <solver>

--- a/fomod tree/configs/configs-reasonable.xml
+++ b/fomod tree/configs/configs-reasonable.xml
@@ -176,14 +176,6 @@
     <!-- ##################### DISTANCE AND SCREEN SIZE CULLING ############ -->
 
     <!--
-      maxPhysicsDistance: (float) hard cutoff distance in world units beyond which
-      physics is never calculated for non-player skeletons, regardless of budget or
-      screen visibility. 0 disables the cutoff.
-      If no value is set, default is 0 (disabled).
-    -->
-    <maxPhysicsDistance>0</maxPhysicsDistance>
-
-    <!--
       minScreenSizeFraction: (float 0-1) physics is skipped for non-player skeletons
       whose bounding sphere diameter, projected onto the screen, is smaller than this
       fraction of the screen height. For example, 0.02 skips skeletons that appear

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -454,7 +454,7 @@ namespace hdt
 			// is exceeded, so a shrinking auto-adjust cap can't strip physics from NPCs next to the camera.
 			const bool forceKeepNear = i.m_distanceFromCamera2 < minCullingDistance2;
 			const bool overBudget = activeSkeletons >= maxActiveSkeletons;
-			if (!i.hasPhysics || !i.updateAttachedState(playerCell, overBudget && !forceKeepNear || skipDeadActor)) {
+			if (!i.hasPhysics || !i.updateAttachedState(playerCell, overBudget && !forceKeepNear || skipDeadActor))
 				continue;
 
 				activeSkeletons++;

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -399,7 +399,7 @@ namespace hdt
 		if (m_minScreenSizeFraction > 0.f) {
 			if (auto* cam = RE::Main::WorldRootCamera()) {
 				const auto& f = cam->GetRuntimeData2().viewFrustum;
-				const float screenH = f.fTop - f.fBottom; // near-plane total vertical span in world units
+				const float screenH = f.fTop - f.fBottom;  // near-plane total vertical span in world units
 				m_screenSizeNearPlaneScale = 4.f * f.fNear * f.fNear;
 				m_screenSizeThresholdScale = m_minScreenSizeFraction * m_minScreenSizeFraction * screenH * screenH;
 			}
@@ -1062,7 +1062,7 @@ namespace hdt
 		// Ie, is the NPC's projected bounding sphere smaller than the allowed fraction of screen height?
 		// screenFraction < minFraction <=> 2r·fNear / (dist·screenH) < fr <=> 4r²·fNear² < fr²·dist²·screenH²
 		if (manager->m_screenSizeThresholdScale > 0.f) {
-			const float r = skeleton3D->worldBound.radius; // the radius of the bounding sphere of the skeleton in world units
+			const float r = skeleton3D->worldBound.radius;  // the radius of the bounding sphere of the skeleton in world units
 			if (manager->m_screenSizeNearPlaneScale * r * r < manager->m_screenSizeThresholdScale * m_distanceFromCamera2)
 				return false;
 		}
@@ -1121,7 +1121,7 @@ namespace hdt
 					state = SkeletonState::e_ActiveIsPlayer;
 				}
 			} else if (instance()->m_maxPhysicsDistance > 0.f &&
-				m_distanceFromCamera2 > instance()->m_maxPhysicsDistance * instance()->m_maxPhysicsDistance) {
+					   m_distanceFromCamera2 > instance()->m_maxPhysicsDistance * instance()->m_maxPhysicsDistance) {
 				state = SkeletonState::e_InactiveTooFar;
 			} else if (isInPlayerView()) {
 				isActive = true;

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -457,188 +457,188 @@ namespace hdt
 			if (!i.hasPhysics || !i.updateAttachedState(playerCell, overBudget && !forceKeepNear || skipDeadActor)) {
 				continue;
 
-			activeSkeletons++;
+				activeSkeletons++;
 
-			// Check wind obstructions for active skeletons.
-			if (!windEnabled)
-				continue;
+				// Check wind obstructions for active skeletons.
+				if (!windEnabled)
+					continue;
 
-			const auto armorReacts = [](const auto& armor) {
-				return armor.m_hasDynamicPhysics && armor.state() == ActorManager::ItemState::e_Active;
-			};
+				const auto armorReacts = [](const auto& armor) {
+					return armor.m_hasDynamicPhysics && armor.state() == ActorManager::ItemState::e_Active;
+				};
 
-			const auto headReacts = [](const auto& headPart) {
-				return headPart.m_hasDynamicPhysics && headPart.state() == ActorManager::ItemState::e_Active;
-			};
+				const auto headReacts = [](const auto& headPart) {
+					return headPart.m_hasDynamicPhysics && headPart.state() == ActorManager::ItemState::e_Active;
+				};
 
-			// Does this actor have anything visible and active that can be blown in the wind?
-			if (!std::ranges::any_of(i.getArmors(), armorReacts) && !std::ranges::any_of(i.head.headParts, headReacts)) {
-				continue;
-			}
+				// Does this actor have anything visible and active that can be blown in the wind?
+				if (!std::ranges::any_of(i.getArmors(), armorReacts) && !std::ranges::any_of(i.head.headParts, headReacts)) {
+					continue;
+				}
 
-			const auto owner = skyrim_cast<RE::Actor*>(i.skeletonOwner.get());
-			if (!owner) {
-				logger::debug("{} is active skeleton, but failed to cast to Actor, no wind obstruction check possible.", i.name());
-				continue;
-			}
+				const auto owner = skyrim_cast<RE::Actor*>(i.skeletonOwner.get());
+				if (!owner) {
+					logger::debug("{} is active skeleton, but failed to cast to Actor, no wind obstruction check possible.", i.name());
+					continue;
+				}
 
-			// Get the  wind direction pointing TOWARDS the source of the wind
-			auto reverseWindDir = wind * -1.0f;
+				// Get the  wind direction pointing TOWARDS the source of the wind
+				auto reverseWindDir = wind * -1.0f;
 
-			// Normalize the direction vector to ensure accurate math
-			reverseWindDir.Unitize();
+				// Normalize the direction vector to ensure accurate math
+				reverseWindDir.Unitize();
 
-			// we project the ray forward by m_distanceForMaxWind
-			RE::NiPoint3 origin;
+				// we project the ray forward by m_distanceForMaxWind
+				RE::NiPoint3 origin;
 
-			// If possible, use the head for the origin. Since hair is more likely to be affected, and
-			// it'd be more accurate in animations/height of the actor.
-			if (auto headNode = owner->GetNodeByName("NPC Head [Head]")) {
-				origin = headNode->world.translate;
-			} else {
-				origin = owner->data.location;
-				origin.z += 100.0f;  // Offset by 100 units so at least it's not their feet
-			}
+				// If possible, use the head for the origin. Since hair is more likely to be affected, and
+				// it'd be more accurate in animations/height of the actor.
+				if (auto headNode = owner->GetNodeByName("NPC Head [Head]")) {
+					origin = headNode->world.translate;
+				} else {
+					origin = owner->data.location;
+					origin.z += 100.0f;  // Offset by 100 units so at least it's not their feet
+				}
 
-			RE::NiPoint3 targetPos = origin + reverseWindDir * world->m_distanceForMaxWind;
+				RE::NiPoint3 targetPos = origin + reverseWindDir * world->m_distanceForMaxWind;
 
-			RE::NiPoint3 hitLocation;
+				RE::NiPoint3 hitLocation;
 
-			const auto object = Actor_CalculateLOS(owner, &targetPos, &hitLocation, std::numbers::pi_v<float> * 2.f);
+				const auto object = Actor_CalculateLOS(owner, &targetPos, &hitLocation, std::numbers::pi_v<float> * 2.f);
 
-			float targetWindFactor = 1.0f;
-			float dist = 0.0f;
-			if (object) {
-				auto diff = owner->data.location - hitLocation;
-				diff.z = 0;  // remove z component difference
-				dist = diff.Length();
-				// windfactor = 0 when dist <= m_distanceForNoWind, = 1 when dist >= m_distanceForMaxWind, and is linear with dist between these 2 values.
-				targetWindFactor = std::clamp((dist - world->m_distanceForNoWind) / (world->m_distanceForMaxWind - world->m_distanceForNoWind), 0.f, 1.f);
-			}
-
-			if (const float current = i.getWindFactor(); !btFuzzyZero(targetWindFactor - current)) {
-				const float next = std::lerp(current, targetWindFactor, 0.05f);
-				const float newWindFactor = std::abs(targetWindFactor - next) < 0.01f ? targetWindFactor : next;
-
+				float targetWindFactor = 1.0f;
+				float dist = 0.0f;
 				if (object) {
-					logger::debug("{} blocked by {} with distance {:.2f}; setting windFactor {:.2f}.", i.name(), object->name, dist, newWindFactor);
+					auto diff = owner->data.location - hitLocation;
+					diff.z = 0;  // remove z component difference
+					dist = diff.Length();
+					// windfactor = 0 when dist <= m_distanceForNoWind, = 1 when dist >= m_distanceForMaxWind, and is linear with dist between these 2 values.
+					targetWindFactor = std::clamp((dist - world->m_distanceForNoWind) / (world->m_distanceForMaxWind - world->m_distanceForNoWind), 0.f, 1.f);
 				}
 
-				i.updateWindFactor(newWindFactor);
+				if (const float current = i.getWindFactor(); !btFuzzyZero(targetWindFactor - current)) {
+					const float next = std::lerp(current, targetWindFactor, 0.05f);
+					const float newWindFactor = std::abs(targetWindFactor - next) < 0.01f ? targetWindFactor : next;
+
+					if (object) {
+						logger::debug("{} blocked by {} with distance {:.2f}; setting windFactor {:.2f}.", i.name(), object->name, dist, newWindFactor);
+					}
+
+					i.updateWindFactor(newWindFactor);
+				}
+			}
+
+			for (auto& i : m_skeletons) {
+				i.cleanArmor();
+				i.cleanHead();
+			}
+
+			// We share the same doMetrics condition here and in hdtSkyrimPhysicsWorld to avoid any gap between both.
+			// The evaluation is done here rather than in hdtSkyrimPhysicsWorld because this event is called first.
+			world->m_doMetrics = updateMetrics &&                     // do not do metrics on a MenuOpenCloseEvent
+			                     !world->isSuspended() &&             // do not do metrics while paused
+			                     frameCount++ % world->min_fps == 0;  // check every min-fps frames (i.e., a stable 60 fps should wait for 1 second)
+
+			if (world->m_doMetrics) {
+				const auto averageProcessingTimeInMainLoop = world->m_averageSMPProcessingTimeInMainLoop;
+
+				const auto maxBudgetTime = world->m_budgetMs;
+				const auto averageTimePerSkeletonInMainLoop = activeSkeletons > 0 ? averageProcessingTimeInMainLoop / activeSkeletons : 0.f;
+
+				logger::trace(
+					"msecs/activeSkeleton {:.2f} activeSkeletons/maxActive/total {}/{}/{} processTimeInMainLoop/budgetTime {:.2f}/{:.2f}",
+					averageTimePerSkeletonInMainLoop,
+					activeSkeletons,
+					maxActiveSkeletons,
+					m_skeletons.size(),
+					averageProcessingTimeInMainLoop,
+					maxBudgetTime);
+
+				if (m_autoAdjustMaxSkeletons && m_maxActiveSkeletons > 3) {
+					// Deadzones to prevent constantly switching back and fourth
+					if (averageProcessingTimeInMainLoop > maxBudgetTime) {
+						// When few skeletons active, step down by 1 to avoid over-correction
+						maxActiveSkeletons -= (activeSkeletons < 10) ? 1 : 2;
+					} else if (averageProcessingTimeInMainLoop < maxBudgetTime) {
+						// Scale up by however many skeletons fit within the remaining budget headroom, max of 2
+						// Falls back to +2 when no skeletons are active (timePerSkeleton == 0).
+						const float headroom = maxBudgetTime - averageProcessingTimeInMainLoop;
+						const int canAdd = (averageTimePerSkeletonInMainLoop > 0.f) ? static_cast<int>(headroom / averageTimePerSkeletonInMainLoop) : 2;
+						maxActiveSkeletons += std::clamp(canAdd, 0, 2);
+					}
+
+					// clamp the adjusted value between 3 and m_maxActiveSkeletons
+					maxActiveSkeletons = std::clamp(maxActiveSkeletons, 3, m_maxActiveSkeletons);
+					frameCount = 1;
+
+				} else if (maxActiveSkeletons != m_maxActiveSkeletons)
+					maxActiveSkeletons = m_maxActiveSkeletons;
 			}
 		}
 
-		for (auto& i : m_skeletons) {
-			i.cleanArmor();
-			i.cleanHead();
-		}
+		void ActorManager::PhysicsItem::setPhysics(RE::BSTSmartPointer<SkyrimSystem> & system, bool active)
+		{
+			clearPhysics();
+			m_physics = system;
+			m_hasDynamicPhysics = false;
 
-		// We share the same doMetrics condition here and in hdtSkyrimPhysicsWorld to avoid any gap between both.
-		// The evaluation is done here rather than in hdtSkyrimPhysicsWorld because this event is called first.
-		world->m_doMetrics = updateMetrics &&                     // do not do metrics on a MenuOpenCloseEvent
-		                     !world->isSuspended() &&             // do not do metrics while paused
-		                     frameCount++ % world->min_fps == 0;  // check every min-fps frames (i.e., a stable 60 fps should wait for 1 second)
-
-		if (world->m_doMetrics) {
-			const auto averageProcessingTimeInMainLoop = world->m_averageSMPProcessingTimeInMainLoop;
-
-			const auto maxBudgetTime = world->m_budgetMs;
-			const auto averageTimePerSkeletonInMainLoop = activeSkeletons > 0 ? averageProcessingTimeInMainLoop / activeSkeletons : 0.f;
-
-			logger::trace(
-				"msecs/activeSkeleton {:.2f} activeSkeletons/maxActive/total {}/{}/{} processTimeInMainLoop/budgetTime {:.2f}/{:.2f}",
-				averageTimePerSkeletonInMainLoop,
-				activeSkeletons,
-				maxActiveSkeletons,
-				m_skeletons.size(),
-				averageProcessingTimeInMainLoop,
-				maxBudgetTime);
-
-			if (m_autoAdjustMaxSkeletons && m_maxActiveSkeletons > 3) {
-				// Deadzones to prevent constantly switching back and fourth
-				if (averageProcessingTimeInMainLoop > maxBudgetTime) {
-					// When few skeletons active, step down by 1 to avoid over-correction
-					maxActiveSkeletons -= (activeSkeletons < 10) ? 1 : 2;
-				} else if (averageProcessingTimeInMainLoop < maxBudgetTime) {
-					// Scale up by however many skeletons fit within the remaining budget headroom, max of 2
-					// Falls back to +2 when no skeletons are active (timePerSkeleton == 0).
-					const float headroom = maxBudgetTime - averageProcessingTimeInMainLoop;
-					const int canAdd = (averageTimePerSkeletonInMainLoop > 0.f) ? static_cast<int>(headroom / averageTimePerSkeletonInMainLoop) : 2;
-					maxActiveSkeletons += std::clamp(canAdd, 0, 2);
+			if (m_physics) {
+				for (const auto& bone : m_physics->getBones()) {
+					if (bone && !bone->m_rig.isStaticOrKinematicObject()) {
+						m_hasDynamicPhysics = true;
+						break;
+					}
 				}
+			}
 
-				// clamp the adjusted value between 3 and m_maxActiveSkeletons
-				maxActiveSkeletons = std::clamp(maxActiveSkeletons, 3, m_maxActiveSkeletons);
-				frameCount = 1;
-
-			} else if (maxActiveSkeletons != m_maxActiveSkeletons)
-				maxActiveSkeletons = m_maxActiveSkeletons;
-		}
-	}
-
-	void ActorManager::PhysicsItem::setPhysics(RE::BSTSmartPointer<SkyrimSystem>& system, bool active)
-	{
-		clearPhysics();
-		m_physics = system;
-		m_hasDynamicPhysics = false;
-
-		if (m_physics) {
-			for (const auto& bone : m_physics->getBones()) {
-				if (bone && !bone->m_rig.isStaticOrKinematicObject()) {
-					m_hasDynamicPhysics = true;
-					break;
-				}
+			if (active) {
+				SkyrimPhysicsWorld::get()->addSkinnedMeshSystem(m_physics.get());
 			}
 		}
 
-		if (active) {
-			SkyrimPhysicsWorld::get()->addSkinnedMeshSystem(m_physics.get());
+		void ActorManager::PhysicsItem::clearPhysics()
+		{
+			if (state() == ItemState::e_Active) {
+				m_physics->m_world->removeSkinnedMeshSystem(m_physics.get());
+			}
+			m_physics = nullptr;
+			m_hasDynamicPhysics = false;
 		}
-	}
 
-	void ActorManager::PhysicsItem::clearPhysics()
-	{
-		if (state() == ItemState::e_Active) {
-			m_physics->m_world->removeSkinnedMeshSystem(m_physics.get());
+		ActorManager::ItemState ActorManager::PhysicsItem::state() const
+		{
+			return m_physics ? (m_physics->m_world ? ItemState::e_Active : ItemState::e_Inactive) : ItemState::e_NoPhysics;
 		}
-		m_physics = nullptr;
-		m_hasDynamicPhysics = false;
-	}
 
-	ActorManager::ItemState ActorManager::PhysicsItem::state() const
-	{
-		return m_physics ? (m_physics->m_world ? ItemState::e_Active : ItemState::e_Inactive) : ItemState::e_NoPhysics;
-	}
-
-	const std::vector<RE::BSTSmartPointer<SkinnedMeshBody>>& ActorManager::PhysicsItem::meshes() const
-	{
-		return m_physics->meshes();
-	}
-
-	void ActorManager::PhysicsItem::updateActive(bool active)
-	{
-		if (active && state() == ItemState::e_Inactive) {
-			SkyrimPhysicsWorld::get()->addSkinnedMeshSystem(m_physics.get());
-		} else if (!active && state() == ItemState::e_Active) {
-			m_physics->m_world->removeSkinnedMeshSystem(m_physics.get());
+		const std::vector<RE::BSTSmartPointer<SkinnedMeshBody>>& ActorManager::PhysicsItem::meshes() const
+		{
+			return m_physics->meshes();
 		}
-	}
 
-	void ActorManager::PhysicsItem::setWindFactor(float a_windFactor)
-	{
-		if (m_physics)
-			m_physics->m_windFactor = a_windFactor;
-	}
+		void ActorManager::PhysicsItem::updateActive(bool active)
+		{
+			if (active && state() == ItemState::e_Inactive) {
+				SkyrimPhysicsWorld::get()->addSkinnedMeshSystem(m_physics.get());
+			} else if (!active && state() == ItemState::e_Active) {
+				m_physics->m_world->removeSkinnedMeshSystem(m_physics.get());
+			}
+		}
 
-	std::vector<ActorManager::Skeleton>& ActorManager::getSkeletons()
-	{
-		return m_skeletons;
-	}
+		void ActorManager::PhysicsItem::setWindFactor(float a_windFactor)
+		{
+			if (m_physics)
+				m_physics->m_windFactor = a_windFactor;
+		}
 
-	bool ActorManager::skeletonNeedsParts(RE::NiNode* skeleton)
-	{
-		return !isFirstPersonSkeleton(skeleton);
-		/*
+		std::vector<ActorManager::Skeleton>& ActorManager::getSkeletons()
+		{
+			return m_skeletons;
+		}
+
+		bool ActorManager::skeletonNeedsParts(RE::NiNode * skeleton)
+		{
+			return !isFirstPersonSkeleton(skeleton);
+			/*
 		auto iter = std::find_if(m_skeletons.begin(), m_skeletons.end(), [=](Skeleton& i)
 		{
 			return i.skeleton == skeleton;
@@ -648,973 +648,973 @@ namespace hdt
 			return (iter->head.headNode == 0);
 		}
 		*/
-	}
-
-	ActorManager::Skeleton& ActorManager::getSkeletonData(RE::NiNode* skeleton)
-	{
-		auto iter = std::find_if(m_skeletons.begin(), m_skeletons.end(), [=](Skeleton& i) {
-			return i.skeleton == skeleton;
-		});
-
-		if (iter != m_skeletons.end()) {
-			return *iter;
 		}
 
-		if (!isFirstPersonSkeleton(skeleton)) {
-			auto ownerIter = std::find_if(m_skeletons.begin(), m_skeletons.end(), [=](Skeleton& i) {
-				return !isFirstPersonSkeleton(i.skeleton.get()) && i.skeletonOwner && skeleton->GetUserData() && i.skeletonOwner.get() == skeleton->GetUserData();
+		ActorManager::Skeleton& ActorManager::getSkeletonData(RE::NiNode * skeleton)
+		{
+			auto iter = std::find_if(m_skeletons.begin(), m_skeletons.end(), [=](Skeleton& i) {
+				return i.skeleton == skeleton;
 			});
 
-			if (ownerIter != m_skeletons.end()) {
-				logger::debug("New skeleton found for formid {:08X}.", skeleton->GetUserData()->formID);
-				ownerIter->cleanHead(true);
+			if (iter != m_skeletons.end()) {
+				return *iter;
 			}
+
+			if (!isFirstPersonSkeleton(skeleton)) {
+				auto ownerIter = std::find_if(m_skeletons.begin(), m_skeletons.end(), [=](Skeleton& i) {
+					return !isFirstPersonSkeleton(i.skeleton.get()) && i.skeletonOwner && skeleton->GetUserData() && i.skeletonOwner.get() == skeleton->GetUserData();
+				});
+
+				if (ownerIter != m_skeletons.end()) {
+					logger::debug("New skeleton found for formid {:08X}.", skeleton->GetUserData()->formID);
+					ownerIter->cleanHead(true);
+				}
+			}
+
+			m_skeletons.push_back(Skeleton());
+			m_skeletons.back().skeleton = hdt::make_nismart(skeleton);
+			return m_skeletons.back();
 		}
 
-		m_skeletons.push_back(Skeleton());
-		m_skeletons.back().skeleton = hdt::make_nismart(skeleton);
-		return m_skeletons.back();
-	}
-
-	ActorManager::Skeleton* ActorManager::get3rdPersonSkeleton(RE::Actor* actor)
-	{
-		for (auto& i : m_skeletons) {
-			const auto owner = skyrim_cast<RE::Actor*>(i.skeletonOwner.get());
-			if (actor == owner && i.skeleton && !isFirstPersonSkeleton(i.skeleton.get())) {
-				return &i;
+		ActorManager::Skeleton* ActorManager::get3rdPersonSkeleton(RE::Actor * actor)
+		{
+			for (auto& i : m_skeletons) {
+				const auto owner = skyrim_cast<RE::Actor*>(i.skeletonOwner.get());
+				if (actor == owner && i.skeleton && !isFirstPersonSkeleton(i.skeleton.get())) {
+					return &i;
+				}
 			}
-		}
-		return 0;
-	}
-
-	void ActorManager::Skeleton::doSkeletonMerge(RE::NiNode* dst, RE::NiNode* src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString>& map, bool renameSource)
-	{
-		doSkeletonMerge(dst, src, prefix, map, dst, renameSource);
-	}
-
-	void ActorManager::Skeleton::doSkeletonMerge(RE::NiNode* dst, RE::NiNode* src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString>& map, RE::NiNode* dstRoot, bool renameSource)
-	{
-		const auto& children = src->GetChildren();
-
-		for (uint16_t i = 0; i < children.size(); ++i) {
-			auto srcChild = castNiNode(children[i].get());
-			if (!srcChild)
-				continue;
-
-			if (!srcChild->name.size()) {
-				doSkeletonMerge(dst, srcChild, prefix, map, dstRoot, renameSource);
-				continue;
-			}
-
-			// FIXME: This was previously only in doHeadSkeletonMerge.
-			// But surely non-head skeletons wouldn't have this anyway?
-			if (!strcmp(srcChild->name.c_str(), "BSFaceGenNiNodeSkinned")) {
-				logger::debug("Skipping facegen ninode in skeleton merge.");
-				continue;
-			}
-
-			// TODO check it's not a lurker skeleton
-			auto dstChild = findNode(dstRoot, srcChild->name);
-			if (dstChild) {
-				doSkeletonMerge(dstChild, srcChild, prefix, map, dstRoot, renameSource);
-			} else {
-				dst->AttachChild(cloneNodeTree(srcChild, prefix, map, renameSource), false);
-			}
-		}
-	}
-
-	RE::NiNode* ActorManager::Skeleton::cloneNodeTree(RE::NiNode* src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString>& map, bool renameSource)
-	{
-		//
-		RE::NiCloningProcess c;
-
-		//
-		c.appendChar = '$';
-		c.copyType = 1;
-		c.scale = { 1.0f, 1.0f, 1.0f };
-
-		auto ret = static_cast<RE::NiNode*>(src->CreateClone(c));
-		src->ProcessClone(c);
-
-		// Renaming the source tree for Head parts corrupts the shared npcFaceGeomNode cache,
-		// so only rename the source for armor merges where the source is a per-attachment tree
-		if (renameSource) {
-			renameTree(src, prefix, map);
-		}
-		renameTree(ret, prefix, map);
-
-		return ret;
-	}
-
-	void ActorManager::Skeleton::renameTree(RE::NiNode* root, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString>& map)
-	{
-		if (root->name.size()) {
-			std::string newName{ prefix };
-			newName += root->name;
-			if (map.insert(std::make_pair<RE::BSFixedString, RE::BSFixedString>(root->name.c_str(), newName)).second) {
-				logger::debug("Rename Bone {} -> {}.", root->name, newName.c_str());
-			}
-
-			setNiNodeName(root, newName.c_str());
+			return 0;
 		}
 
-		auto& children = root->GetChildren();
-		for (uint16_t i = 0; i < children.size(); ++i) {
-			auto child = castNiNode(children[static_cast<std::uint16_t>(i)].get());
-			if (child) {
-				renameTree(child, prefix, map);
-			}
+		void ActorManager::Skeleton::doSkeletonMerge(RE::NiNode * dst, RE::NiNode * src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString> & map, bool renameSource)
+		{
+			doSkeletonMerge(dst, src, prefix, map, dst, renameSource);
 		}
-	}
 
-	void ActorManager::Skeleton::doSkeletonClean(RE::NiNode* dst, std::string_view prefix)
-	{
-		std::vector<std::pair<RE::NiNode*, RE::NiAVObject*>> toDetach;
+		void ActorManager::Skeleton::doSkeletonMerge(RE::NiNode * dst, RE::NiNode * src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString> & map, RE::NiNode * dstRoot, bool renameSource)
+		{
+			const auto& children = src->GetChildren();
 
-		std::function<void(RE::NiNode*)> traverse = [&](RE::NiNode* node) {
-			if (!node)
-				return;
-			for (auto& childPtr : node->GetChildren()) {
-				if (!childPtr)
+			for (uint16_t i = 0; i < children.size(); ++i) {
+				auto srcChild = castNiNode(children[i].get());
+				if (!srcChild)
 					continue;
-				auto* rawChild = childPtr.get();
 
-				const char* cname = rawChild->name.c_str();
-				std::string_view childName = (cname && cname[0]) ? std::string_view(cname) : std::string_view{};
-
-				if (childName.size() >= prefix.size() &&
-					childName.substr(0, prefix.size()) == prefix) {
-					toDetach.push_back({ node, rawChild });
-				} else {
-					auto* childNode = rawChild->AsNode();
-					if (childNode) {
-						traverse(childNode);
-					}
-				}
-			}
-		};
-
-		traverse(dst);
-
-		for (auto& [parent, child] : toDetach) {
-			RE::NiPointer<RE::NiAVObject> ref;
-			parent->DetachChild(child, ref);
-		}
-	}
-
-	// returns the name of the skeleton owner
-	std::string ActorManager::Skeleton::name()
-	{
-		if (skeleton->GetUserData() && skeleton->GetUserData()->GetObjectReference()) {
-			auto bname = skyrim_cast<RE::TESFullName*>(skeleton->GetUserData()->GetObjectReference());
-			if (bname) {
-				return bname->GetFullName();
-			}
-		}
-		return "";
-	}
-
-	// Logs a warning once per NIF path when VR NiStream Type B stubs are found.
-	// Uses a static set to avoid duplicate warnings for the same NIF across frames.
-	static void logBrokenNifOnce(const char* nifPath, RE::NiAVObject* root)
-	{
-		if (!REL::Module::IsVR() || !nifPath || !root)
-			return;
-		static std::mutex warnedMutex;
-		static std::unordered_set<std::string> warned;
-		std::lock_guard lock(warnedMutex);
-		if (warned.count(nifPath))
-			return;
-		std::vector<RE::NiAVObject*> stack = { root };
-		while (!stack.empty()) {
-			auto obj = stack.back();
-			stack.pop_back();
-			if (!obj || !isValidNiObject(obj))
-				continue;
-			if (isVRNiStreamStub(obj)) {
-				warned.insert(nifPath);
-				logger::warn(
-					"[VR NiStream] NIF '{}' contains SE-format blocks VR cannot fully instantiate "
-					"(Type B stubs, broken vtable[43]). Run through Cathedral Assets Optimizer (CAO) for Skyrim VR.",
-					nifPath);
-				return;
-			}
-			auto node = obj->AsNode();
-			if (node)
-				for (auto& c : node->GetChildren())
-					if (c)
-						stack.push_back(c.get());
-		}
-	}
-
-	void ActorManager::Skeleton::addArmor(RE::NiNode* armorModel)
-	{
-		logBrokenNifOnce(armorModel->name.c_str(), armorModel);
-
-		IDType id = armors.size() ? armors.back().id + 1 : 0;
-		auto prefix = armorPrefix(id);
-		// FIXME we probably could simplify this by using findNode as surely we don't merge Armors with lurkers skeleton?
-		npc = hdt::make_nismart(getNpcNode(skeleton.get()));
-		auto physicsFile = DefaultBBP::instance()->scanBBP(armorModel);
-
-		armors.push_back(Armor());
-		armors.back().id = id;
-		armors.back().prefix = prefix;
-		armors.back().physicsFile = physicsFile;
-
-		doSkeletonMerge(npc.get(), armorModel, prefix, armors.back().renameMap);
-	}
-
-	void ActorManager::Skeleton::attachArmor([[maybe_unused]] RE::NiNode* armorModel, RE::NiAVObject* attachedNode)
-	{
-		if (armors.size() == 0 || armors.back().hasPhysics()) {
-			logger::trace("Not attaching armor - no record or physics already exists");
-		}
-
-		Armor& armor = armors.back();
-
-		// The name of the attachedNode provided here will have been changed by the Skyrim exe between this event and the next.
-		armor.armorWorn = hdt::make_nismart(attachedNode);
-		// That's why we set here the need to fix this armor in fixArmorNameMaps() (see its comment)
-		// to avoid this name change breaking processes like 'smp reset' when looking for the armor name in the armor nameMap.
-		armor.armorCurrentMeshName = attachedNode->name.size() ? attachedNode->name : "";
-		armor.mustFixNameMap = true;
-		mustFixOneArmorMap = true;
-
-		if (!isFirstPersonSkeleton(skeleton.get())) {
-			// FIXME we probably could simplify this by using findNode as surely we don't attach Armors to lurkers skeleton?
-			auto renameMap = armor.renameMap;
-			auto system = SkyrimSystemCreator().createOrUpdateSystem(getNpcNode(skeleton.get()), attachedNode, &armor.physicsFile, std::move(renameMap), nullptr);
-			if (system) {
-				armor.setPhysics(system, isActive);
-				hasPhysics = true;
-			}
-		}
-
-		if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
-			RE::Actor* actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID);
-			if (actor) {
-				setHeadActiveIfNoHairArmor(actor, this);
-			}
-		}
-	}
-
-	void ActorManager::Skeleton::cleanArmor()
-	{
-		for (auto& i : armors) {
-			if (!i.armorWorn) {
-				continue;
-			}
-
-			if (i.armorWorn->parent) {
-				continue;
-			}
-
-			i.clearPhysics();
-			if (npc) {
-				doSkeletonClean(npc.get(), i.prefix);
-			}
-
-			i.prefix = std::string();
-		}
-
-		armors.erase(std::remove_if(armors.begin(), armors.end(), [](Armor& i) { return i.prefix.empty(); }), armors.end());
-	}
-
-	void ActorManager::Skeleton::cleanHead(bool cleanAll)
-	{
-		for (auto& headPart : head.headParts) {
-			if (!headPart.headPart->parent || cleanAll) {
-				if (cleanAll) {
-					logger::debug("Cleaning headpart {} due to clean all.", headPart.headPart->name);
-				} else {
-					logger::debug("Headpart {} disconnected.", headPart.headPart->name);
+				if (!srcChild->name.size()) {
+					doSkeletonMerge(dst, srcChild, prefix, map, dstRoot, renameSource);
+					continue;
 				}
 
-				auto renameIt = this->head.renameMap.begin();
-				while (renameIt != this->head.renameMap.end()) {
-					bool erase = false;
+				// FIXME: This was previously only in doHeadSkeletonMerge.
+				// But surely non-head skeletons wouldn't have this anyway?
+				if (!strcmp(srcChild->name.c_str(), "BSFaceGenNiNodeSkinned")) {
+					logger::debug("Skipping facegen ninode in skeleton merge.");
+					continue;
+				}
 
-					if (headPart.renamedBonesInUse.count(renameIt->first) != 0) {
-						auto findNode = this->head.nodeUseCount.find(renameIt->first);
-						if (findNode != this->head.nodeUseCount.end()) {
-							findNode->second -= 1;
-							logger::debug("Decrementing use count by 1, it is now {}.", findNode->second);
-							if (findNode->second <= 0) {
-								logger::debug("Node no longer in use, cleaning from skeleton.");
-								auto removeObj = findObject(npc.get(), renameIt->second);
-								if (removeObj) {
-									logger::debug("Found node {}, removing.", removeObj->name);
-									auto parent = removeObj->parent;
-									if (parent) {
-										parent->DetachChild2(removeObj);
-									}
-								}
-								this->head.nodeUseCount.erase(findNode);
-								erase = true;
-							}
+				// TODO check it's not a lurker skeleton
+				auto dstChild = findNode(dstRoot, srcChild->name);
+				if (dstChild) {
+					doSkeletonMerge(dstChild, srcChild, prefix, map, dstRoot, renameSource);
+				} else {
+					dst->AttachChild(cloneNodeTree(srcChild, prefix, map, renameSource), false);
+				}
+			}
+		}
+
+		RE::NiNode* ActorManager::Skeleton::cloneNodeTree(RE::NiNode * src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString> & map, bool renameSource)
+		{
+			//
+			RE::NiCloningProcess c;
+
+			//
+			c.appendChar = '$';
+			c.copyType = 1;
+			c.scale = { 1.0f, 1.0f, 1.0f };
+
+			auto ret = static_cast<RE::NiNode*>(src->CreateClone(c));
+			src->ProcessClone(c);
+
+			// Renaming the source tree for Head parts corrupts the shared npcFaceGeomNode cache,
+			// so only rename the source for armor merges where the source is a per-attachment tree
+			if (renameSource) {
+				renameTree(src, prefix, map);
+			}
+			renameTree(ret, prefix, map);
+
+			return ret;
+		}
+
+		void ActorManager::Skeleton::renameTree(RE::NiNode * root, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString> & map)
+		{
+			if (root->name.size()) {
+				std::string newName{ prefix };
+				newName += root->name;
+				if (map.insert(std::make_pair<RE::BSFixedString, RE::BSFixedString>(root->name.c_str(), newName)).second) {
+					logger::debug("Rename Bone {} -> {}.", root->name, newName.c_str());
+				}
+
+				setNiNodeName(root, newName.c_str());
+			}
+
+			auto& children = root->GetChildren();
+			for (uint16_t i = 0; i < children.size(); ++i) {
+				auto child = castNiNode(children[static_cast<std::uint16_t>(i)].get());
+				if (child) {
+					renameTree(child, prefix, map);
+				}
+			}
+		}
+
+		void ActorManager::Skeleton::doSkeletonClean(RE::NiNode * dst, std::string_view prefix)
+		{
+			std::vector<std::pair<RE::NiNode*, RE::NiAVObject*>> toDetach;
+
+			std::function<void(RE::NiNode*)> traverse = [&](RE::NiNode* node) {
+				if (!node)
+					return;
+				for (auto& childPtr : node->GetChildren()) {
+					if (!childPtr)
+						continue;
+					auto* rawChild = childPtr.get();
+
+					const char* cname = rawChild->name.c_str();
+					std::string_view childName = (cname && cname[0]) ? std::string_view(cname) : std::string_view{};
+
+					if (childName.size() >= prefix.size() &&
+						childName.substr(0, prefix.size()) == prefix) {
+						toDetach.push_back({ node, rawChild });
+					} else {
+						auto* childNode = rawChild->AsNode();
+						if (childNode) {
+							traverse(childNode);
 						}
 					}
-
-					if (erase) {
-						renameIt = this->head.renameMap.erase(renameIt);
-					} else {
-						++renameIt;
-					}
 				}
+			};
 
-				headPart.headPart = nullptr;
-				headPart.origPartRootNode = nullptr;
-				headPart.clearPhysics();
-				headPart.renamedBonesInUse.clear();
+			traverse(dst);
+
+			for (auto& [parent, child] : toDetach) {
+				RE::NiPointer<RE::NiAVObject> ref;
+				parent->DetachChild(child, ref);
 			}
 		}
 
-		head.headParts.erase(std::remove_if(head.headParts.begin(), head.headParts.end(), [](Head::HeadPart& i) { return !i.headPart; }), head.headParts.end());
-	}
-
-	void ActorManager::Skeleton::clear()
-	{
-		std::for_each(armors.begin(), armors.end(), [](Armor& armor) { armor.clearPhysics(); });
-		SkyrimPhysicsWorld::get()->removeSystemByNode(npc.get());
-		cleanHead();
-		head.headParts.clear();
-		head.headNode = nullptr;
-		armors.clear();
-	}
-
-	void ActorManager::Skeleton::calculateDistanceAndOrientationDifferenceFromSource(RE::NiPoint3 sourcePosition, RE::NiPoint3 sourceOrientation)
-	{
-		if (isPlayerCharacter()) {
-			m_distanceFromCamera2 = 0.f;
-			return;
-		}
-
-		auto pos = position();
-		if (!pos.has_value()) {
-			m_distanceFromCamera2 = std::numeric_limits<float>::max();
-			return;
-		}
-
-		// We calculate the vector between camera and the skeleton feet.
-		const auto camera2SkeletonVector = pos.value() - sourcePosition;
-		// This is the distance (squared) between the camera and the skeleton feet.
-		m_distanceFromCamera2 = camera2SkeletonVector.x * camera2SkeletonVector.x + camera2SkeletonVector.y * camera2SkeletonVector.y + camera2SkeletonVector.z * camera2SkeletonVector.z;
-		// This is |camera2SkeletonVector|*cos(angle between both vectors)
-		m_cosAngleFromCameraDirectionTimesSkeletonDistance = camera2SkeletonVector.x * sourceOrientation.x + camera2SkeletonVector.y * sourceOrientation.y + camera2SkeletonVector.z * sourceOrientation.z;
-	}
-
-	// Is called to print messages only
-	bool ActorManager::Skeleton::checkPhysics()
-	{
-		hasPhysics = false;
-		std::for_each(armors.begin(), armors.end(), [=](Armor& armor) {
-			if (armor.state() != ItemState::e_NoPhysics) {
-				hasPhysics = true;
-			}
-		});
-
-		if (!hasPhysics) {
-			std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) {
-				if (headPart.state() != ItemState::e_NoPhysics) {
-					hasPhysics = true;
-				}
-			});
-		}
-
-		logger::trace("{} isDrawn {}", name(), hasPhysics);
-
-		return hasPhysics;
-	}
-
-	bool ActorManager::Skeleton::isActiveInScene() const
-	{
-		// TODO: do this better
-		// When entering/exiting an interior, NPCs are detached from the scene but not unloaded, so we need to check two levels up.
-		// This properly removes exterior cell armors from the physics world when entering an interior, and vice versa.
-		return skeleton->parent && skeleton->parent->parent && skeleton->parent->parent->parent;
-	}
-
-	bool ActorManager::Skeleton::isPlayerCharacter() const
-	{
-		constexpr uint32_t playerFormID = 0x14;
-		return skeletonOwner.get() == RE::PlayerCharacter::GetSingleton() || (skeleton->GetUserData() && skeleton->GetUserData()->formID == playerFormID);
-	}
-
-	bool ActorManager::Skeleton::isInPlayerView()
-	{
-		// This function is called only when the skeleton isn't the player character.
-		// This might change in the future; in that case this test will have to be enabled.
-		//if (isPlayerCharacter())
-		//	return true;
-
-		auto* manager = ActorManager::instance();
-		const float minDist = manager->m_minCullingDistance;
-
-		// We always enable the skeletons that are just around the camera.
-		// It's useful if for example the skeleton origin is very near, behind the camera,
-		// but some parts of the skeleton are in front of the camera and need to be animated.
-		if (m_distanceFromCamera2 < minDist * minDist)
-			return true;
-
-		auto* owner = skyrim_cast<RE::Actor*>(skeletonOwner.get());
-		if (!owner)
-			return true;  // should never happen, a skeleton without owner?
-
-		// We don't enable the skeletons off-screen
-		auto* camera = RE::Main::WorldRootCamera();
-		auto* skeleton3D = owner->Get3D(false);
-
-		if (!skeleton3D || (camera && !camera->NodeInFrustum(skeleton3D)))
-			return false;
-
-		// Is the skeleton too small on screen?
-		// Ie, is the NPC's projected bounding sphere smaller than the allowed fraction of screen height?
-		// screenFraction < minFraction <=> r / (distance * tan(fov/2)) < fr <=> r^2 < fr^2 * distance^2 * tan(fov/2)^2
-		if (manager->m_screenSizeThresholdScale > 0.f) {
-			const auto& bound = skeleton3D->worldBound;
-			const auto cameraToBound = bound.center - manager->m_cameraPositionDuringFrame;
-			const float distanceToBound2 = cameraToBound.x * cameraToBound.x + cameraToBound.y * cameraToBound.y + cameraToBound.z * cameraToBound.z;
-
-			if (distanceToBound2 > bound.radius * bound.radius) {
-				// Use the nearest point on the sphere for a conservative size estimate.
-				const float visibleDistance = std::sqrt(distanceToBound2) - bound.radius;
-				if (bound.radius * bound.radius < manager->m_screenSizeThresholdScale * visibleDistance * visibleDistance)
-					return false;
-			}
-		}
-
-		RE::NiPoint3 hitLocation;
-		auto* obstacle = Actor_CalculateLOS(owner, &manager->m_cameraPositionDuringFrame, &hitLocation, 6.28f);
-		return !obstacle;  // If obstacle, we hit something on the path
-	}
-
-	std::optional<RE::NiPoint3> ActorManager::Skeleton::position() const
-	{
-		if (npc) {
-			// This works for lurker skeletons.
-			auto rootNode = findNode(npc.get(), "NPC Root [Root]");
-			if (rootNode) {
-				return std::optional<RE::NiPoint3>(rootNode->world.translate);
-			}
-		}
-
-		return std::optional<RE::NiPoint3>();
-	}
-
-	void ActorManager::Skeleton::updateWindFactor(float a_windFactor)
-	{
-		this->currentWindFactor = a_windFactor;
-		std::for_each(armors.begin(), armors.end(), [=](Armor& armor) { armor.setWindFactor(a_windFactor); });
-		std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) { headPart.setWindFactor(a_windFactor); });
-	}
-
-	float ActorManager::Skeleton::getWindFactor()
-	{
-		return this->currentWindFactor;
-	}
-
-	bool ActorManager::Skeleton::updateAttachedState(const RE::NiNode* playerCell, bool deactivate = false)
-	{
-		// 1- Skeletons that aren't active in any scene are always detached, unless they are in the
-		// same cell as the player character (workaround for issue in Ancestor Glade).
-		// 2- Player character is always attached.
-		// 3- Otherwise, attach only if both the camera and this skeleton have a position,
-		// the distance between them is below the threshold value,
-		// and the angle difference between the camera orientation and the skeleton orientation is below the threshold value.
-		isActive = false;
-		state = SkeletonState::e_InactiveNotInScene;
-
-		if (deactivate)
-			state = SkeletonState::e_InactiveTooFar;
-		else if (isActiveInScene() || skeleton->parent && skeleton->parent->parent == playerCell) {
-			if (isPlayerCharacter()) {
-				// That setting defines whether we don't set the PC skeleton as active
-				// when it is in 1st person view, to avoid calculating physics uselessly.
-				if (!(instance()->m_disable1stPersonViewPhysics                                                                                    // disabling?
-						&& RE::PlayerCamera::GetSingleton()->currentState == RE::PlayerCamera::GetSingleton()->GetRuntimeData().cameraStates[0]))  // 1st person view
-				{
-					isActive = true;
-					state = SkeletonState::e_ActiveIsPlayer;
-				}
-			} else if (isInPlayerView()) {
-				isActive = true;
-				state = SkeletonState::e_ActiveNearPlayer;
-			} else
-				state = SkeletonState::e_InactiveUnseenByPlayer;
-		}
-
-		// We update the activity state of armors and head parts, and add and remove SkinnedMeshSystems to these parts in consequence.
-		// We set headparts as not active if the head isn't active (for example because it's hidden by a wig).
-		std::for_each(armors.begin(), armors.end(), [=](Armor& armor) { armor.updateActive(isActive); });
-		const bool isHeadActive = head.isActive;
-		std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) { headPart.updateActive(isHeadActive && isActive); });
-		return isActive;
-	}
-
-	void ActorManager::Skeleton::reloadMeshes()
-	{
-		for (auto& i : armors) {
-			i.clearPhysics();
-			if (!isFirstPersonSkeleton(skeleton.get())) {
-				auto renameMap = i.renameMap;
-				auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), i.armorWorn.get(), &i.physicsFile, std::move(renameMap), nullptr);
-				if (system) {
-					i.setPhysics(system, isActive);
-					hasPhysics = true;
+		// returns the name of the skeleton owner
+		std::string ActorManager::Skeleton::name()
+		{
+			if (skeleton->GetUserData() && skeleton->GetUserData()->GetObjectReference()) {
+				auto bname = skyrim_cast<RE::TESFullName*>(skeleton->GetUserData()->GetObjectReference());
+				if (bname) {
+					return bname->GetFullName();
 				}
 			}
+			return "";
 		}
-		scanHead();
-	}
 
-	// Reload meshes without entirely wiping their physics
-	void ActorManager::Skeleton::softReloadMeshes()
-	{
-		auto reloadPhysicsItem = [&](auto& item, RE::NiAVObject* model, const auto& renameMapSrc, bool itemActive) {
-			RE::BSTSmartPointer<SkyrimSystem> oldSystem = item.m_physics;
-			item.clearPhysics();
-
-			if (!model || isFirstPersonSkeleton(skeleton.get()) || item.physicsFile.first.empty()) {
+		// Logs a warning once per NIF path when VR NiStream Type B stubs are found.
+		// Uses a static set to avoid duplicate warnings for the same NIF across frames.
+		static void logBrokenNifOnce(const char* nifPath, RE::NiAVObject* root)
+		{
+			if (!REL::Module::IsVR() || !nifPath || !root)
 				return;
+			static std::mutex warnedMutex;
+			static std::unordered_set<std::string> warned;
+			std::lock_guard lock(warnedMutex);
+			if (warned.count(nifPath))
+				return;
+			std::vector<RE::NiAVObject*> stack = { root };
+			while (!stack.empty()) {
+				auto obj = stack.back();
+				stack.pop_back();
+				if (!obj || !isValidNiObject(obj))
+					continue;
+				if (isVRNiStreamStub(obj)) {
+					warned.insert(nifPath);
+					logger::warn(
+						"[VR NiStream] NIF '{}' contains SE-format blocks VR cannot fully instantiate "
+						"(Type B stubs, broken vtable[43]). Run through Cathedral Assets Optimizer (CAO) for Skyrim VR.",
+						nifPath);
+					return;
+				}
+				auto node = obj->AsNode();
+				if (node)
+					for (auto& c : node->GetChildren())
+						if (c)
+							stack.push_back(c.get());
+			}
+		}
+
+		void ActorManager::Skeleton::addArmor(RE::NiNode * armorModel)
+		{
+			logBrokenNifOnce(armorModel->name.c_str(), armorModel);
+
+			IDType id = armors.size() ? armors.back().id + 1 : 0;
+			auto prefix = armorPrefix(id);
+			// FIXME we probably could simplify this by using findNode as surely we don't merge Armors with lurkers skeleton?
+			npc = hdt::make_nismart(getNpcNode(skeleton.get()));
+			auto physicsFile = DefaultBBP::instance()->scanBBP(armorModel);
+
+			armors.push_back(Armor());
+			armors.back().id = id;
+			armors.back().prefix = prefix;
+			armors.back().physicsFile = physicsFile;
+
+			doSkeletonMerge(npc.get(), armorModel, prefix, armors.back().renameMap);
+		}
+
+		void ActorManager::Skeleton::attachArmor([[maybe_unused]] RE::NiNode * armorModel, RE::NiAVObject * attachedNode)
+		{
+			if (armors.size() == 0 || armors.back().hasPhysics()) {
+				logger::trace("Not attaching armor - no record or physics already exists");
 			}
 
-			auto renameMap = renameMapSrc;
-			auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), model, &item.physicsFile, std::move(renameMap), nullptr);
+			Armor& armor = armors.back();
 
-			if (system) {
-				system->block_resetting = true;
-				if (oldSystem) {
-					hdt::util::transferCurrentPosesBetweenSystems(oldSystem.get(), system.get());
+			// The name of the attachedNode provided here will have been changed by the Skyrim exe between this event and the next.
+			armor.armorWorn = hdt::make_nismart(attachedNode);
+			// That's why we set here the need to fix this armor in fixArmorNameMaps() (see its comment)
+			// to avoid this name change breaking processes like 'smp reset' when looking for the armor name in the armor nameMap.
+			armor.armorCurrentMeshName = attachedNode->name.size() ? attachedNode->name : "";
+			armor.mustFixNameMap = true;
+			mustFixOneArmorMap = true;
+
+			if (!isFirstPersonSkeleton(skeleton.get())) {
+				// FIXME we probably could simplify this by using findNode as surely we don't attach Armors to lurkers skeleton?
+				auto renameMap = armor.renameMap;
+				auto system = SkyrimSystemCreator().createOrUpdateSystem(getNpcNode(skeleton.get()), attachedNode, &armor.physicsFile, std::move(renameMap), nullptr);
+				if (system) {
+					armor.setPhysics(system, isActive);
+					hasPhysics = true;
+				}
+			}
+
+			if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
+				RE::Actor* actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID);
+				if (actor) {
+					setHeadActiveIfNoHairArmor(actor, this);
+				}
+			}
+		}
+
+		void ActorManager::Skeleton::cleanArmor()
+		{
+			for (auto& i : armors) {
+				if (!i.armorWorn) {
+					continue;
 				}
 
-				item.setPhysics(system, itemActive);
-				hasPhysics = true;
-				system->block_resetting = false;
-			}
-		};
+				if (i.armorWorn->parent) {
+					continue;
+				}
 
-		for (auto& armor : armors) {
-			reloadPhysicsItem(armor, armor.armorWorn.get(), armor.renameMap, isActive);
-		}
+				i.clearPhysics();
+				if (npc) {
+					doSkeletonClean(npc.get(), i.prefix);
+				}
 
-		if (isFirstPersonSkeleton(skeleton.get()) || !head.headNode) {
-			return;
-		}
-
-		if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
-			if (auto actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID)) {
-				setHeadActiveIfNoHairArmor(actor, this);
-			}
-		}
-
-		std::unordered_set<std::string> physicsDupes;
-		for (auto& headPart : head.headParts) {
-			// Skip duplicate physics files, but ensure we clear their old physics
-			if (!headPart.physicsFile.first.empty() && !physicsDupes.insert(headPart.physicsFile.first).second) {
-				headPart.clearPhysics();
-				continue;
+				i.prefix = std::string();
 			}
 
-			reloadPhysicsItem(headPart, head.headNode.get(), head.renameMap, isActive && head.isActive);
-		}
-	}
-
-	void ActorManager::Skeleton::scanHead()
-	{
-		if (isFirstPersonSkeleton(this->skeleton.get())) {
-			logger::debug("Not scanning head of first person skeleton.");
-			return;
+			armors.erase(std::remove_if(armors.begin(), armors.end(), [](Armor& i) { return i.prefix.empty(); }), armors.end());
 		}
 
-		if (!this->head.headNode) {
-			logger::debug("Actor has no head node.");
-			return;
-		}
-
-		std::unordered_set<std::string> physicsDupes;
-
-		if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
-			RE::Actor* actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID);
-			if (actor) {
-				setHeadActiveIfNoHairArmor(actor, this);
-			}
-		}
-
-		for (auto& headPart : this->head.headParts) {
-			// always regen physics for all head parts
-			headPart.clearPhysics();
-
-			if (headPart.physicsFile.first.empty()) {
-				logger::debug("No physics file for headpart {}.", headPart.headPart->name);
-				continue;
-			}
-
-			if (physicsDupes.count(headPart.physicsFile.first)) {
-				logger::debug("Previous head part generated physics system for file {}, skipping.", headPart.physicsFile.first.c_str());
-				continue;
-			}
-
-			logger::debug("Try create system for headpart {} physics file {}.", headPart.headPart->name, headPart.physicsFile.first.c_str());
-			physicsDupes.insert(headPart.physicsFile.first);
-			auto renameMap = this->head.renameMap;
-			auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), this->head.headNode.get(), &headPart.physicsFile, std::move(renameMap), nullptr);
-			if (system) {
-				logger::debug("Success.");
-				headPart.setPhysics(system, isActive);
-				hasPhysics = true;
-			}
-		}
-	}
-
-	void ActorManager::Skeleton::processGeometry(RE::BSFaceGenNiNode* headNode, RE::BSGeometry* geometry)
-	{
-		if (this->head.headNode && this->head.headNode != headNode) {
-			logger::debug("Completely new head attached to skeleton, clearing tracking.");
-			for (auto& headPart : this->head.headParts) {
-				headPart.clearPhysics();
-				headPart.headPart = nullptr;
-				headPart.origPartRootNode = nullptr;
-			}
-
-			this->head.headParts.clear();
-
-			if (npc)
-				doSkeletonClean(npc.get(), this->head.prefix);
-
-			this->head.prefix = std::string();
-			this->head.headNode = nullptr;
-			this->head.renameMap.clear();
-			this->head.nodeUseCount.clear();
-		}
-
-		// clean swapped out headparts
-		cleanHead();
-
-		// Todo: This didn't have a null check before, but I don't see why not.
-		if (!this->head.headNode) {
-			this->head.headNode = hdt::make_nismart(headNode);
-			++this->head.id;
-			this->head.prefix = headPrefix(this->head.id);
-		}
-
-		auto it = std::find_if(this->head.headParts.begin(), this->head.headParts.end(), [geometry](const Head::HeadPart& p) {
-			return p.headPart == geometry;
-		});
-
-		if (it != this->head.headParts.end()) {
-			logger::debug("Geometry is already added as head part.");
-			return;
-		}
-
-		this->head.headParts.push_back(Head::HeadPart());
-
-		head.headParts.back().headPart = hdt::make_nismart(geometry);
-		head.headParts.back().clearPhysics();
-
-		// Skinning
-		logger::debug("Skinning geometry to skeleton.");
-
-		if (!geometry->GetGeometryRuntimeData().skinInstance || !geometry->GetGeometryRuntimeData().skinInstance->skinData) {
-			logger::error("Geometry is missing skin instance - how?");
-			return;
-		}
-
-		auto fmd = geometry->GetExtraData<RE::BSFaceGenModelExtraData>("FMD");
-
-		RE::BSGeometry* origGeom = nullptr;
-		RE::NiGeometry* origNiGeom = nullptr;
-
-		if (fmd && fmd->m_model && fmd->m_model->modelMeshData && fmd->m_model->modelMeshData->faceNode) {
-			logger::debug("Original part node found via facegen extra model data.");
-			auto origRootNode = fmd->m_model->modelMeshData->faceNode->AsNode();
-			head.headParts.back().physicsFile = DefaultBBP::instance()->scanBBP(origRootNode);
-			head.headParts.back().origPartRootNode = hdt::make_nismart(origRootNode);
-
-			auto& children = origRootNode->GetChildren();
-			for (uint16_t i = 0; i < children.size(); i++) {
-				if (children[i]) {
-					const auto geo = children[i]->AsGeometry();
-
-					if (geo) {
-						origGeom = geo;
-						break;
+		void ActorManager::Skeleton::cleanHead(bool cleanAll)
+		{
+			for (auto& headPart : head.headParts) {
+				if (!headPart.headPart->parent || cleanAll) {
+					if (cleanAll) {
+						logger::debug("Cleaning headpart {} due to clean all.", headPart.headPart->name);
+					} else {
+						logger::debug("Headpart {} disconnected.", headPart.headPart->name);
 					}
-				}
-			}
-		} else {
-			logger::debug("No facegen extra model data available, loading original facegeometry.");
-			if (!head.npcFaceGeomNode && !head.npcFaceGeomNodeBroken) {
-				if (skeleton->GetUserData() && skeleton->GetUserData()->GetObjectReference()) {
-					auto skeletonNpc = skyrim_cast<RE::TESNPC*>(skeleton->GetUserData()->GetObjectReference());
-					if (skeletonNpc) {
-						char filePath[MAX_PATH];
-						if (TESNPC_GetFaceGeomPath(skeletonNpc, filePath)) {
-							logger::debug("Loading facegeometry via BSModelDB from path {}.", filePath);
 
-							// same DBTraits Bethesda uses for FaceGen (from FUN_1403bbe00 on AE)
-							RE::BSModelDB::DBTraits::ArgsType args;
-							args.LODmult = 0;
-							args.texLoadLevel = 3;
-							args.unk8 = false;
-							args.unk9 = true;
-							args.unkA = false;
-							args.postProcess = true;
+					auto renameIt = this->head.renameMap.begin();
+					while (renameIt != this->head.renameMap.end()) {
+						bool erase = false;
 
-							RE::NiPointer<RE::NiNode> loadedModel;
-							auto error = RE::BSModelDB::Demand(filePath, loadedModel, args);
-
-							if (error == RE::BSResource::ErrorCode::kNone && loadedModel) {
-								auto rootFadeNode = loadedModel->AsFadeNode();
-								if (rootFadeNode) {
-									logger::debug("NPC facegeometry root fadeNode successfully loaded.");
-
-									// Because we mutate rootFadeNode, we MUST deep clone the cached model!
-									// The clone can't be null (Otherwise it would CTD internally), so no null checks needed
-									RE::NiCloningProcess c;
-
-									// These just say, copy the original exactly
-									c.copyType = 1;
-									c.scale = { 1.0f, 1.0f, 1.0f };
-
-									auto clonedObj = rootFadeNode->CreateClone(c);
-									rootFadeNode->ProcessClone(c);
-									auto clonedRoot = static_cast<RE::BSFadeNode*>(clonedObj);
-
-									// VR stuff probably still needed?
-									// VR: NiSkinInstance::LinkObject fails to resolve internal bone refs,
-									// storing the bone name as a raw char* instead of a resolved NiNode*.
-									// Bone NiNodes are self-contained in the face geometry NIF, so resolve
-									// them now by name lookup against the loaded tree.
-									// Must run before NiStream_deconstructor while the tree is live.
-									if (REL::Module::IsVR()) {
-										auto& ch = clonedRoot->GetChildren();
-										for (std::uint16_t ci = 0; ci < ch.size(); ++ci) {
-											auto faceChild = ch[ci].get();
-											if (!faceChild || !isValidNiObject(faceChild))
-												continue;
-											auto faceGeo = faceChild->AsGeometry();
-											if (!faceGeo)
-												continue;
-											const auto& grd = faceGeo->GetGeometryRuntimeData();
-											if (!grd.skinInstance || !grd.skinInstance->skinData)
-												continue;
-											std::uint32_t vrResolved = 0, vrFailed = 0;
-											for (std::uint32_t bi = 0; bi < grd.skinInstance->skinData->bones; ++bi) {
-												auto bone = grd.skinInstance->bones[bi];
-												if (!bone || isValidNiObject(bone))
-													continue;
-												// char* case: bone pointer is canonical but its bytes are not a valid vtable.
-												// Guard against truly non-canonical addresses before reading as a string.
-												if (reinterpret_cast<uintptr_t>(bone) > kCanonicalUserSpaceMax)
-													continue;
-												const char* name = reinterpret_cast<const char*>(bone);
-												auto result = findNode(clonedRoot, RE::BSFixedString(name));
-												grd.skinInstance->bones[bi] = result;
-												if (result)
-													++vrResolved;
-												else {
-													++vrFailed;
-													logger::warn("VR bone fix '{}': bone[{}] '{}' not found in NIF tree.", faceGeo->name.c_str(), bi, name);
-												}
-											}
-											if (vrResolved || vrFailed)
-												logger::info("VR bone fix '{}': resolved {}/{} unresolved bone refs in '{}'.", faceGeo->name.c_str(), vrResolved, vrResolved + vrFailed, filePath);
+						if (headPart.renamedBonesInUse.count(renameIt->first) != 0) {
+							auto findNode = this->head.nodeUseCount.find(renameIt->first);
+							if (findNode != this->head.nodeUseCount.end()) {
+								findNode->second -= 1;
+								logger::debug("Decrementing use count by 1, it is now {}.", findNode->second);
+								if (findNode->second <= 0) {
+									logger::debug("Node no longer in use, cleaning from skeleton.");
+									auto removeObj = findObject(npc.get(), renameIt->second);
+									if (removeObj) {
+										logger::debug("Found node {}, removing.", removeObj->name);
+										auto parent = removeObj->parent;
+										if (parent) {
+											parent->DetachChild2(removeObj);
 										}
 									}
-
-									head.npcFaceGeomNode = hdt::make_nismart(clonedRoot);
-								} else {
-									logger::debug("NPC facegeometry root wasn't fadeNode as expected.");
+									this->head.nodeUseCount.erase(findNode);
+									erase = true;
 								}
-							} else {
-								logger::error("Facegeometry rejected by BSModelDB. Possibly a corrupted or unconverted LE mesh.");
-								head.npcFaceGeomNodeBroken = true;
 							}
 						}
-					}
-				}
-			} else
-				logger::debug("Using cached facegeometry.");
-			if (head.npcFaceGeomNode) {
-				head.headParts.back().physicsFile = DefaultBBP::instance()->scanBBP(head.npcFaceGeomNode.get());
-				auto obj = findObject(head.npcFaceGeomNode.get(), geometry->name);
-				if (obj) {
-					auto ob = obj->AsGeometry();
-					if (ob) {
-						origGeom = ob;
-					} else {
-						auto on = obj->AsNiGeometry();
-						if (on) {
-							origNiGeom = on;
+
+						if (erase) {
+							renameIt = this->head.renameMap.erase(renameIt);
+						} else {
+							++renameIt;
 						}
 					}
+
+					headPart.headPart = nullptr;
+					headPart.origPartRootNode = nullptr;
+					headPart.clearPhysics();
+					headPart.renamedBonesInUse.clear();
+				}
+			}
+
+			head.headParts.erase(std::remove_if(head.headParts.begin(), head.headParts.end(), [](Head::HeadPart& i) { return !i.headPart; }), head.headParts.end());
+		}
+
+		void ActorManager::Skeleton::clear()
+		{
+			std::for_each(armors.begin(), armors.end(), [](Armor& armor) { armor.clearPhysics(); });
+			SkyrimPhysicsWorld::get()->removeSystemByNode(npc.get());
+			cleanHead();
+			head.headParts.clear();
+			head.headNode = nullptr;
+			armors.clear();
+		}
+
+		void ActorManager::Skeleton::calculateDistanceAndOrientationDifferenceFromSource(RE::NiPoint3 sourcePosition, RE::NiPoint3 sourceOrientation)
+		{
+			if (isPlayerCharacter()) {
+				m_distanceFromCamera2 = 0.f;
+				return;
+			}
+
+			auto pos = position();
+			if (!pos.has_value()) {
+				m_distanceFromCamera2 = std::numeric_limits<float>::max();
+				return;
+			}
+
+			// We calculate the vector between camera and the skeleton feet.
+			const auto camera2SkeletonVector = pos.value() - sourcePosition;
+			// This is the distance (squared) between the camera and the skeleton feet.
+			m_distanceFromCamera2 = camera2SkeletonVector.x * camera2SkeletonVector.x + camera2SkeletonVector.y * camera2SkeletonVector.y + camera2SkeletonVector.z * camera2SkeletonVector.z;
+			// This is |camera2SkeletonVector|*cos(angle between both vectors)
+			m_cosAngleFromCameraDirectionTimesSkeletonDistance = camera2SkeletonVector.x * sourceOrientation.x + camera2SkeletonVector.y * sourceOrientation.y + camera2SkeletonVector.z * sourceOrientation.z;
+		}
+
+		// Is called to print messages only
+		bool ActorManager::Skeleton::checkPhysics()
+		{
+			hasPhysics = false;
+			std::for_each(armors.begin(), armors.end(), [=](Armor& armor) {
+				if (armor.state() != ItemState::e_NoPhysics) {
+					hasPhysics = true;
+				}
+			});
+
+			if (!hasPhysics) {
+				std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) {
+					if (headPart.state() != ItemState::e_NoPhysics) {
+						hasPhysics = true;
+					}
+				});
+			}
+
+			logger::trace("{} isDrawn {}", name(), hasPhysics);
+
+			return hasPhysics;
+		}
+
+		bool ActorManager::Skeleton::isActiveInScene() const
+		{
+			// TODO: do this better
+			// When entering/exiting an interior, NPCs are detached from the scene but not unloaded, so we need to check two levels up.
+			// This properly removes exterior cell armors from the physics world when entering an interior, and vice versa.
+			return skeleton->parent && skeleton->parent->parent && skeleton->parent->parent->parent;
+		}
+
+		bool ActorManager::Skeleton::isPlayerCharacter() const
+		{
+			constexpr uint32_t playerFormID = 0x14;
+			return skeletonOwner.get() == RE::PlayerCharacter::GetSingleton() || (skeleton->GetUserData() && skeleton->GetUserData()->formID == playerFormID);
+		}
+
+		bool ActorManager::Skeleton::isInPlayerView()
+		{
+			// This function is called only when the skeleton isn't the player character.
+			// This might change in the future; in that case this test will have to be enabled.
+			//if (isPlayerCharacter())
+			//	return true;
+
+			auto* manager = ActorManager::instance();
+			const float minDist = manager->m_minCullingDistance;
+
+			// We always enable the skeletons that are just around the camera.
+			// It's useful if for example the skeleton origin is very near, behind the camera,
+			// but some parts of the skeleton are in front of the camera and need to be animated.
+			if (m_distanceFromCamera2 < minDist * minDist)
+				return true;
+
+			auto* owner = skyrim_cast<RE::Actor*>(skeletonOwner.get());
+			if (!owner)
+				return true;  // should never happen, a skeleton without owner?
+
+			// We don't enable the skeletons off-screen
+			auto* camera = RE::Main::WorldRootCamera();
+			auto* skeleton3D = owner->Get3D(false);
+
+			if (!skeleton3D || (camera && !camera->NodeInFrustum(skeleton3D)))
+				return false;
+
+			// Is the skeleton too small on screen?
+			// Ie, is the NPC's projected bounding sphere smaller than the allowed fraction of screen height?
+			// screenFraction < minFraction <=> r / (distance * tan(fov/2)) < fr <=> r^2 < fr^2 * distance^2 * tan(fov/2)^2
+			if (manager->m_screenSizeThresholdScale > 0.f) {
+				const auto& bound = skeleton3D->worldBound;
+				const auto cameraToBound = bound.center - manager->m_cameraPositionDuringFrame;
+				const float distanceToBound2 = cameraToBound.x * cameraToBound.x + cameraToBound.y * cameraToBound.y + cameraToBound.z * cameraToBound.z;
+
+				if (distanceToBound2 > bound.radius * bound.radius) {
+					// Use the nearest point on the sphere for a conservative size estimate.
+					const float visibleDistance = std::sqrt(distanceToBound2) - bound.radius;
+					if (bound.radius * bound.radius < manager->m_screenSizeThresholdScale * visibleDistance * visibleDistance)
+						return false;
+				}
+			}
+
+			RE::NiPoint3 hitLocation;
+			auto* obstacle = Actor_CalculateLOS(owner, &manager->m_cameraPositionDuringFrame, &hitLocation, 6.28f);
+			return !obstacle;  // If obstacle, we hit something on the path
+		}
+
+		std::optional<RE::NiPoint3> ActorManager::Skeleton::position() const
+		{
+			if (npc) {
+				// This works for lurker skeletons.
+				auto rootNode = findNode(npc.get(), "NPC Root [Root]");
+				if (rootNode) {
+					return std::optional<RE::NiPoint3>(rootNode->world.translate);
+				}
+			}
+
+			return std::optional<RE::NiPoint3>();
+		}
+
+		void ActorManager::Skeleton::updateWindFactor(float a_windFactor)
+		{
+			this->currentWindFactor = a_windFactor;
+			std::for_each(armors.begin(), armors.end(), [=](Armor& armor) { armor.setWindFactor(a_windFactor); });
+			std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) { headPart.setWindFactor(a_windFactor); });
+		}
+
+		float ActorManager::Skeleton::getWindFactor()
+		{
+			return this->currentWindFactor;
+		}
+
+		bool ActorManager::Skeleton::updateAttachedState(const RE::NiNode* playerCell, bool deactivate = false)
+		{
+			// 1- Skeletons that aren't active in any scene are always detached, unless they are in the
+			// same cell as the player character (workaround for issue in Ancestor Glade).
+			// 2- Player character is always attached.
+			// 3- Otherwise, attach only if both the camera and this skeleton have a position,
+			// the distance between them is below the threshold value,
+			// and the angle difference between the camera orientation and the skeleton orientation is below the threshold value.
+			isActive = false;
+			state = SkeletonState::e_InactiveNotInScene;
+
+			if (deactivate)
+				state = SkeletonState::e_InactiveTooFar;
+			else if (isActiveInScene() || skeleton->parent && skeleton->parent->parent == playerCell) {
+				if (isPlayerCharacter()) {
+					// That setting defines whether we don't set the PC skeleton as active
+					// when it is in 1st person view, to avoid calculating physics uselessly.
+					if (!(instance()->m_disable1stPersonViewPhysics                                                                                    // disabling?
+							&& RE::PlayerCamera::GetSingleton()->currentState == RE::PlayerCamera::GetSingleton()->GetRuntimeData().cameraStates[0]))  // 1st person view
+					{
+						isActive = true;
+						state = SkeletonState::e_ActiveIsPlayer;
+					}
+				} else if (isInPlayerView()) {
+					isActive = true;
+					state = SkeletonState::e_ActiveNearPlayer;
+				} else
+					state = SkeletonState::e_InactiveUnseenByPlayer;
+			}
+
+			// We update the activity state of armors and head parts, and add and remove SkinnedMeshSystems to these parts in consequence.
+			// We set headparts as not active if the head isn't active (for example because it's hidden by a wig).
+			std::for_each(armors.begin(), armors.end(), [=](Armor& armor) { armor.updateActive(isActive); });
+			const bool isHeadActive = head.isActive;
+			std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) { headPart.updateActive(isHeadActive && isActive); });
+			return isActive;
+		}
+
+		void ActorManager::Skeleton::reloadMeshes()
+		{
+			for (auto& i : armors) {
+				i.clearPhysics();
+				if (!isFirstPersonSkeleton(skeleton.get())) {
+					auto renameMap = i.renameMap;
+					auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), i.armorWorn.get(), &i.physicsFile, std::move(renameMap), nullptr);
+					if (system) {
+						i.setPhysics(system, isActive);
+						hasPhysics = true;
+					}
+				}
+			}
+			scanHead();
+		}
+
+		// Reload meshes without entirely wiping their physics
+		void ActorManager::Skeleton::softReloadMeshes()
+		{
+			auto reloadPhysicsItem = [&](auto& item, RE::NiAVObject* model, const auto& renameMapSrc, bool itemActive) {
+				RE::BSTSmartPointer<SkyrimSystem> oldSystem = item.m_physics;
+				item.clearPhysics();
+
+				if (!model || isFirstPersonSkeleton(skeleton.get()) || item.physicsFile.first.empty()) {
+					return;
+				}
+
+				auto renameMap = renameMapSrc;
+				auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), model, &item.physicsFile, std::move(renameMap), nullptr);
+
+				if (system) {
+					system->block_resetting = true;
+					if (oldSystem) {
+						hdt::util::transferCurrentPosesBetweenSystems(oldSystem.get(), system.get());
+					}
+
+					item.setPhysics(system, itemActive);
+					hasPhysics = true;
+					system->block_resetting = false;
+				}
+			};
+
+			for (auto& armor : armors) {
+				reloadPhysicsItem(armor, armor.armorWorn.get(), armor.renameMap, isActive);
+			}
+
+			if (isFirstPersonSkeleton(skeleton.get()) || !head.headNode) {
+				return;
+			}
+
+			if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
+				if (auto actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID)) {
+					setHeadActiveIfNoHairArmor(actor, this);
+				}
+			}
+
+			std::unordered_set<std::string> physicsDupes;
+			for (auto& headPart : head.headParts) {
+				// Skip duplicate physics files, but ensure we clear their old physics
+				if (!headPart.physicsFile.first.empty() && !physicsDupes.insert(headPart.physicsFile.first).second) {
+					headPart.clearPhysics();
+					continue;
+				}
+
+				reloadPhysicsItem(headPart, head.headNode.get(), head.renameMap, isActive && head.isActive);
+			}
+		}
+
+		void ActorManager::Skeleton::scanHead()
+		{
+			if (isFirstPersonSkeleton(this->skeleton.get())) {
+				logger::debug("Not scanning head of first person skeleton.");
+				return;
+			}
+
+			if (!this->head.headNode) {
+				logger::debug("Actor has no head node.");
+				return;
+			}
+
+			std::unordered_set<std::string> physicsDupes;
+
+			if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
+				RE::Actor* actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID);
+				if (actor) {
+					setHeadActiveIfNoHairArmor(actor, this);
+				}
+			}
+
+			for (auto& headPart : this->head.headParts) {
+				// always regen physics for all head parts
+				headPart.clearPhysics();
+
+				if (headPart.physicsFile.first.empty()) {
+					logger::debug("No physics file for headpart {}.", headPart.headPart->name);
+					continue;
+				}
+
+				if (physicsDupes.count(headPart.physicsFile.first)) {
+					logger::debug("Previous head part generated physics system for file {}, skipping.", headPart.physicsFile.first.c_str());
+					continue;
+				}
+
+				logger::debug("Try create system for headpart {} physics file {}.", headPart.headPart->name, headPart.physicsFile.first.c_str());
+				physicsDupes.insert(headPart.physicsFile.first);
+				auto renameMap = this->head.renameMap;
+				auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), this->head.headNode.get(), &headPart.physicsFile, std::move(renameMap), nullptr);
+				if (system) {
+					logger::debug("Success.");
+					headPart.setPhysics(system, isActive);
+					hasPhysics = true;
 				}
 			}
 		}
 
-		bool hasMerged = false;
-		bool hasRenames = false;
+		void ActorManager::Skeleton::processGeometry(RE::BSFaceGenNiNode * headNode, RE::BSGeometry * geometry)
+		{
+			if (this->head.headNode && this->head.headNode != headNode) {
+				logger::debug("Completely new head attached to skeleton, clearing tracking.");
+				for (auto& headPart : this->head.headParts) {
+					headPart.clearPhysics();
+					headPart.headPart = nullptr;
+					headPart.origPartRootNode = nullptr;
+				}
 
-		for (uint32_t boneIdx = 0; boneIdx < geometry->GetGeometryRuntimeData().skinInstance->skinData->bones; boneIdx++) {
-			RE::BSFixedString boneName("");
+				this->head.headParts.clear();
 
-			// skin the way the game does via FMD
-			if (boneIdx <= 7) {
-				if (fmd)
-					boneName = fmd->bones[boneIdx];
+				if (npc)
+					doSkeletonClean(npc.get(), this->head.prefix);
+
+				this->head.prefix = std::string();
+				this->head.headNode = nullptr;
+				this->head.renameMap.clear();
+				this->head.nodeUseCount.clear();
 			}
 
-			// BSModelDB guarantees origGeom is perfectly formed, so we check this BEFORE the active geometry
-			if (boneName.empty() && origGeom) {
-				const auto& rd = origGeom->GetGeometryRuntimeData();
-				if (rd.skinInstance && reinterpret_cast<uintptr_t>(rd.skinInstance.get()) <= kCanonicalUserSpaceMax) {
-					auto skinData = rd.skinInstance->skinData.get();
-					if (skinData && reinterpret_cast<uintptr_t>(skinData) <= kCanonicalUserSpaceMax && boneIdx < skinData->bones) {
-						if (rd.skinInstance->bones && reinterpret_cast<uintptr_t>(rd.skinInstance->bones) <= kCanonicalUserSpaceMax) {
-							auto bone = rd.skinInstance->bones[boneIdx];
-							if (isValidNiObject(bone)) {
-								boneName = bone->name;
-							} else {
-								logger::debug("isValidNiObject was false for BSModelDB");
+			// clean swapped out headparts
+			cleanHead();
+
+			// Todo: This didn't have a null check before, but I don't see why not.
+			if (!this->head.headNode) {
+				this->head.headNode = hdt::make_nismart(headNode);
+				++this->head.id;
+				this->head.prefix = headPrefix(this->head.id);
+			}
+
+			auto it = std::find_if(this->head.headParts.begin(), this->head.headParts.end(), [geometry](const Head::HeadPart& p) {
+				return p.headPart == geometry;
+			});
+
+			if (it != this->head.headParts.end()) {
+				logger::debug("Geometry is already added as head part.");
+				return;
+			}
+
+			this->head.headParts.push_back(Head::HeadPart());
+
+			head.headParts.back().headPart = hdt::make_nismart(geometry);
+			head.headParts.back().clearPhysics();
+
+			// Skinning
+			logger::debug("Skinning geometry to skeleton.");
+
+			if (!geometry->GetGeometryRuntimeData().skinInstance || !geometry->GetGeometryRuntimeData().skinInstance->skinData) {
+				logger::error("Geometry is missing skin instance - how?");
+				return;
+			}
+
+			auto fmd = geometry->GetExtraData<RE::BSFaceGenModelExtraData>("FMD");
+
+			RE::BSGeometry* origGeom = nullptr;
+			RE::NiGeometry* origNiGeom = nullptr;
+
+			if (fmd && fmd->m_model && fmd->m_model->modelMeshData && fmd->m_model->modelMeshData->faceNode) {
+				logger::debug("Original part node found via facegen extra model data.");
+				auto origRootNode = fmd->m_model->modelMeshData->faceNode->AsNode();
+				head.headParts.back().physicsFile = DefaultBBP::instance()->scanBBP(origRootNode);
+				head.headParts.back().origPartRootNode = hdt::make_nismart(origRootNode);
+
+				auto& children = origRootNode->GetChildren();
+				for (uint16_t i = 0; i < children.size(); i++) {
+					if (children[i]) {
+						const auto geo = children[i]->AsGeometry();
+
+						if (geo) {
+							origGeom = geo;
+							break;
+						}
+					}
+				}
+			} else {
+				logger::debug("No facegen extra model data available, loading original facegeometry.");
+				if (!head.npcFaceGeomNode && !head.npcFaceGeomNodeBroken) {
+					if (skeleton->GetUserData() && skeleton->GetUserData()->GetObjectReference()) {
+						auto skeletonNpc = skyrim_cast<RE::TESNPC*>(skeleton->GetUserData()->GetObjectReference());
+						if (skeletonNpc) {
+							char filePath[MAX_PATH];
+							if (TESNPC_GetFaceGeomPath(skeletonNpc, filePath)) {
+								logger::debug("Loading facegeometry via BSModelDB from path {}.", filePath);
+
+								// same DBTraits Bethesda uses for FaceGen (from FUN_1403bbe00 on AE)
+								RE::BSModelDB::DBTraits::ArgsType args;
+								args.LODmult = 0;
+								args.texLoadLevel = 3;
+								args.unk8 = false;
+								args.unk9 = true;
+								args.unkA = false;
+								args.postProcess = true;
+
+								RE::NiPointer<RE::NiNode> loadedModel;
+								auto error = RE::BSModelDB::Demand(filePath, loadedModel, args);
+
+								if (error == RE::BSResource::ErrorCode::kNone && loadedModel) {
+									auto rootFadeNode = loadedModel->AsFadeNode();
+									if (rootFadeNode) {
+										logger::debug("NPC facegeometry root fadeNode successfully loaded.");
+
+										// Because we mutate rootFadeNode, we MUST deep clone the cached model!
+										// The clone can't be null (Otherwise it would CTD internally), so no null checks needed
+										RE::NiCloningProcess c;
+
+										// These just say, copy the original exactly
+										c.copyType = 1;
+										c.scale = { 1.0f, 1.0f, 1.0f };
+
+										auto clonedObj = rootFadeNode->CreateClone(c);
+										rootFadeNode->ProcessClone(c);
+										auto clonedRoot = static_cast<RE::BSFadeNode*>(clonedObj);
+
+										// VR stuff probably still needed?
+										// VR: NiSkinInstance::LinkObject fails to resolve internal bone refs,
+										// storing the bone name as a raw char* instead of a resolved NiNode*.
+										// Bone NiNodes are self-contained in the face geometry NIF, so resolve
+										// them now by name lookup against the loaded tree.
+										// Must run before NiStream_deconstructor while the tree is live.
+										if (REL::Module::IsVR()) {
+											auto& ch = clonedRoot->GetChildren();
+											for (std::uint16_t ci = 0; ci < ch.size(); ++ci) {
+												auto faceChild = ch[ci].get();
+												if (!faceChild || !isValidNiObject(faceChild))
+													continue;
+												auto faceGeo = faceChild->AsGeometry();
+												if (!faceGeo)
+													continue;
+												const auto& grd = faceGeo->GetGeometryRuntimeData();
+												if (!grd.skinInstance || !grd.skinInstance->skinData)
+													continue;
+												std::uint32_t vrResolved = 0, vrFailed = 0;
+												for (std::uint32_t bi = 0; bi < grd.skinInstance->skinData->bones; ++bi) {
+													auto bone = grd.skinInstance->bones[bi];
+													if (!bone || isValidNiObject(bone))
+														continue;
+													// char* case: bone pointer is canonical but its bytes are not a valid vtable.
+													// Guard against truly non-canonical addresses before reading as a string.
+													if (reinterpret_cast<uintptr_t>(bone) > kCanonicalUserSpaceMax)
+														continue;
+													const char* name = reinterpret_cast<const char*>(bone);
+													auto result = findNode(clonedRoot, RE::BSFixedString(name));
+													grd.skinInstance->bones[bi] = result;
+													if (result)
+														++vrResolved;
+													else {
+														++vrFailed;
+														logger::warn("VR bone fix '{}': bone[{}] '{}' not found in NIF tree.", faceGeo->name.c_str(), bi, name);
+													}
+												}
+												if (vrResolved || vrFailed)
+													logger::info("VR bone fix '{}': resolved {}/{} unresolved bone refs in '{}'.", faceGeo->name.c_str(), vrResolved, vrResolved + vrFailed, filePath);
+											}
+										}
+
+										head.npcFaceGeomNode = hdt::make_nismart(clonedRoot);
+									} else {
+										logger::debug("NPC facegeometry root wasn't fadeNode as expected.");
+									}
+								} else {
+									logger::error("Facegeometry rejected by BSModelDB. Possibly a corrupted or unconverted LE mesh.");
+									head.npcFaceGeomNodeBroken = true;
+								}
+							}
+						}
+					}
+				} else
+					logger::debug("Using cached facegeometry.");
+				if (head.npcFaceGeomNode) {
+					head.headParts.back().physicsFile = DefaultBBP::instance()->scanBBP(head.npcFaceGeomNode.get());
+					auto obj = findObject(head.npcFaceGeomNode.get(), geometry->name);
+					if (obj) {
+						auto ob = obj->AsGeometry();
+						if (ob) {
+							origGeom = ob;
+						} else {
+							auto on = obj->AsNiGeometry();
+							if (on) {
+								origNiGeom = on;
 							}
 						}
 					}
 				}
 			}
 
-			// Fallback to active rendering geometry
-			// We only do this if origGeom failed, because FaceGen > 7 leaves garbage in here
-			// This should be dead code, but we keep it just in case..
-			if (boneName.empty()) {
-				const auto& activeSkin = geometry->GetGeometryRuntimeData().skinInstance;
-				if (activeSkin && reinterpret_cast<uintptr_t>(activeSkin.get()) <= kCanonicalUserSpaceMax) {
-					auto skinData = activeSkin->skinData.get();
-					if (skinData && reinterpret_cast<uintptr_t>(skinData) <= kCanonicalUserSpaceMax && boneIdx < skinData->bones) {
-						if (activeSkin->bones && reinterpret_cast<uintptr_t>(activeSkin->bones) <= kCanonicalUserSpaceMax) {
-							auto bone = activeSkin->bones[boneIdx];
-							if (isValidNiObject(bone)) {
-								boneName = bone->name;
-							} else if (bone && reinterpret_cast<uintptr_t>(bone) <= kCanonicalUserSpaceMax) {
-								// Try to salvage what we can to avoid bald NPC's and what not
-								const char* raw = reinterpret_cast<const char*>(bone);
-								bool looksLikeString = true;
-								for (int ci = 0; ci < 64; ++ci) {
-									char ch = raw[ci];
-									if (ch == '\0')
-										break;
+			bool hasMerged = false;
+			bool hasRenames = false;
 
-									// cast to unsigned char to prevent negative values passing the < 0x20 check
-									if ((unsigned char)ch < 0x20 || (unsigned char)ch > 0x7E) {
-										looksLikeString = false;
-										logger::debug("Hit a corrupted bone name?");
-										break;
+			for (uint32_t boneIdx = 0; boneIdx < geometry->GetGeometryRuntimeData().skinInstance->skinData->bones; boneIdx++) {
+				RE::BSFixedString boneName("");
+
+				// skin the way the game does via FMD
+				if (boneIdx <= 7) {
+					if (fmd)
+						boneName = fmd->bones[boneIdx];
+				}
+
+				// BSModelDB guarantees origGeom is perfectly formed, so we check this BEFORE the active geometry
+				if (boneName.empty() && origGeom) {
+					const auto& rd = origGeom->GetGeometryRuntimeData();
+					if (rd.skinInstance && reinterpret_cast<uintptr_t>(rd.skinInstance.get()) <= kCanonicalUserSpaceMax) {
+						auto skinData = rd.skinInstance->skinData.get();
+						if (skinData && reinterpret_cast<uintptr_t>(skinData) <= kCanonicalUserSpaceMax && boneIdx < skinData->bones) {
+							if (rd.skinInstance->bones && reinterpret_cast<uintptr_t>(rd.skinInstance->bones) <= kCanonicalUserSpaceMax) {
+								auto bone = rd.skinInstance->bones[boneIdx];
+								if (isValidNiObject(bone)) {
+									boneName = bone->name;
+								} else {
+									logger::debug("isValidNiObject was false for BSModelDB");
+								}
+							}
+						}
+					}
+				}
+
+				// Fallback to active rendering geometry
+				// We only do this if origGeom failed, because FaceGen > 7 leaves garbage in here
+				// This should be dead code, but we keep it just in case..
+				if (boneName.empty()) {
+					const auto& activeSkin = geometry->GetGeometryRuntimeData().skinInstance;
+					if (activeSkin && reinterpret_cast<uintptr_t>(activeSkin.get()) <= kCanonicalUserSpaceMax) {
+						auto skinData = activeSkin->skinData.get();
+						if (skinData && reinterpret_cast<uintptr_t>(skinData) <= kCanonicalUserSpaceMax && boneIdx < skinData->bones) {
+							if (activeSkin->bones && reinterpret_cast<uintptr_t>(activeSkin->bones) <= kCanonicalUserSpaceMax) {
+								auto bone = activeSkin->bones[boneIdx];
+								if (isValidNiObject(bone)) {
+									boneName = bone->name;
+								} else if (bone && reinterpret_cast<uintptr_t>(bone) <= kCanonicalUserSpaceMax) {
+									// Try to salvage what we can to avoid bald NPC's and what not
+									const char* raw = reinterpret_cast<const char*>(bone);
+									bool looksLikeString = true;
+									for (int ci = 0; ci < 64; ++ci) {
+										char ch = raw[ci];
+										if (ch == '\0')
+											break;
+
+										// cast to unsigned char to prevent negative values passing the < 0x20 check
+										if ((unsigned char)ch < 0x20 || (unsigned char)ch > 0x7E) {
+											looksLikeString = false;
+											logger::debug("Hit a corrupted bone name?");
+											break;
+										}
+									}
+									if (looksLikeString && raw[0] != '\0') {
+										boneName = raw;
+									} else {
+										logger::debug("Rendering geometry fallback failed to resolve bone names");
 									}
 								}
-								if (looksLikeString && raw[0] != '\0') {
-									boneName = raw;
-								} else {
-									logger::debug("Rendering geometry fallback failed to resolve bone names");
-								}
 							}
 						}
 					}
 				}
-			}
 
-			auto renameIt = this->head.renameMap.find(boneName.c_str());
-			if (renameIt != this->head.renameMap.end()) {
-				logger::debug("Found renamed bone {} -> {}.", boneName, renameIt->second.c_str());
-				boneName = renameIt->second;
-				hasRenames = true;
-			}
-
-			auto boneNode = findNode(this->npc.get(), boneName);
-
-			if (!boneNode && !hasMerged) {
-				logger::debug("Bone not found on skeleton, trying skeleton merge.");
-				if (this->head.headParts.back().origPartRootNode) {
-					doSkeletonMerge(npc.get(), head.headParts.back().origPartRootNode.get(), head.prefix, head.renameMap, false);
-				} else if (this->head.npcFaceGeomNode) {
-					logger::debug("Merging facegen into the head node.");
-
-					// Facegen data doesn't have any tree structure to the skeleton. We need to make any new
-					// nodes children of the head node, so that they move properly when there's no physics.
-					// This case never happens to a lurker skeleton, thus we don't need to test.
-					RE::NiNode* npcHeadNode = findNode(head.npcFaceGeomNode.get(), "NPC Head [Head]");
-					if (npcHeadNode) {
-						RE::NiTransform invTransform = npcHeadNode->local.Invert();
-						auto& children = head.npcFaceGeomNode->GetChildren();
-
-						for (int32_t i = static_cast<int32_t>(children.size()) - 1; i >= 0; --i) {
-							auto child = castNiNode(children[static_cast<std::uint16_t>(i)].get());
-
-							if (child && !findNode(npc.get(), child->name)) {
-								// hold a reference so DetachChildAt2 doesn't destroy the node
-								RE::NiPointer<RE::NiNode> ref(child);
-								child->local = invTransform * child->local;
-								head.npcFaceGeomNode->DetachChildAt2(i);
-								npcHeadNode->AttachChild(child, false);
-							}
-						}
-					}
-					doSkeletonMerge(npc.get(), this->head.npcFaceGeomNode.get(), head.prefix, head.renameMap, false);
-				}
-
-				hasMerged = true;
-
-				auto postMergeRenameIt = this->head.renameMap.find(boneName.c_str());
-
-				if (postMergeRenameIt != this->head.renameMap.end()) {
-					logger::debug("Found renamed bone {} -> {}.", boneName, postMergeRenameIt->second.c_str());
-					boneName = postMergeRenameIt->second;
+				auto renameIt = this->head.renameMap.find(boneName.c_str());
+				if (renameIt != this->head.renameMap.end()) {
+					logger::debug("Found renamed bone {} -> {}.", boneName, renameIt->second.c_str());
+					boneName = renameIt->second;
 					hasRenames = true;
 				}
 
-				boneNode = findNode(this->npc.get(), boneName);
-			}
+				auto boneNode = findNode(this->npc.get(), boneName);
 
-			if (!boneNode) {
-				logger::error("Bone {} not found after skeleton merge, geometry cannot be fully skinned.", boneName);
-				continue;
-			}
+				if (!boneNode && !hasMerged) {
+					logger::debug("Bone not found on skeleton, trying skeleton merge.");
+					if (this->head.headParts.back().origPartRootNode) {
+						doSkeletonMerge(npc.get(), head.headParts.back().origPartRootNode.get(), head.prefix, head.renameMap, false);
+					} else if (this->head.npcFaceGeomNode) {
+						logger::debug("Merging facegen into the head node.");
 
-			geometry->GetGeometryRuntimeData().skinInstance->bones[boneIdx] = boneNode;
-			geometry->GetGeometryRuntimeData().skinInstance->boneWorldTransforms[boneIdx] = &boneNode->world;
-		}
+						// Facegen data doesn't have any tree structure to the skeleton. We need to make any new
+						// nodes children of the head node, so that they move properly when there's no physics.
+						// This case never happens to a lurker skeleton, thus we don't need to test.
+						RE::NiNode* npcHeadNode = findNode(head.npcFaceGeomNode.get(), "NPC Head [Head]");
+						if (npcHeadNode) {
+							RE::NiTransform invTransform = npcHeadNode->local.Invert();
+							auto& children = head.npcFaceGeomNode->GetChildren();
 
-		geometry->GetGeometryRuntimeData().skinInstance->rootParent = headNode;
+							for (int32_t i = static_cast<int32_t>(children.size()) - 1; i >= 0; --i) {
+								auto child = castNiNode(children[static_cast<std::uint16_t>(i)].get());
 
-		if (hasRenames) {
-			for (auto& entry : head.renameMap) {
-				bool inUse = false;
-
-				auto origPartRoot = this->head.headParts.back().origPartRootNode.get();
-				auto npcFaceGeom = this->head.npcFaceGeomNode.get();
-
-				// we must check for BOTH entry.first (original name) and entry.second (renamed name)
-				// If this geometry performed the skeleton merge, renameTree altered the names in the source tree to
-				// entry.second. If another geometry did the merge, the names remain entry.first
-				if (origPartRoot && (findObject(origPartRoot, entry.first) || findObject(origPartRoot, entry.second))) {
-					inUse = true;
-				} else if (npcFaceGeom && (findObject(npcFaceGeom, entry.first) || findObject(npcFaceGeom, entry.second))) {
-					inUse = true;
-				}
-
-				if (inUse) {
-					auto findNode = this->head.nodeUseCount.find(entry.first);
-					if (findNode != this->head.nodeUseCount.end()) {
-						findNode->second += 1;
-						logger::debug("Incrementing use count by 1, it is now {}.", findNode->second);
-					} else {
-						this->head.nodeUseCount.insert(std::make_pair(entry.first, static_cast<uint8_t>(1)));
-						logger::debug("First use of bone, count 1.");
+								if (child && !findNode(npc.get(), child->name)) {
+									// hold a reference so DetachChildAt2 doesn't destroy the node
+									RE::NiPointer<RE::NiNode> ref(child);
+									child->local = invTransform * child->local;
+									head.npcFaceGeomNode->DetachChildAt2(i);
+									npcHeadNode->AttachChild(child, false);
+								}
+							}
+						}
+						doSkeletonMerge(npc.get(), this->head.npcFaceGeomNode.get(), head.prefix, head.renameMap, false);
 					}
-					head.headParts.back().renamedBonesInUse.insert(entry.first);
+
+					hasMerged = true;
+
+					auto postMergeRenameIt = this->head.renameMap.find(boneName.c_str());
+
+					if (postMergeRenameIt != this->head.renameMap.end()) {
+						logger::debug("Found renamed bone {} -> {}.", boneName, postMergeRenameIt->second.c_str());
+						boneName = postMergeRenameIt->second;
+						hasRenames = true;
+					}
+
+					boneNode = findNode(this->npc.get(), boneName);
+				}
+
+				if (!boneNode) {
+					logger::error("Bone {} not found after skeleton merge, geometry cannot be fully skinned.", boneName);
+					continue;
+				}
+
+				geometry->GetGeometryRuntimeData().skinInstance->bones[boneIdx] = boneNode;
+				geometry->GetGeometryRuntimeData().skinInstance->boneWorldTransforms[boneIdx] = &boneNode->world;
+			}
+
+			geometry->GetGeometryRuntimeData().skinInstance->rootParent = headNode;
+
+			if (hasRenames) {
+				for (auto& entry : head.renameMap) {
+					bool inUse = false;
+
+					auto origPartRoot = this->head.headParts.back().origPartRootNode.get();
+					auto npcFaceGeom = this->head.npcFaceGeomNode.get();
+
+					// we must check for BOTH entry.first (original name) and entry.second (renamed name)
+					// If this geometry performed the skeleton merge, renameTree altered the names in the source tree to
+					// entry.second. If another geometry did the merge, the names remain entry.first
+					if (origPartRoot && (findObject(origPartRoot, entry.first) || findObject(origPartRoot, entry.second))) {
+						inUse = true;
+					} else if (npcFaceGeom && (findObject(npcFaceGeom, entry.first) || findObject(npcFaceGeom, entry.second))) {
+						inUse = true;
+					}
+
+					if (inUse) {
+						auto findNode = this->head.nodeUseCount.find(entry.first);
+						if (findNode != this->head.nodeUseCount.end()) {
+							findNode->second += 1;
+							logger::debug("Incrementing use count by 1, it is now {}.", findNode->second);
+						} else {
+							this->head.nodeUseCount.insert(std::make_pair(entry.first, static_cast<uint8_t>(1)));
+							logger::debug("First use of bone, count 1.");
+						}
+						head.headParts.back().renamedBonesInUse.insert(entry.first);
+					}
 				}
 			}
-		}
 
-		logger::debug("Done skinning part.");
+			logger::debug("Done skinning part.");
+		}
 	}
-}

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -440,11 +440,21 @@ namespace hdt
 		activeSkeletons = 0;
 		const float minCullingDistance2 = m_minCullingDistance * m_minCullingDistance;
 		for (auto& i : m_skeletons) {
+			// If the option is enabled, we skip dead actors when they are not the player,
+			// to save performance.
+			bool skipDeadActor = false;
+			if (m_skipDeadActors && !i.isPlayerCharacter()) {
+				const auto actor = skyrim_cast<RE::Actor*>(i.skeletonOwner.get());
+				if (actor && actor->IsDead()) {
+					skipDeadActor = true;
+				}
+			}
+
 			// Skeletons inside the minimum culling distance are kept active even when the budget cap
 			// is exceeded, so a shrinking auto-adjust cap can't strip physics from NPCs next to the camera.
 			const bool forceKeepNear = i.m_distanceFromCamera2 < minCullingDistance2;
 			const bool overBudget = activeSkeletons >= maxActiveSkeletons;
-			if (!i.hasPhysics || !i.updateAttachedState(playerCell, overBudget && !forceKeepNear))
+			if (!i.hasPhysics || !i.updateAttachedState(playerCell, overBudget && !forceKeepNear || skipDeadActor)) {
 				continue;
 
 			activeSkeletons++;

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -394,14 +394,14 @@ namespace hdt
 		const auto cameraOrientation = cameraTransform.rotate * RE::NiPoint3(0., 1., 0.);  // The camera matrix is relative to the world.
 		m_cameraPositionDuringFrame = cameraPosition;
 
-		m_screenSizeNearPlaneScale = 0.f;
 		m_screenSizeThresholdScale = 0.f;
 		if (m_minScreenSizeFraction > 0.f) {
-			if (auto* cam = RE::Main::WorldRootCamera()) {
-				const auto& f = cam->GetRuntimeData2().viewFrustum;
-				const float screenH = f.fTop - f.fBottom;  // near-plane total vertical span in world units
-				m_screenSizeNearPlaneScale = 4.f * f.fNear * f.fNear;
-				m_screenSizeThresholdScale = m_minScreenSizeFraction * m_minScreenSizeFraction * screenH * screenH;
+			if (auto* worldSceneGraph = RE::DrawWorld::GetSingleton().worldSceneGraph) {
+				const float cameraFOVDegrees = static_cast<RE::BSSceneGraph*>(worldSceneGraph)->GetRuntimeData().cameraFOV;
+				if (cameraFOVDegrees > 0.f && cameraFOVDegrees < 180.f) {
+					const float tanHalfFOV = std::tan(cameraFOVDegrees * std::numbers::pi_v<float> / 360.f);
+					m_screenSizeThresholdScale = m_minScreenSizeFraction * m_minScreenSizeFraction * tanHalfFOV * tanHalfFOV;
+				}
 			}
 		}
 
@@ -1060,11 +1060,18 @@ namespace hdt
 
 		// Is the skeleton too small on screen?
 		// Ie, is the NPC's projected bounding sphere smaller than the allowed fraction of screen height?
-		// screenFraction < minFraction <=> 2r·fNear / (dist·screenH) < fr <=> 4r²·fNear² < fr²·dist²·screenH²
+		// screenFraction < minFraction <=> r / (distance * tan(fov/2)) < fr <=> r^2 < fr^2 * distance^2 * tan(fov/2)^2
 		if (manager->m_screenSizeThresholdScale > 0.f) {
-			const float r = skeleton3D->worldBound.radius;  // the radius of the bounding sphere of the skeleton in world units
-			if (manager->m_screenSizeNearPlaneScale * r * r < manager->m_screenSizeThresholdScale * m_distanceFromCamera2)
-				return false;
+			const auto& bound = skeleton3D->worldBound;
+			const auto cameraToBound = bound.center - manager->m_cameraPositionDuringFrame;
+			const float distanceToBound2 = cameraToBound.x * cameraToBound.x + cameraToBound.y * cameraToBound.y + cameraToBound.z * cameraToBound.z;
+
+			if (distanceToBound2 > bound.radius * bound.radius) {
+				// Use the nearest point on the sphere for a conservative size estimate.
+				const float visibleDistance = std::sqrt(distanceToBound2) - bound.radius;
+				if (bound.radius * bound.radius < manager->m_screenSizeThresholdScale * visibleDistance * visibleDistance)
+					return false;
+			}
 		}
 
 		RE::NiPoint3 hitLocation;

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -457,188 +457,188 @@ namespace hdt
 			if (!i.hasPhysics || !i.updateAttachedState(playerCell, overBudget && !forceKeepNear || skipDeadActor))
 				continue;
 
-				activeSkeletons++;
+			activeSkeletons++;
 
-				// Check wind obstructions for active skeletons.
-				if (!windEnabled)
-					continue;
+			// Check wind obstructions for active skeletons.
+			if (!windEnabled)
+				continue;
 
-				const auto armorReacts = [](const auto& armor) {
-					return armor.m_hasDynamicPhysics && armor.state() == ActorManager::ItemState::e_Active;
-				};
+			const auto armorReacts = [](const auto& armor) {
+				return armor.m_hasDynamicPhysics && armor.state() == ActorManager::ItemState::e_Active;
+			};
 
-				const auto headReacts = [](const auto& headPart) {
-					return headPart.m_hasDynamicPhysics && headPart.state() == ActorManager::ItemState::e_Active;
-				};
+			const auto headReacts = [](const auto& headPart) {
+				return headPart.m_hasDynamicPhysics && headPart.state() == ActorManager::ItemState::e_Active;
+			};
 
-				// Does this actor have anything visible and active that can be blown in the wind?
-				if (!std::ranges::any_of(i.getArmors(), armorReacts) && !std::ranges::any_of(i.head.headParts, headReacts)) {
-					continue;
-				}
+			// Does this actor have anything visible and active that can be blown in the wind?
+			if (!std::ranges::any_of(i.getArmors(), armorReacts) && !std::ranges::any_of(i.head.headParts, headReacts)) {
+				continue;
+			}
 
-				const auto owner = skyrim_cast<RE::Actor*>(i.skeletonOwner.get());
-				if (!owner) {
-					logger::debug("{} is active skeleton, but failed to cast to Actor, no wind obstruction check possible.", i.name());
-					continue;
-				}
+			const auto owner = skyrim_cast<RE::Actor*>(i.skeletonOwner.get());
+			if (!owner) {
+				logger::debug("{} is active skeleton, but failed to cast to Actor, no wind obstruction check possible.", i.name());
+				continue;
+			}
 
-				// Get the  wind direction pointing TOWARDS the source of the wind
-				auto reverseWindDir = wind * -1.0f;
+			// Get the  wind direction pointing TOWARDS the source of the wind
+			auto reverseWindDir = wind * -1.0f;
 
-				// Normalize the direction vector to ensure accurate math
-				reverseWindDir.Unitize();
+			// Normalize the direction vector to ensure accurate math
+			reverseWindDir.Unitize();
 
-				// we project the ray forward by m_distanceForMaxWind
-				RE::NiPoint3 origin;
+			// we project the ray forward by m_distanceForMaxWind
+			RE::NiPoint3 origin;
 
-				// If possible, use the head for the origin. Since hair is more likely to be affected, and
-				// it'd be more accurate in animations/height of the actor.
-				if (auto headNode = owner->GetNodeByName("NPC Head [Head]")) {
-					origin = headNode->world.translate;
-				} else {
-					origin = owner->data.location;
-					origin.z += 100.0f;  // Offset by 100 units so at least it's not their feet
-				}
+			// If possible, use the head for the origin. Since hair is more likely to be affected, and
+			// it'd be more accurate in animations/height of the actor.
+			if (auto headNode = owner->GetNodeByName("NPC Head [Head]")) {
+				origin = headNode->world.translate;
+			} else {
+				origin = owner->data.location;
+				origin.z += 100.0f;  // Offset by 100 units so at least it's not their feet
+			}
 
-				RE::NiPoint3 targetPos = origin + reverseWindDir * world->m_distanceForMaxWind;
+			RE::NiPoint3 targetPos = origin + reverseWindDir * world->m_distanceForMaxWind;
 
-				RE::NiPoint3 hitLocation;
+			RE::NiPoint3 hitLocation;
 
-				const auto object = Actor_CalculateLOS(owner, &targetPos, &hitLocation, std::numbers::pi_v<float> * 2.f);
+			const auto object = Actor_CalculateLOS(owner, &targetPos, &hitLocation, std::numbers::pi_v<float> * 2.f);
 
-				float targetWindFactor = 1.0f;
-				float dist = 0.0f;
+			float targetWindFactor = 1.0f;
+			float dist = 0.0f;
+			if (object) {
+				auto diff = owner->data.location - hitLocation;
+				diff.z = 0;  // remove z component difference
+				dist = diff.Length();
+				// windfactor = 0 when dist <= m_distanceForNoWind, = 1 when dist >= m_distanceForMaxWind, and is linear with dist between these 2 values.
+				targetWindFactor = std::clamp((dist - world->m_distanceForNoWind) / (world->m_distanceForMaxWind - world->m_distanceForNoWind), 0.f, 1.f);
+			}
+
+			if (const float current = i.getWindFactor(); !btFuzzyZero(targetWindFactor - current)) {
+				const float next = std::lerp(current, targetWindFactor, 0.05f);
+				const float newWindFactor = std::abs(targetWindFactor - next) < 0.01f ? targetWindFactor : next;
+
 				if (object) {
-					auto diff = owner->data.location - hitLocation;
-					diff.z = 0;  // remove z component difference
-					dist = diff.Length();
-					// windfactor = 0 when dist <= m_distanceForNoWind, = 1 when dist >= m_distanceForMaxWind, and is linear with dist between these 2 values.
-					targetWindFactor = std::clamp((dist - world->m_distanceForNoWind) / (world->m_distanceForMaxWind - world->m_distanceForNoWind), 0.f, 1.f);
+					logger::debug("{} blocked by {} with distance {:.2f}; setting windFactor {:.2f}.", i.name(), object->name, dist, newWindFactor);
 				}
 
-				if (const float current = i.getWindFactor(); !btFuzzyZero(targetWindFactor - current)) {
-					const float next = std::lerp(current, targetWindFactor, 0.05f);
-					const float newWindFactor = std::abs(targetWindFactor - next) < 0.01f ? targetWindFactor : next;
+				i.updateWindFactor(newWindFactor);
+			}
+		}
 
-					if (object) {
-						logger::debug("{} blocked by {} with distance {:.2f}; setting windFactor {:.2f}.", i.name(), object->name, dist, newWindFactor);
-					}
+		for (auto& i : m_skeletons) {
+			i.cleanArmor();
+			i.cleanHead();
+		}
 
-					i.updateWindFactor(newWindFactor);
+		// We share the same doMetrics condition here and in hdtSkyrimPhysicsWorld to avoid any gap between both.
+		// The evaluation is done here rather than in hdtSkyrimPhysicsWorld because this event is called first.
+		world->m_doMetrics = updateMetrics &&                     // do not do metrics on a MenuOpenCloseEvent
+		                     !world->isSuspended() &&             // do not do metrics while paused
+		                     frameCount++ % world->min_fps == 0;  // check every min-fps frames (i.e., a stable 60 fps should wait for 1 second)
+
+		if (world->m_doMetrics) {
+			const auto averageProcessingTimeInMainLoop = world->m_averageSMPProcessingTimeInMainLoop;
+
+			const auto maxBudgetTime = world->m_budgetMs;
+			const auto averageTimePerSkeletonInMainLoop = activeSkeletons > 0 ? averageProcessingTimeInMainLoop / activeSkeletons : 0.f;
+
+			logger::trace(
+				"msecs/activeSkeleton {:.2f} activeSkeletons/maxActive/total {}/{}/{} processTimeInMainLoop/budgetTime {:.2f}/{:.2f}",
+				averageTimePerSkeletonInMainLoop,
+				activeSkeletons,
+				maxActiveSkeletons,
+				m_skeletons.size(),
+				averageProcessingTimeInMainLoop,
+				maxBudgetTime);
+
+			if (m_autoAdjustMaxSkeletons && m_maxActiveSkeletons > 3) {
+				// Deadzones to prevent constantly switching back and fourth
+				if (averageProcessingTimeInMainLoop > maxBudgetTime) {
+					// When few skeletons active, step down by 1 to avoid over-correction
+					maxActiveSkeletons -= (activeSkeletons < 10) ? 1 : 2;
+				} else if (averageProcessingTimeInMainLoop < maxBudgetTime) {
+					// Scale up by however many skeletons fit within the remaining budget headroom, max of 2
+					// Falls back to +2 when no skeletons are active (timePerSkeleton == 0).
+					const float headroom = maxBudgetTime - averageProcessingTimeInMainLoop;
+					const int canAdd = (averageTimePerSkeletonInMainLoop > 0.f) ? static_cast<int>(headroom / averageTimePerSkeletonInMainLoop) : 2;
+					maxActiveSkeletons += std::clamp(canAdd, 0, 2);
+				}
+
+				// clamp the adjusted value between 3 and m_maxActiveSkeletons
+				maxActiveSkeletons = std::clamp(maxActiveSkeletons, 3, m_maxActiveSkeletons);
+				frameCount = 1;
+
+			} else if (maxActiveSkeletons != m_maxActiveSkeletons)
+				maxActiveSkeletons = m_maxActiveSkeletons;
+		}
+	}
+
+	void ActorManager::PhysicsItem::setPhysics(RE::BSTSmartPointer<SkyrimSystem>& system, bool active)
+	{
+		clearPhysics();
+		m_physics = system;
+		m_hasDynamicPhysics = false;
+
+		if (m_physics) {
+			for (const auto& bone : m_physics->getBones()) {
+				if (bone && !bone->m_rig.isStaticOrKinematicObject()) {
+					m_hasDynamicPhysics = true;
+					break;
 				}
 			}
-
-			for (auto& i : m_skeletons) {
-				i.cleanArmor();
-				i.cleanHead();
-			}
-
-			// We share the same doMetrics condition here and in hdtSkyrimPhysicsWorld to avoid any gap between both.
-			// The evaluation is done here rather than in hdtSkyrimPhysicsWorld because this event is called first.
-			world->m_doMetrics = updateMetrics &&                     // do not do metrics on a MenuOpenCloseEvent
-			                     !world->isSuspended() &&             // do not do metrics while paused
-			                     frameCount++ % world->min_fps == 0;  // check every min-fps frames (i.e., a stable 60 fps should wait for 1 second)
-
-			if (world->m_doMetrics) {
-				const auto averageProcessingTimeInMainLoop = world->m_averageSMPProcessingTimeInMainLoop;
-
-				const auto maxBudgetTime = world->m_budgetMs;
-				const auto averageTimePerSkeletonInMainLoop = activeSkeletons > 0 ? averageProcessingTimeInMainLoop / activeSkeletons : 0.f;
-
-				logger::trace(
-					"msecs/activeSkeleton {:.2f} activeSkeletons/maxActive/total {}/{}/{} processTimeInMainLoop/budgetTime {:.2f}/{:.2f}",
-					averageTimePerSkeletonInMainLoop,
-					activeSkeletons,
-					maxActiveSkeletons,
-					m_skeletons.size(),
-					averageProcessingTimeInMainLoop,
-					maxBudgetTime);
-
-				if (m_autoAdjustMaxSkeletons && m_maxActiveSkeletons > 3) {
-					// Deadzones to prevent constantly switching back and fourth
-					if (averageProcessingTimeInMainLoop > maxBudgetTime) {
-						// When few skeletons active, step down by 1 to avoid over-correction
-						maxActiveSkeletons -= (activeSkeletons < 10) ? 1 : 2;
-					} else if (averageProcessingTimeInMainLoop < maxBudgetTime) {
-						// Scale up by however many skeletons fit within the remaining budget headroom, max of 2
-						// Falls back to +2 when no skeletons are active (timePerSkeleton == 0).
-						const float headroom = maxBudgetTime - averageProcessingTimeInMainLoop;
-						const int canAdd = (averageTimePerSkeletonInMainLoop > 0.f) ? static_cast<int>(headroom / averageTimePerSkeletonInMainLoop) : 2;
-						maxActiveSkeletons += std::clamp(canAdd, 0, 2);
-					}
-
-					// clamp the adjusted value between 3 and m_maxActiveSkeletons
-					maxActiveSkeletons = std::clamp(maxActiveSkeletons, 3, m_maxActiveSkeletons);
-					frameCount = 1;
-
-				} else if (maxActiveSkeletons != m_maxActiveSkeletons)
-					maxActiveSkeletons = m_maxActiveSkeletons;
-			}
 		}
 
-		void ActorManager::PhysicsItem::setPhysics(RE::BSTSmartPointer<SkyrimSystem> & system, bool active)
-		{
-			clearPhysics();
-			m_physics = system;
-			m_hasDynamicPhysics = false;
-
-			if (m_physics) {
-				for (const auto& bone : m_physics->getBones()) {
-					if (bone && !bone->m_rig.isStaticOrKinematicObject()) {
-						m_hasDynamicPhysics = true;
-						break;
-					}
-				}
-			}
-
-			if (active) {
-				SkyrimPhysicsWorld::get()->addSkinnedMeshSystem(m_physics.get());
-			}
+		if (active) {
+			SkyrimPhysicsWorld::get()->addSkinnedMeshSystem(m_physics.get());
 		}
+	}
 
-		void ActorManager::PhysicsItem::clearPhysics()
-		{
-			if (state() == ItemState::e_Active) {
-				m_physics->m_world->removeSkinnedMeshSystem(m_physics.get());
-			}
-			m_physics = nullptr;
-			m_hasDynamicPhysics = false;
+	void ActorManager::PhysicsItem::clearPhysics()
+	{
+		if (state() == ItemState::e_Active) {
+			m_physics->m_world->removeSkinnedMeshSystem(m_physics.get());
 		}
+		m_physics = nullptr;
+		m_hasDynamicPhysics = false;
+	}
 
-		ActorManager::ItemState ActorManager::PhysicsItem::state() const
-		{
-			return m_physics ? (m_physics->m_world ? ItemState::e_Active : ItemState::e_Inactive) : ItemState::e_NoPhysics;
+	ActorManager::ItemState ActorManager::PhysicsItem::state() const
+	{
+		return m_physics ? (m_physics->m_world ? ItemState::e_Active : ItemState::e_Inactive) : ItemState::e_NoPhysics;
+	}
+
+	const std::vector<RE::BSTSmartPointer<SkinnedMeshBody>>& ActorManager::PhysicsItem::meshes() const
+	{
+		return m_physics->meshes();
+	}
+
+	void ActorManager::PhysicsItem::updateActive(bool active)
+	{
+		if (active && state() == ItemState::e_Inactive) {
+			SkyrimPhysicsWorld::get()->addSkinnedMeshSystem(m_physics.get());
+		} else if (!active && state() == ItemState::e_Active) {
+			m_physics->m_world->removeSkinnedMeshSystem(m_physics.get());
 		}
+	}
 
-		const std::vector<RE::BSTSmartPointer<SkinnedMeshBody>>& ActorManager::PhysicsItem::meshes() const
-		{
-			return m_physics->meshes();
-		}
+	void ActorManager::PhysicsItem::setWindFactor(float a_windFactor)
+	{
+		if (m_physics)
+			m_physics->m_windFactor = a_windFactor;
+	}
 
-		void ActorManager::PhysicsItem::updateActive(bool active)
-		{
-			if (active && state() == ItemState::e_Inactive) {
-				SkyrimPhysicsWorld::get()->addSkinnedMeshSystem(m_physics.get());
-			} else if (!active && state() == ItemState::e_Active) {
-				m_physics->m_world->removeSkinnedMeshSystem(m_physics.get());
-			}
-		}
+	std::vector<ActorManager::Skeleton>& ActorManager::getSkeletons()
+	{
+		return m_skeletons;
+	}
 
-		void ActorManager::PhysicsItem::setWindFactor(float a_windFactor)
-		{
-			if (m_physics)
-				m_physics->m_windFactor = a_windFactor;
-		}
-
-		std::vector<ActorManager::Skeleton>& ActorManager::getSkeletons()
-		{
-			return m_skeletons;
-		}
-
-		bool ActorManager::skeletonNeedsParts(RE::NiNode * skeleton)
-		{
-			return !isFirstPersonSkeleton(skeleton);
-			/*
+	bool ActorManager::skeletonNeedsParts(RE::NiNode* skeleton)
+	{
+		return !isFirstPersonSkeleton(skeleton);
+		/*
 		auto iter = std::find_if(m_skeletons.begin(), m_skeletons.end(), [=](Skeleton& i)
 		{
 			return i.skeleton == skeleton;
@@ -648,973 +648,973 @@ namespace hdt
 			return (iter->head.headNode == 0);
 		}
 		*/
+	}
+
+	ActorManager::Skeleton& ActorManager::getSkeletonData(RE::NiNode* skeleton)
+	{
+		auto iter = std::find_if(m_skeletons.begin(), m_skeletons.end(), [=](Skeleton& i) {
+			return i.skeleton == skeleton;
+		});
+
+		if (iter != m_skeletons.end()) {
+			return *iter;
 		}
 
-		ActorManager::Skeleton& ActorManager::getSkeletonData(RE::NiNode * skeleton)
-		{
-			auto iter = std::find_if(m_skeletons.begin(), m_skeletons.end(), [=](Skeleton& i) {
-				return i.skeleton == skeleton;
+		if (!isFirstPersonSkeleton(skeleton)) {
+			auto ownerIter = std::find_if(m_skeletons.begin(), m_skeletons.end(), [=](Skeleton& i) {
+				return !isFirstPersonSkeleton(i.skeleton.get()) && i.skeletonOwner && skeleton->GetUserData() && i.skeletonOwner.get() == skeleton->GetUserData();
 			});
 
-			if (iter != m_skeletons.end()) {
-				return *iter;
-			}
-
-			if (!isFirstPersonSkeleton(skeleton)) {
-				auto ownerIter = std::find_if(m_skeletons.begin(), m_skeletons.end(), [=](Skeleton& i) {
-					return !isFirstPersonSkeleton(i.skeleton.get()) && i.skeletonOwner && skeleton->GetUserData() && i.skeletonOwner.get() == skeleton->GetUserData();
-				});
-
-				if (ownerIter != m_skeletons.end()) {
-					logger::debug("New skeleton found for formid {:08X}.", skeleton->GetUserData()->formID);
-					ownerIter->cleanHead(true);
-				}
-			}
-
-			m_skeletons.push_back(Skeleton());
-			m_skeletons.back().skeleton = hdt::make_nismart(skeleton);
-			return m_skeletons.back();
-		}
-
-		ActorManager::Skeleton* ActorManager::get3rdPersonSkeleton(RE::Actor * actor)
-		{
-			for (auto& i : m_skeletons) {
-				const auto owner = skyrim_cast<RE::Actor*>(i.skeletonOwner.get());
-				if (actor == owner && i.skeleton && !isFirstPersonSkeleton(i.skeleton.get())) {
-					return &i;
-				}
-			}
-			return 0;
-		}
-
-		void ActorManager::Skeleton::doSkeletonMerge(RE::NiNode * dst, RE::NiNode * src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString> & map, bool renameSource)
-		{
-			doSkeletonMerge(dst, src, prefix, map, dst, renameSource);
-		}
-
-		void ActorManager::Skeleton::doSkeletonMerge(RE::NiNode * dst, RE::NiNode * src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString> & map, RE::NiNode * dstRoot, bool renameSource)
-		{
-			const auto& children = src->GetChildren();
-
-			for (uint16_t i = 0; i < children.size(); ++i) {
-				auto srcChild = castNiNode(children[i].get());
-				if (!srcChild)
-					continue;
-
-				if (!srcChild->name.size()) {
-					doSkeletonMerge(dst, srcChild, prefix, map, dstRoot, renameSource);
-					continue;
-				}
-
-				// FIXME: This was previously only in doHeadSkeletonMerge.
-				// But surely non-head skeletons wouldn't have this anyway?
-				if (!strcmp(srcChild->name.c_str(), "BSFaceGenNiNodeSkinned")) {
-					logger::debug("Skipping facegen ninode in skeleton merge.");
-					continue;
-				}
-
-				// TODO check it's not a lurker skeleton
-				auto dstChild = findNode(dstRoot, srcChild->name);
-				if (dstChild) {
-					doSkeletonMerge(dstChild, srcChild, prefix, map, dstRoot, renameSource);
-				} else {
-					dst->AttachChild(cloneNodeTree(srcChild, prefix, map, renameSource), false);
-				}
+			if (ownerIter != m_skeletons.end()) {
+				logger::debug("New skeleton found for formid {:08X}.", skeleton->GetUserData()->formID);
+				ownerIter->cleanHead(true);
 			}
 		}
 
-		RE::NiNode* ActorManager::Skeleton::cloneNodeTree(RE::NiNode * src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString> & map, bool renameSource)
-		{
-			//
-			RE::NiCloningProcess c;
+		m_skeletons.push_back(Skeleton());
+		m_skeletons.back().skeleton = hdt::make_nismart(skeleton);
+		return m_skeletons.back();
+	}
 
-			//
-			c.appendChar = '$';
-			c.copyType = 1;
-			c.scale = { 1.0f, 1.0f, 1.0f };
-
-			auto ret = static_cast<RE::NiNode*>(src->CreateClone(c));
-			src->ProcessClone(c);
-
-			// Renaming the source tree for Head parts corrupts the shared npcFaceGeomNode cache,
-			// so only rename the source for armor merges where the source is a per-attachment tree
-			if (renameSource) {
-				renameTree(src, prefix, map);
-			}
-			renameTree(ret, prefix, map);
-
-			return ret;
-		}
-
-		void ActorManager::Skeleton::renameTree(RE::NiNode * root, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString> & map)
-		{
-			if (root->name.size()) {
-				std::string newName{ prefix };
-				newName += root->name;
-				if (map.insert(std::make_pair<RE::BSFixedString, RE::BSFixedString>(root->name.c_str(), newName)).second) {
-					logger::debug("Rename Bone {} -> {}.", root->name, newName.c_str());
-				}
-
-				setNiNodeName(root, newName.c_str());
-			}
-
-			auto& children = root->GetChildren();
-			for (uint16_t i = 0; i < children.size(); ++i) {
-				auto child = castNiNode(children[static_cast<std::uint16_t>(i)].get());
-				if (child) {
-					renameTree(child, prefix, map);
-				}
+	ActorManager::Skeleton* ActorManager::get3rdPersonSkeleton(RE::Actor* actor)
+	{
+		for (auto& i : m_skeletons) {
+			const auto owner = skyrim_cast<RE::Actor*>(i.skeletonOwner.get());
+			if (actor == owner && i.skeleton && !isFirstPersonSkeleton(i.skeleton.get())) {
+				return &i;
 			}
 		}
+		return 0;
+	}
 
-		void ActorManager::Skeleton::doSkeletonClean(RE::NiNode * dst, std::string_view prefix)
-		{
-			std::vector<std::pair<RE::NiNode*, RE::NiAVObject*>> toDetach;
+	void ActorManager::Skeleton::doSkeletonMerge(RE::NiNode* dst, RE::NiNode* src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString>& map, bool renameSource)
+	{
+		doSkeletonMerge(dst, src, prefix, map, dst, renameSource);
+	}
 
-			std::function<void(RE::NiNode*)> traverse = [&](RE::NiNode* node) {
-				if (!node)
-					return;
-				for (auto& childPtr : node->GetChildren()) {
-					if (!childPtr)
-						continue;
-					auto* rawChild = childPtr.get();
+	void ActorManager::Skeleton::doSkeletonMerge(RE::NiNode* dst, RE::NiNode* src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString>& map, RE::NiNode* dstRoot, bool renameSource)
+	{
+		const auto& children = src->GetChildren();
 
-					const char* cname = rawChild->name.c_str();
-					std::string_view childName = (cname && cname[0]) ? std::string_view(cname) : std::string_view{};
+		for (uint16_t i = 0; i < children.size(); ++i) {
+			auto srcChild = castNiNode(children[i].get());
+			if (!srcChild)
+				continue;
 
-					if (childName.size() >= prefix.size() &&
-						childName.substr(0, prefix.size()) == prefix) {
-						toDetach.push_back({ node, rawChild });
-					} else {
-						auto* childNode = rawChild->AsNode();
-						if (childNode) {
-							traverse(childNode);
-						}
-					}
-				}
-			};
-
-			traverse(dst);
-
-			for (auto& [parent, child] : toDetach) {
-				RE::NiPointer<RE::NiAVObject> ref;
-				parent->DetachChild(child, ref);
-			}
-		}
-
-		// returns the name of the skeleton owner
-		std::string ActorManager::Skeleton::name()
-		{
-			if (skeleton->GetUserData() && skeleton->GetUserData()->GetObjectReference()) {
-				auto bname = skyrim_cast<RE::TESFullName*>(skeleton->GetUserData()->GetObjectReference());
-				if (bname) {
-					return bname->GetFullName();
-				}
-			}
-			return "";
-		}
-
-		// Logs a warning once per NIF path when VR NiStream Type B stubs are found.
-		// Uses a static set to avoid duplicate warnings for the same NIF across frames.
-		static void logBrokenNifOnce(const char* nifPath, RE::NiAVObject* root)
-		{
-			if (!REL::Module::IsVR() || !nifPath || !root)
-				return;
-			static std::mutex warnedMutex;
-			static std::unordered_set<std::string> warned;
-			std::lock_guard lock(warnedMutex);
-			if (warned.count(nifPath))
-				return;
-			std::vector<RE::NiAVObject*> stack = { root };
-			while (!stack.empty()) {
-				auto obj = stack.back();
-				stack.pop_back();
-				if (!obj || !isValidNiObject(obj))
-					continue;
-				if (isVRNiStreamStub(obj)) {
-					warned.insert(nifPath);
-					logger::warn(
-						"[VR NiStream] NIF '{}' contains SE-format blocks VR cannot fully instantiate "
-						"(Type B stubs, broken vtable[43]). Run through Cathedral Assets Optimizer (CAO) for Skyrim VR.",
-						nifPath);
-					return;
-				}
-				auto node = obj->AsNode();
-				if (node)
-					for (auto& c : node->GetChildren())
-						if (c)
-							stack.push_back(c.get());
-			}
-		}
-
-		void ActorManager::Skeleton::addArmor(RE::NiNode * armorModel)
-		{
-			logBrokenNifOnce(armorModel->name.c_str(), armorModel);
-
-			IDType id = armors.size() ? armors.back().id + 1 : 0;
-			auto prefix = armorPrefix(id);
-			// FIXME we probably could simplify this by using findNode as surely we don't merge Armors with lurkers skeleton?
-			npc = hdt::make_nismart(getNpcNode(skeleton.get()));
-			auto physicsFile = DefaultBBP::instance()->scanBBP(armorModel);
-
-			armors.push_back(Armor());
-			armors.back().id = id;
-			armors.back().prefix = prefix;
-			armors.back().physicsFile = physicsFile;
-
-			doSkeletonMerge(npc.get(), armorModel, prefix, armors.back().renameMap);
-		}
-
-		void ActorManager::Skeleton::attachArmor([[maybe_unused]] RE::NiNode * armorModel, RE::NiAVObject * attachedNode)
-		{
-			if (armors.size() == 0 || armors.back().hasPhysics()) {
-				logger::trace("Not attaching armor - no record or physics already exists");
+			if (!srcChild->name.size()) {
+				doSkeletonMerge(dst, srcChild, prefix, map, dstRoot, renameSource);
+				continue;
 			}
 
-			Armor& armor = armors.back();
-
-			// The name of the attachedNode provided here will have been changed by the Skyrim exe between this event and the next.
-			armor.armorWorn = hdt::make_nismart(attachedNode);
-			// That's why we set here the need to fix this armor in fixArmorNameMaps() (see its comment)
-			// to avoid this name change breaking processes like 'smp reset' when looking for the armor name in the armor nameMap.
-			armor.armorCurrentMeshName = attachedNode->name.size() ? attachedNode->name : "";
-			armor.mustFixNameMap = true;
-			mustFixOneArmorMap = true;
-
-			if (!isFirstPersonSkeleton(skeleton.get())) {
-				// FIXME we probably could simplify this by using findNode as surely we don't attach Armors to lurkers skeleton?
-				auto renameMap = armor.renameMap;
-				auto system = SkyrimSystemCreator().createOrUpdateSystem(getNpcNode(skeleton.get()), attachedNode, &armor.physicsFile, std::move(renameMap), nullptr);
-				if (system) {
-					armor.setPhysics(system, isActive);
-					hasPhysics = true;
-				}
+			// FIXME: This was previously only in doHeadSkeletonMerge.
+			// But surely non-head skeletons wouldn't have this anyway?
+			if (!strcmp(srcChild->name.c_str(), "BSFaceGenNiNodeSkinned")) {
+				logger::debug("Skipping facegen ninode in skeleton merge.");
+				continue;
 			}
 
-			if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
-				RE::Actor* actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID);
-				if (actor) {
-					setHeadActiveIfNoHairArmor(actor, this);
-				}
-			}
-		}
-
-		void ActorManager::Skeleton::cleanArmor()
-		{
-			for (auto& i : armors) {
-				if (!i.armorWorn) {
-					continue;
-				}
-
-				if (i.armorWorn->parent) {
-					continue;
-				}
-
-				i.clearPhysics();
-				if (npc) {
-					doSkeletonClean(npc.get(), i.prefix);
-				}
-
-				i.prefix = std::string();
-			}
-
-			armors.erase(std::remove_if(armors.begin(), armors.end(), [](Armor& i) { return i.prefix.empty(); }), armors.end());
-		}
-
-		void ActorManager::Skeleton::cleanHead(bool cleanAll)
-		{
-			for (auto& headPart : head.headParts) {
-				if (!headPart.headPart->parent || cleanAll) {
-					if (cleanAll) {
-						logger::debug("Cleaning headpart {} due to clean all.", headPart.headPart->name);
-					} else {
-						logger::debug("Headpart {} disconnected.", headPart.headPart->name);
-					}
-
-					auto renameIt = this->head.renameMap.begin();
-					while (renameIt != this->head.renameMap.end()) {
-						bool erase = false;
-
-						if (headPart.renamedBonesInUse.count(renameIt->first) != 0) {
-							auto findNode = this->head.nodeUseCount.find(renameIt->first);
-							if (findNode != this->head.nodeUseCount.end()) {
-								findNode->second -= 1;
-								logger::debug("Decrementing use count by 1, it is now {}.", findNode->second);
-								if (findNode->second <= 0) {
-									logger::debug("Node no longer in use, cleaning from skeleton.");
-									auto removeObj = findObject(npc.get(), renameIt->second);
-									if (removeObj) {
-										logger::debug("Found node {}, removing.", removeObj->name);
-										auto parent = removeObj->parent;
-										if (parent) {
-											parent->DetachChild2(removeObj);
-										}
-									}
-									this->head.nodeUseCount.erase(findNode);
-									erase = true;
-								}
-							}
-						}
-
-						if (erase) {
-							renameIt = this->head.renameMap.erase(renameIt);
-						} else {
-							++renameIt;
-						}
-					}
-
-					headPart.headPart = nullptr;
-					headPart.origPartRootNode = nullptr;
-					headPart.clearPhysics();
-					headPart.renamedBonesInUse.clear();
-				}
-			}
-
-			head.headParts.erase(std::remove_if(head.headParts.begin(), head.headParts.end(), [](Head::HeadPart& i) { return !i.headPart; }), head.headParts.end());
-		}
-
-		void ActorManager::Skeleton::clear()
-		{
-			std::for_each(armors.begin(), armors.end(), [](Armor& armor) { armor.clearPhysics(); });
-			SkyrimPhysicsWorld::get()->removeSystemByNode(npc.get());
-			cleanHead();
-			head.headParts.clear();
-			head.headNode = nullptr;
-			armors.clear();
-		}
-
-		void ActorManager::Skeleton::calculateDistanceAndOrientationDifferenceFromSource(RE::NiPoint3 sourcePosition, RE::NiPoint3 sourceOrientation)
-		{
-			if (isPlayerCharacter()) {
-				m_distanceFromCamera2 = 0.f;
-				return;
-			}
-
-			auto pos = position();
-			if (!pos.has_value()) {
-				m_distanceFromCamera2 = std::numeric_limits<float>::max();
-				return;
-			}
-
-			// We calculate the vector between camera and the skeleton feet.
-			const auto camera2SkeletonVector = pos.value() - sourcePosition;
-			// This is the distance (squared) between the camera and the skeleton feet.
-			m_distanceFromCamera2 = camera2SkeletonVector.x * camera2SkeletonVector.x + camera2SkeletonVector.y * camera2SkeletonVector.y + camera2SkeletonVector.z * camera2SkeletonVector.z;
-			// This is |camera2SkeletonVector|*cos(angle between both vectors)
-			m_cosAngleFromCameraDirectionTimesSkeletonDistance = camera2SkeletonVector.x * sourceOrientation.x + camera2SkeletonVector.y * sourceOrientation.y + camera2SkeletonVector.z * sourceOrientation.z;
-		}
-
-		// Is called to print messages only
-		bool ActorManager::Skeleton::checkPhysics()
-		{
-			hasPhysics = false;
-			std::for_each(armors.begin(), armors.end(), [=](Armor& armor) {
-				if (armor.state() != ItemState::e_NoPhysics) {
-					hasPhysics = true;
-				}
-			});
-
-			if (!hasPhysics) {
-				std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) {
-					if (headPart.state() != ItemState::e_NoPhysics) {
-						hasPhysics = true;
-					}
-				});
-			}
-
-			logger::trace("{} isDrawn {}", name(), hasPhysics);
-
-			return hasPhysics;
-		}
-
-		bool ActorManager::Skeleton::isActiveInScene() const
-		{
-			// TODO: do this better
-			// When entering/exiting an interior, NPCs are detached from the scene but not unloaded, so we need to check two levels up.
-			// This properly removes exterior cell armors from the physics world when entering an interior, and vice versa.
-			return skeleton->parent && skeleton->parent->parent && skeleton->parent->parent->parent;
-		}
-
-		bool ActorManager::Skeleton::isPlayerCharacter() const
-		{
-			constexpr uint32_t playerFormID = 0x14;
-			return skeletonOwner.get() == RE::PlayerCharacter::GetSingleton() || (skeleton->GetUserData() && skeleton->GetUserData()->formID == playerFormID);
-		}
-
-		bool ActorManager::Skeleton::isInPlayerView()
-		{
-			// This function is called only when the skeleton isn't the player character.
-			// This might change in the future; in that case this test will have to be enabled.
-			//if (isPlayerCharacter())
-			//	return true;
-
-			auto* manager = ActorManager::instance();
-			const float minDist = manager->m_minCullingDistance;
-
-			// We always enable the skeletons that are just around the camera.
-			// It's useful if for example the skeleton origin is very near, behind the camera,
-			// but some parts of the skeleton are in front of the camera and need to be animated.
-			if (m_distanceFromCamera2 < minDist * minDist)
-				return true;
-
-			auto* owner = skyrim_cast<RE::Actor*>(skeletonOwner.get());
-			if (!owner)
-				return true;  // should never happen, a skeleton without owner?
-
-			// We don't enable the skeletons off-screen
-			auto* camera = RE::Main::WorldRootCamera();
-			auto* skeleton3D = owner->Get3D(false);
-
-			if (!skeleton3D || (camera && !camera->NodeInFrustum(skeleton3D)))
-				return false;
-
-			// Is the skeleton too small on screen?
-			// Ie, is the NPC's projected bounding sphere smaller than the allowed fraction of screen height?
-			// screenFraction < minFraction <=> r / (distance * tan(fov/2)) < fr <=> r^2 < fr^2 * distance^2 * tan(fov/2)^2
-			if (manager->m_screenSizeThresholdScale > 0.f) {
-				const auto& bound = skeleton3D->worldBound;
-				const auto cameraToBound = bound.center - manager->m_cameraPositionDuringFrame;
-				const float distanceToBound2 = cameraToBound.x * cameraToBound.x + cameraToBound.y * cameraToBound.y + cameraToBound.z * cameraToBound.z;
-
-				if (distanceToBound2 > bound.radius * bound.radius) {
-					// Use the nearest point on the sphere for a conservative size estimate.
-					const float visibleDistance = std::sqrt(distanceToBound2) - bound.radius;
-					if (bound.radius * bound.radius < manager->m_screenSizeThresholdScale * visibleDistance * visibleDistance)
-						return false;
-				}
-			}
-
-			RE::NiPoint3 hitLocation;
-			auto* obstacle = Actor_CalculateLOS(owner, &manager->m_cameraPositionDuringFrame, &hitLocation, 6.28f);
-			return !obstacle;  // If obstacle, we hit something on the path
-		}
-
-		std::optional<RE::NiPoint3> ActorManager::Skeleton::position() const
-		{
-			if (npc) {
-				// This works for lurker skeletons.
-				auto rootNode = findNode(npc.get(), "NPC Root [Root]");
-				if (rootNode) {
-					return std::optional<RE::NiPoint3>(rootNode->world.translate);
-				}
-			}
-
-			return std::optional<RE::NiPoint3>();
-		}
-
-		void ActorManager::Skeleton::updateWindFactor(float a_windFactor)
-		{
-			this->currentWindFactor = a_windFactor;
-			std::for_each(armors.begin(), armors.end(), [=](Armor& armor) { armor.setWindFactor(a_windFactor); });
-			std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) { headPart.setWindFactor(a_windFactor); });
-		}
-
-		float ActorManager::Skeleton::getWindFactor()
-		{
-			return this->currentWindFactor;
-		}
-
-		bool ActorManager::Skeleton::updateAttachedState(const RE::NiNode* playerCell, bool deactivate = false)
-		{
-			// 1- Skeletons that aren't active in any scene are always detached, unless they are in the
-			// same cell as the player character (workaround for issue in Ancestor Glade).
-			// 2- Player character is always attached.
-			// 3- Otherwise, attach only if both the camera and this skeleton have a position,
-			// the distance between them is below the threshold value,
-			// and the angle difference between the camera orientation and the skeleton orientation is below the threshold value.
-			isActive = false;
-			state = SkeletonState::e_InactiveNotInScene;
-
-			if (deactivate)
-				state = SkeletonState::e_InactiveTooFar;
-			else if (isActiveInScene() || skeleton->parent && skeleton->parent->parent == playerCell) {
-				if (isPlayerCharacter()) {
-					// That setting defines whether we don't set the PC skeleton as active
-					// when it is in 1st person view, to avoid calculating physics uselessly.
-					if (!(instance()->m_disable1stPersonViewPhysics                                                                                    // disabling?
-							&& RE::PlayerCamera::GetSingleton()->currentState == RE::PlayerCamera::GetSingleton()->GetRuntimeData().cameraStates[0]))  // 1st person view
-					{
-						isActive = true;
-						state = SkeletonState::e_ActiveIsPlayer;
-					}
-				} else if (isInPlayerView()) {
-					isActive = true;
-					state = SkeletonState::e_ActiveNearPlayer;
-				} else
-					state = SkeletonState::e_InactiveUnseenByPlayer;
-			}
-
-			// We update the activity state of armors and head parts, and add and remove SkinnedMeshSystems to these parts in consequence.
-			// We set headparts as not active if the head isn't active (for example because it's hidden by a wig).
-			std::for_each(armors.begin(), armors.end(), [=](Armor& armor) { armor.updateActive(isActive); });
-			const bool isHeadActive = head.isActive;
-			std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) { headPart.updateActive(isHeadActive && isActive); });
-			return isActive;
-		}
-
-		void ActorManager::Skeleton::reloadMeshes()
-		{
-			for (auto& i : armors) {
-				i.clearPhysics();
-				if (!isFirstPersonSkeleton(skeleton.get())) {
-					auto renameMap = i.renameMap;
-					auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), i.armorWorn.get(), &i.physicsFile, std::move(renameMap), nullptr);
-					if (system) {
-						i.setPhysics(system, isActive);
-						hasPhysics = true;
-					}
-				}
-			}
-			scanHead();
-		}
-
-		// Reload meshes without entirely wiping their physics
-		void ActorManager::Skeleton::softReloadMeshes()
-		{
-			auto reloadPhysicsItem = [&](auto& item, RE::NiAVObject* model, const auto& renameMapSrc, bool itemActive) {
-				RE::BSTSmartPointer<SkyrimSystem> oldSystem = item.m_physics;
-				item.clearPhysics();
-
-				if (!model || isFirstPersonSkeleton(skeleton.get()) || item.physicsFile.first.empty()) {
-					return;
-				}
-
-				auto renameMap = renameMapSrc;
-				auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), model, &item.physicsFile, std::move(renameMap), nullptr);
-
-				if (system) {
-					system->block_resetting = true;
-					if (oldSystem) {
-						hdt::util::transferCurrentPosesBetweenSystems(oldSystem.get(), system.get());
-					}
-
-					item.setPhysics(system, itemActive);
-					hasPhysics = true;
-					system->block_resetting = false;
-				}
-			};
-
-			for (auto& armor : armors) {
-				reloadPhysicsItem(armor, armor.armorWorn.get(), armor.renameMap, isActive);
-			}
-
-			if (isFirstPersonSkeleton(skeleton.get()) || !head.headNode) {
-				return;
-			}
-
-			if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
-				if (auto actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID)) {
-					setHeadActiveIfNoHairArmor(actor, this);
-				}
-			}
-
-			std::unordered_set<std::string> physicsDupes;
-			for (auto& headPart : head.headParts) {
-				// Skip duplicate physics files, but ensure we clear their old physics
-				if (!headPart.physicsFile.first.empty() && !physicsDupes.insert(headPart.physicsFile.first).second) {
-					headPart.clearPhysics();
-					continue;
-				}
-
-				reloadPhysicsItem(headPart, head.headNode.get(), head.renameMap, isActive && head.isActive);
-			}
-		}
-
-		void ActorManager::Skeleton::scanHead()
-		{
-			if (isFirstPersonSkeleton(this->skeleton.get())) {
-				logger::debug("Not scanning head of first person skeleton.");
-				return;
-			}
-
-			if (!this->head.headNode) {
-				logger::debug("Actor has no head node.");
-				return;
-			}
-
-			std::unordered_set<std::string> physicsDupes;
-
-			if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
-				RE::Actor* actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID);
-				if (actor) {
-					setHeadActiveIfNoHairArmor(actor, this);
-				}
-			}
-
-			for (auto& headPart : this->head.headParts) {
-				// always regen physics for all head parts
-				headPart.clearPhysics();
-
-				if (headPart.physicsFile.first.empty()) {
-					logger::debug("No physics file for headpart {}.", headPart.headPart->name);
-					continue;
-				}
-
-				if (physicsDupes.count(headPart.physicsFile.first)) {
-					logger::debug("Previous head part generated physics system for file {}, skipping.", headPart.physicsFile.first.c_str());
-					continue;
-				}
-
-				logger::debug("Try create system for headpart {} physics file {}.", headPart.headPart->name, headPart.physicsFile.first.c_str());
-				physicsDupes.insert(headPart.physicsFile.first);
-				auto renameMap = this->head.renameMap;
-				auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), this->head.headNode.get(), &headPart.physicsFile, std::move(renameMap), nullptr);
-				if (system) {
-					logger::debug("Success.");
-					headPart.setPhysics(system, isActive);
-					hasPhysics = true;
-				}
-			}
-		}
-
-		void ActorManager::Skeleton::processGeometry(RE::BSFaceGenNiNode * headNode, RE::BSGeometry * geometry)
-		{
-			if (this->head.headNode && this->head.headNode != headNode) {
-				logger::debug("Completely new head attached to skeleton, clearing tracking.");
-				for (auto& headPart : this->head.headParts) {
-					headPart.clearPhysics();
-					headPart.headPart = nullptr;
-					headPart.origPartRootNode = nullptr;
-				}
-
-				this->head.headParts.clear();
-
-				if (npc)
-					doSkeletonClean(npc.get(), this->head.prefix);
-
-				this->head.prefix = std::string();
-				this->head.headNode = nullptr;
-				this->head.renameMap.clear();
-				this->head.nodeUseCount.clear();
-			}
-
-			// clean swapped out headparts
-			cleanHead();
-
-			// Todo: This didn't have a null check before, but I don't see why not.
-			if (!this->head.headNode) {
-				this->head.headNode = hdt::make_nismart(headNode);
-				++this->head.id;
-				this->head.prefix = headPrefix(this->head.id);
-			}
-
-			auto it = std::find_if(this->head.headParts.begin(), this->head.headParts.end(), [geometry](const Head::HeadPart& p) {
-				return p.headPart == geometry;
-			});
-
-			if (it != this->head.headParts.end()) {
-				logger::debug("Geometry is already added as head part.");
-				return;
-			}
-
-			this->head.headParts.push_back(Head::HeadPart());
-
-			head.headParts.back().headPart = hdt::make_nismart(geometry);
-			head.headParts.back().clearPhysics();
-
-			// Skinning
-			logger::debug("Skinning geometry to skeleton.");
-
-			if (!geometry->GetGeometryRuntimeData().skinInstance || !geometry->GetGeometryRuntimeData().skinInstance->skinData) {
-				logger::error("Geometry is missing skin instance - how?");
-				return;
-			}
-
-			auto fmd = geometry->GetExtraData<RE::BSFaceGenModelExtraData>("FMD");
-
-			RE::BSGeometry* origGeom = nullptr;
-			RE::NiGeometry* origNiGeom = nullptr;
-
-			if (fmd && fmd->m_model && fmd->m_model->modelMeshData && fmd->m_model->modelMeshData->faceNode) {
-				logger::debug("Original part node found via facegen extra model data.");
-				auto origRootNode = fmd->m_model->modelMeshData->faceNode->AsNode();
-				head.headParts.back().physicsFile = DefaultBBP::instance()->scanBBP(origRootNode);
-				head.headParts.back().origPartRootNode = hdt::make_nismart(origRootNode);
-
-				auto& children = origRootNode->GetChildren();
-				for (uint16_t i = 0; i < children.size(); i++) {
-					if (children[i]) {
-						const auto geo = children[i]->AsGeometry();
-
-						if (geo) {
-							origGeom = geo;
-							break;
-						}
-					}
-				}
+			// TODO check it's not a lurker skeleton
+			auto dstChild = findNode(dstRoot, srcChild->name);
+			if (dstChild) {
+				doSkeletonMerge(dstChild, srcChild, prefix, map, dstRoot, renameSource);
 			} else {
-				logger::debug("No facegen extra model data available, loading original facegeometry.");
-				if (!head.npcFaceGeomNode && !head.npcFaceGeomNodeBroken) {
-					if (skeleton->GetUserData() && skeleton->GetUserData()->GetObjectReference()) {
-						auto skeletonNpc = skyrim_cast<RE::TESNPC*>(skeleton->GetUserData()->GetObjectReference());
-						if (skeletonNpc) {
-							char filePath[MAX_PATH];
-							if (TESNPC_GetFaceGeomPath(skeletonNpc, filePath)) {
-								logger::debug("Loading facegeometry via BSModelDB from path {}.", filePath);
+				dst->AttachChild(cloneNodeTree(srcChild, prefix, map, renameSource), false);
+			}
+		}
+	}
 
-								// same DBTraits Bethesda uses for FaceGen (from FUN_1403bbe00 on AE)
-								RE::BSModelDB::DBTraits::ArgsType args;
-								args.LODmult = 0;
-								args.texLoadLevel = 3;
-								args.unk8 = false;
-								args.unk9 = true;
-								args.unkA = false;
-								args.postProcess = true;
+	RE::NiNode* ActorManager::Skeleton::cloneNodeTree(RE::NiNode* src, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString>& map, bool renameSource)
+	{
+		//
+		RE::NiCloningProcess c;
 
-								RE::NiPointer<RE::NiNode> loadedModel;
-								auto error = RE::BSModelDB::Demand(filePath, loadedModel, args);
+		//
+		c.appendChar = '$';
+		c.copyType = 1;
+		c.scale = { 1.0f, 1.0f, 1.0f };
 
-								if (error == RE::BSResource::ErrorCode::kNone && loadedModel) {
-									auto rootFadeNode = loadedModel->AsFadeNode();
-									if (rootFadeNode) {
-										logger::debug("NPC facegeometry root fadeNode successfully loaded.");
+		auto ret = static_cast<RE::NiNode*>(src->CreateClone(c));
+		src->ProcessClone(c);
 
-										// Because we mutate rootFadeNode, we MUST deep clone the cached model!
-										// The clone can't be null (Otherwise it would CTD internally), so no null checks needed
-										RE::NiCloningProcess c;
+		// Renaming the source tree for Head parts corrupts the shared npcFaceGeomNode cache,
+		// so only rename the source for armor merges where the source is a per-attachment tree
+		if (renameSource) {
+			renameTree(src, prefix, map);
+		}
+		renameTree(ret, prefix, map);
 
-										// These just say, copy the original exactly
-										c.copyType = 1;
-										c.scale = { 1.0f, 1.0f, 1.0f };
+		return ret;
+	}
 
-										auto clonedObj = rootFadeNode->CreateClone(c);
-										rootFadeNode->ProcessClone(c);
-										auto clonedRoot = static_cast<RE::BSFadeNode*>(clonedObj);
+	void ActorManager::Skeleton::renameTree(RE::NiNode* root, std::string_view prefix, std::unordered_map<RE::BSFixedString, RE::BSFixedString>& map)
+	{
+		if (root->name.size()) {
+			std::string newName{ prefix };
+			newName += root->name;
+			if (map.insert(std::make_pair<RE::BSFixedString, RE::BSFixedString>(root->name.c_str(), newName)).second) {
+				logger::debug("Rename Bone {} -> {}.", root->name, newName.c_str());
+			}
 
-										// VR stuff probably still needed?
-										// VR: NiSkinInstance::LinkObject fails to resolve internal bone refs,
-										// storing the bone name as a raw char* instead of a resolved NiNode*.
-										// Bone NiNodes are self-contained in the face geometry NIF, so resolve
-										// them now by name lookup against the loaded tree.
-										// Must run before NiStream_deconstructor while the tree is live.
-										if (REL::Module::IsVR()) {
-											auto& ch = clonedRoot->GetChildren();
-											for (std::uint16_t ci = 0; ci < ch.size(); ++ci) {
-												auto faceChild = ch[ci].get();
-												if (!faceChild || !isValidNiObject(faceChild))
-													continue;
-												auto faceGeo = faceChild->AsGeometry();
-												if (!faceGeo)
-													continue;
-												const auto& grd = faceGeo->GetGeometryRuntimeData();
-												if (!grd.skinInstance || !grd.skinInstance->skinData)
-													continue;
-												std::uint32_t vrResolved = 0, vrFailed = 0;
-												for (std::uint32_t bi = 0; bi < grd.skinInstance->skinData->bones; ++bi) {
-													auto bone = grd.skinInstance->bones[bi];
-													if (!bone || isValidNiObject(bone))
-														continue;
-													// char* case: bone pointer is canonical but its bytes are not a valid vtable.
-													// Guard against truly non-canonical addresses before reading as a string.
-													if (reinterpret_cast<uintptr_t>(bone) > kCanonicalUserSpaceMax)
-														continue;
-													const char* name = reinterpret_cast<const char*>(bone);
-													auto result = findNode(clonedRoot, RE::BSFixedString(name));
-													grd.skinInstance->bones[bi] = result;
-													if (result)
-														++vrResolved;
-													else {
-														++vrFailed;
-														logger::warn("VR bone fix '{}': bone[{}] '{}' not found in NIF tree.", faceGeo->name.c_str(), bi, name);
-													}
-												}
-												if (vrResolved || vrFailed)
-													logger::info("VR bone fix '{}': resolved {}/{} unresolved bone refs in '{}'.", faceGeo->name.c_str(), vrResolved, vrResolved + vrFailed, filePath);
-											}
-										}
+			setNiNodeName(root, newName.c_str());
+		}
 
-										head.npcFaceGeomNode = hdt::make_nismart(clonedRoot);
-									} else {
-										logger::debug("NPC facegeometry root wasn't fadeNode as expected.");
+		auto& children = root->GetChildren();
+		for (uint16_t i = 0; i < children.size(); ++i) {
+			auto child = castNiNode(children[static_cast<std::uint16_t>(i)].get());
+			if (child) {
+				renameTree(child, prefix, map);
+			}
+		}
+	}
+
+	void ActorManager::Skeleton::doSkeletonClean(RE::NiNode* dst, std::string_view prefix)
+	{
+		std::vector<std::pair<RE::NiNode*, RE::NiAVObject*>> toDetach;
+
+		std::function<void(RE::NiNode*)> traverse = [&](RE::NiNode* node) {
+			if (!node)
+				return;
+			for (auto& childPtr : node->GetChildren()) {
+				if (!childPtr)
+					continue;
+				auto* rawChild = childPtr.get();
+
+				const char* cname = rawChild->name.c_str();
+				std::string_view childName = (cname && cname[0]) ? std::string_view(cname) : std::string_view{};
+
+				if (childName.size() >= prefix.size() &&
+					childName.substr(0, prefix.size()) == prefix) {
+					toDetach.push_back({ node, rawChild });
+				} else {
+					auto* childNode = rawChild->AsNode();
+					if (childNode) {
+						traverse(childNode);
+					}
+				}
+			}
+		};
+
+		traverse(dst);
+
+		for (auto& [parent, child] : toDetach) {
+			RE::NiPointer<RE::NiAVObject> ref;
+			parent->DetachChild(child, ref);
+		}
+	}
+
+	// returns the name of the skeleton owner
+	std::string ActorManager::Skeleton::name()
+	{
+		if (skeleton->GetUserData() && skeleton->GetUserData()->GetObjectReference()) {
+			auto bname = skyrim_cast<RE::TESFullName*>(skeleton->GetUserData()->GetObjectReference());
+			if (bname) {
+				return bname->GetFullName();
+			}
+		}
+		return "";
+	}
+
+	// Logs a warning once per NIF path when VR NiStream Type B stubs are found.
+	// Uses a static set to avoid duplicate warnings for the same NIF across frames.
+	static void logBrokenNifOnce(const char* nifPath, RE::NiAVObject* root)
+	{
+		if (!REL::Module::IsVR() || !nifPath || !root)
+			return;
+		static std::mutex warnedMutex;
+		static std::unordered_set<std::string> warned;
+		std::lock_guard lock(warnedMutex);
+		if (warned.count(nifPath))
+			return;
+		std::vector<RE::NiAVObject*> stack = { root };
+		while (!stack.empty()) {
+			auto obj = stack.back();
+			stack.pop_back();
+			if (!obj || !isValidNiObject(obj))
+				continue;
+			if (isVRNiStreamStub(obj)) {
+				warned.insert(nifPath);
+				logger::warn(
+					"[VR NiStream] NIF '{}' contains SE-format blocks VR cannot fully instantiate "
+					"(Type B stubs, broken vtable[43]). Run through Cathedral Assets Optimizer (CAO) for Skyrim VR.",
+					nifPath);
+				return;
+			}
+			auto node = obj->AsNode();
+			if (node)
+				for (auto& c : node->GetChildren())
+					if (c)
+						stack.push_back(c.get());
+		}
+	}
+
+	void ActorManager::Skeleton::addArmor(RE::NiNode* armorModel)
+	{
+		logBrokenNifOnce(armorModel->name.c_str(), armorModel);
+
+		IDType id = armors.size() ? armors.back().id + 1 : 0;
+		auto prefix = armorPrefix(id);
+		// FIXME we probably could simplify this by using findNode as surely we don't merge Armors with lurkers skeleton?
+		npc = hdt::make_nismart(getNpcNode(skeleton.get()));
+		auto physicsFile = DefaultBBP::instance()->scanBBP(armorModel);
+
+		armors.push_back(Armor());
+		armors.back().id = id;
+		armors.back().prefix = prefix;
+		armors.back().physicsFile = physicsFile;
+
+		doSkeletonMerge(npc.get(), armorModel, prefix, armors.back().renameMap);
+	}
+
+	void ActorManager::Skeleton::attachArmor([[maybe_unused]] RE::NiNode* armorModel, RE::NiAVObject* attachedNode)
+	{
+		if (armors.size() == 0 || armors.back().hasPhysics()) {
+			logger::trace("Not attaching armor - no record or physics already exists");
+		}
+
+		Armor& armor = armors.back();
+
+		// The name of the attachedNode provided here will have been changed by the Skyrim exe between this event and the next.
+		armor.armorWorn = hdt::make_nismart(attachedNode);
+		// That's why we set here the need to fix this armor in fixArmorNameMaps() (see its comment)
+		// to avoid this name change breaking processes like 'smp reset' when looking for the armor name in the armor nameMap.
+		armor.armorCurrentMeshName = attachedNode->name.size() ? attachedNode->name : "";
+		armor.mustFixNameMap = true;
+		mustFixOneArmorMap = true;
+
+		if (!isFirstPersonSkeleton(skeleton.get())) {
+			// FIXME we probably could simplify this by using findNode as surely we don't attach Armors to lurkers skeleton?
+			auto renameMap = armor.renameMap;
+			auto system = SkyrimSystemCreator().createOrUpdateSystem(getNpcNode(skeleton.get()), attachedNode, &armor.physicsFile, std::move(renameMap), nullptr);
+			if (system) {
+				armor.setPhysics(system, isActive);
+				hasPhysics = true;
+			}
+		}
+
+		if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
+			RE::Actor* actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID);
+			if (actor) {
+				setHeadActiveIfNoHairArmor(actor, this);
+			}
+		}
+	}
+
+	void ActorManager::Skeleton::cleanArmor()
+	{
+		for (auto& i : armors) {
+			if (!i.armorWorn) {
+				continue;
+			}
+
+			if (i.armorWorn->parent) {
+				continue;
+			}
+
+			i.clearPhysics();
+			if (npc) {
+				doSkeletonClean(npc.get(), i.prefix);
+			}
+
+			i.prefix = std::string();
+		}
+
+		armors.erase(std::remove_if(armors.begin(), armors.end(), [](Armor& i) { return i.prefix.empty(); }), armors.end());
+	}
+
+	void ActorManager::Skeleton::cleanHead(bool cleanAll)
+	{
+		for (auto& headPart : head.headParts) {
+			if (!headPart.headPart->parent || cleanAll) {
+				if (cleanAll) {
+					logger::debug("Cleaning headpart {} due to clean all.", headPart.headPart->name);
+				} else {
+					logger::debug("Headpart {} disconnected.", headPart.headPart->name);
+				}
+
+				auto renameIt = this->head.renameMap.begin();
+				while (renameIt != this->head.renameMap.end()) {
+					bool erase = false;
+
+					if (headPart.renamedBonesInUse.count(renameIt->first) != 0) {
+						auto findNode = this->head.nodeUseCount.find(renameIt->first);
+						if (findNode != this->head.nodeUseCount.end()) {
+							findNode->second -= 1;
+							logger::debug("Decrementing use count by 1, it is now {}.", findNode->second);
+							if (findNode->second <= 0) {
+								logger::debug("Node no longer in use, cleaning from skeleton.");
+								auto removeObj = findObject(npc.get(), renameIt->second);
+								if (removeObj) {
+									logger::debug("Found node {}, removing.", removeObj->name);
+									auto parent = removeObj->parent;
+									if (parent) {
+										parent->DetachChild2(removeObj);
 									}
-								} else {
-									logger::error("Facegeometry rejected by BSModelDB. Possibly a corrupted or unconverted LE mesh.");
-									head.npcFaceGeomNodeBroken = true;
 								}
+								this->head.nodeUseCount.erase(findNode);
+								erase = true;
 							}
 						}
 					}
-				} else
-					logger::debug("Using cached facegeometry.");
-				if (head.npcFaceGeomNode) {
-					head.headParts.back().physicsFile = DefaultBBP::instance()->scanBBP(head.npcFaceGeomNode.get());
-					auto obj = findObject(head.npcFaceGeomNode.get(), geometry->name);
-					if (obj) {
-						auto ob = obj->AsGeometry();
-						if (ob) {
-							origGeom = ob;
-						} else {
-							auto on = obj->AsNiGeometry();
-							if (on) {
-								origNiGeom = on;
+
+					if (erase) {
+						renameIt = this->head.renameMap.erase(renameIt);
+					} else {
+						++renameIt;
+					}
+				}
+
+				headPart.headPart = nullptr;
+				headPart.origPartRootNode = nullptr;
+				headPart.clearPhysics();
+				headPart.renamedBonesInUse.clear();
+			}
+		}
+
+		head.headParts.erase(std::remove_if(head.headParts.begin(), head.headParts.end(), [](Head::HeadPart& i) { return !i.headPart; }), head.headParts.end());
+	}
+
+	void ActorManager::Skeleton::clear()
+	{
+		std::for_each(armors.begin(), armors.end(), [](Armor& armor) { armor.clearPhysics(); });
+		SkyrimPhysicsWorld::get()->removeSystemByNode(npc.get());
+		cleanHead();
+		head.headParts.clear();
+		head.headNode = nullptr;
+		armors.clear();
+	}
+
+	void ActorManager::Skeleton::calculateDistanceAndOrientationDifferenceFromSource(RE::NiPoint3 sourcePosition, RE::NiPoint3 sourceOrientation)
+	{
+		if (isPlayerCharacter()) {
+			m_distanceFromCamera2 = 0.f;
+			return;
+		}
+
+		auto pos = position();
+		if (!pos.has_value()) {
+			m_distanceFromCamera2 = std::numeric_limits<float>::max();
+			return;
+		}
+
+		// We calculate the vector between camera and the skeleton feet.
+		const auto camera2SkeletonVector = pos.value() - sourcePosition;
+		// This is the distance (squared) between the camera and the skeleton feet.
+		m_distanceFromCamera2 = camera2SkeletonVector.x * camera2SkeletonVector.x + camera2SkeletonVector.y * camera2SkeletonVector.y + camera2SkeletonVector.z * camera2SkeletonVector.z;
+		// This is |camera2SkeletonVector|*cos(angle between both vectors)
+		m_cosAngleFromCameraDirectionTimesSkeletonDistance = camera2SkeletonVector.x * sourceOrientation.x + camera2SkeletonVector.y * sourceOrientation.y + camera2SkeletonVector.z * sourceOrientation.z;
+	}
+
+	// Is called to print messages only
+	bool ActorManager::Skeleton::checkPhysics()
+	{
+		hasPhysics = false;
+		std::for_each(armors.begin(), armors.end(), [=](Armor& armor) {
+			if (armor.state() != ItemState::e_NoPhysics) {
+				hasPhysics = true;
+			}
+		});
+
+		if (!hasPhysics) {
+			std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) {
+				if (headPart.state() != ItemState::e_NoPhysics) {
+					hasPhysics = true;
+				}
+			});
+		}
+
+		logger::trace("{} isDrawn {}", name(), hasPhysics);
+
+		return hasPhysics;
+	}
+
+	bool ActorManager::Skeleton::isActiveInScene() const
+	{
+		// TODO: do this better
+		// When entering/exiting an interior, NPCs are detached from the scene but not unloaded, so we need to check two levels up.
+		// This properly removes exterior cell armors from the physics world when entering an interior, and vice versa.
+		return skeleton->parent && skeleton->parent->parent && skeleton->parent->parent->parent;
+	}
+
+	bool ActorManager::Skeleton::isPlayerCharacter() const
+	{
+		constexpr uint32_t playerFormID = 0x14;
+		return skeletonOwner.get() == RE::PlayerCharacter::GetSingleton() || (skeleton->GetUserData() && skeleton->GetUserData()->formID == playerFormID);
+	}
+
+	bool ActorManager::Skeleton::isInPlayerView()
+	{
+		// This function is called only when the skeleton isn't the player character.
+		// This might change in the future; in that case this test will have to be enabled.
+		//if (isPlayerCharacter())
+		//	return true;
+
+		auto* manager = ActorManager::instance();
+		const float minDist = manager->m_minCullingDistance;
+
+		// We always enable the skeletons that are just around the camera.
+		// It's useful if for example the skeleton origin is very near, behind the camera,
+		// but some parts of the skeleton are in front of the camera and need to be animated.
+		if (m_distanceFromCamera2 < minDist * minDist)
+			return true;
+
+		auto* owner = skyrim_cast<RE::Actor*>(skeletonOwner.get());
+		if (!owner)
+			return true;  // should never happen, a skeleton without owner?
+
+		// We don't enable the skeletons off-screen
+		auto* camera = RE::Main::WorldRootCamera();
+		auto* skeleton3D = owner->Get3D(false);
+
+		if (!skeleton3D || (camera && !camera->NodeInFrustum(skeleton3D)))
+			return false;
+
+		// Is the skeleton too small on screen?
+		// Ie, is the NPC's projected bounding sphere smaller than the allowed fraction of screen height?
+		// screenFraction < minFraction <=> r / (distance * tan(fov/2)) < fr <=> r^2 < fr^2 * distance^2 * tan(fov/2)^2
+		if (manager->m_screenSizeThresholdScale > 0.f) {
+			const auto& bound = skeleton3D->worldBound;
+			const auto cameraToBound = bound.center - manager->m_cameraPositionDuringFrame;
+			const float distanceToBound2 = cameraToBound.x * cameraToBound.x + cameraToBound.y * cameraToBound.y + cameraToBound.z * cameraToBound.z;
+
+			if (distanceToBound2 > bound.radius * bound.radius) {
+				// Use the nearest point on the sphere for a conservative size estimate.
+				const float visibleDistance = std::sqrt(distanceToBound2) - bound.radius;
+				if (bound.radius * bound.radius < manager->m_screenSizeThresholdScale * visibleDistance * visibleDistance)
+					return false;
+			}
+		}
+
+		RE::NiPoint3 hitLocation;
+		auto* obstacle = Actor_CalculateLOS(owner, &manager->m_cameraPositionDuringFrame, &hitLocation, 6.28f);
+		return !obstacle;  // If obstacle, we hit something on the path
+	}
+
+	std::optional<RE::NiPoint3> ActorManager::Skeleton::position() const
+	{
+		if (npc) {
+			// This works for lurker skeletons.
+			auto rootNode = findNode(npc.get(), "NPC Root [Root]");
+			if (rootNode) {
+				return std::optional<RE::NiPoint3>(rootNode->world.translate);
+			}
+		}
+
+		return std::optional<RE::NiPoint3>();
+	}
+
+	void ActorManager::Skeleton::updateWindFactor(float a_windFactor)
+	{
+		this->currentWindFactor = a_windFactor;
+		std::for_each(armors.begin(), armors.end(), [=](Armor& armor) { armor.setWindFactor(a_windFactor); });
+		std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) { headPart.setWindFactor(a_windFactor); });
+	}
+
+	float ActorManager::Skeleton::getWindFactor()
+	{
+		return this->currentWindFactor;
+	}
+
+	bool ActorManager::Skeleton::updateAttachedState(const RE::NiNode* playerCell, bool deactivate = false)
+	{
+		// 1- Skeletons that aren't active in any scene are always detached, unless they are in the
+		// same cell as the player character (workaround for issue in Ancestor Glade).
+		// 2- Player character is always attached.
+		// 3- Otherwise, attach only if both the camera and this skeleton have a position,
+		// the distance between them is below the threshold value,
+		// and the angle difference between the camera orientation and the skeleton orientation is below the threshold value.
+		isActive = false;
+		state = SkeletonState::e_InactiveNotInScene;
+
+		if (deactivate)
+			state = SkeletonState::e_InactiveTooFar;
+		else if (isActiveInScene() || skeleton->parent && skeleton->parent->parent == playerCell) {
+			if (isPlayerCharacter()) {
+				// That setting defines whether we don't set the PC skeleton as active
+				// when it is in 1st person view, to avoid calculating physics uselessly.
+				if (!(instance()->m_disable1stPersonViewPhysics                                                                                    // disabling?
+						&& RE::PlayerCamera::GetSingleton()->currentState == RE::PlayerCamera::GetSingleton()->GetRuntimeData().cameraStates[0]))  // 1st person view
+				{
+					isActive = true;
+					state = SkeletonState::e_ActiveIsPlayer;
+				}
+			} else if (isInPlayerView()) {
+				isActive = true;
+				state = SkeletonState::e_ActiveNearPlayer;
+			} else
+				state = SkeletonState::e_InactiveUnseenByPlayer;
+		}
+
+		// We update the activity state of armors and head parts, and add and remove SkinnedMeshSystems to these parts in consequence.
+		// We set headparts as not active if the head isn't active (for example because it's hidden by a wig).
+		std::for_each(armors.begin(), armors.end(), [=](Armor& armor) { armor.updateActive(isActive); });
+		const bool isHeadActive = head.isActive;
+		std::for_each(head.headParts.begin(), head.headParts.end(), [=](Head::HeadPart& headPart) { headPart.updateActive(isHeadActive && isActive); });
+		return isActive;
+	}
+
+	void ActorManager::Skeleton::reloadMeshes()
+	{
+		for (auto& i : armors) {
+			i.clearPhysics();
+			if (!isFirstPersonSkeleton(skeleton.get())) {
+				auto renameMap = i.renameMap;
+				auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), i.armorWorn.get(), &i.physicsFile, std::move(renameMap), nullptr);
+				if (system) {
+					i.setPhysics(system, isActive);
+					hasPhysics = true;
+				}
+			}
+		}
+		scanHead();
+	}
+
+	// Reload meshes without entirely wiping their physics
+	void ActorManager::Skeleton::softReloadMeshes()
+	{
+		auto reloadPhysicsItem = [&](auto& item, RE::NiAVObject* model, const auto& renameMapSrc, bool itemActive) {
+			RE::BSTSmartPointer<SkyrimSystem> oldSystem = item.m_physics;
+			item.clearPhysics();
+
+			if (!model || isFirstPersonSkeleton(skeleton.get()) || item.physicsFile.first.empty()) {
+				return;
+			}
+
+			auto renameMap = renameMapSrc;
+			auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), model, &item.physicsFile, std::move(renameMap), nullptr);
+
+			if (system) {
+				system->block_resetting = true;
+				if (oldSystem) {
+					hdt::util::transferCurrentPosesBetweenSystems(oldSystem.get(), system.get());
+				}
+
+				item.setPhysics(system, itemActive);
+				hasPhysics = true;
+				system->block_resetting = false;
+			}
+		};
+
+		for (auto& armor : armors) {
+			reloadPhysicsItem(armor, armor.armorWorn.get(), armor.renameMap, isActive);
+		}
+
+		if (isFirstPersonSkeleton(skeleton.get()) || !head.headNode) {
+			return;
+		}
+
+		if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
+			if (auto actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID)) {
+				setHeadActiveIfNoHairArmor(actor, this);
+			}
+		}
+
+		std::unordered_set<std::string> physicsDupes;
+		for (auto& headPart : head.headParts) {
+			// Skip duplicate physics files, but ensure we clear their old physics
+			if (!headPart.physicsFile.first.empty() && !physicsDupes.insert(headPart.physicsFile.first).second) {
+				headPart.clearPhysics();
+				continue;
+			}
+
+			reloadPhysicsItem(headPart, head.headNode.get(), head.renameMap, isActive && head.isActive);
+		}
+	}
+
+	void ActorManager::Skeleton::scanHead()
+	{
+		if (isFirstPersonSkeleton(this->skeleton.get())) {
+			logger::debug("Not scanning head of first person skeleton.");
+			return;
+		}
+
+		if (!this->head.headNode) {
+			logger::debug("Actor has no head node.");
+			return;
+		}
+
+		std::unordered_set<std::string> physicsDupes;
+
+		if (instance()->m_disableSMPHairWhenWigEquipped && skeleton && skeleton->GetUserData()) {
+			RE::Actor* actor = RE::TESForm::LookupByID<RE::Actor>(skeleton->GetUserData()->formID);
+			if (actor) {
+				setHeadActiveIfNoHairArmor(actor, this);
+			}
+		}
+
+		for (auto& headPart : this->head.headParts) {
+			// always regen physics for all head parts
+			headPart.clearPhysics();
+
+			if (headPart.physicsFile.first.empty()) {
+				logger::debug("No physics file for headpart {}.", headPart.headPart->name);
+				continue;
+			}
+
+			if (physicsDupes.count(headPart.physicsFile.first)) {
+				logger::debug("Previous head part generated physics system for file {}, skipping.", headPart.physicsFile.first.c_str());
+				continue;
+			}
+
+			logger::debug("Try create system for headpart {} physics file {}.", headPart.headPart->name, headPart.physicsFile.first.c_str());
+			physicsDupes.insert(headPart.physicsFile.first);
+			auto renameMap = this->head.renameMap;
+			auto system = SkyrimSystemCreator().createOrUpdateSystem(npc.get(), this->head.headNode.get(), &headPart.physicsFile, std::move(renameMap), nullptr);
+			if (system) {
+				logger::debug("Success.");
+				headPart.setPhysics(system, isActive);
+				hasPhysics = true;
+			}
+		}
+	}
+
+	void ActorManager::Skeleton::processGeometry(RE::BSFaceGenNiNode* headNode, RE::BSGeometry* geometry)
+	{
+		if (this->head.headNode && this->head.headNode != headNode) {
+			logger::debug("Completely new head attached to skeleton, clearing tracking.");
+			for (auto& headPart : this->head.headParts) {
+				headPart.clearPhysics();
+				headPart.headPart = nullptr;
+				headPart.origPartRootNode = nullptr;
+			}
+
+			this->head.headParts.clear();
+
+			if (npc)
+				doSkeletonClean(npc.get(), this->head.prefix);
+
+			this->head.prefix = std::string();
+			this->head.headNode = nullptr;
+			this->head.renameMap.clear();
+			this->head.nodeUseCount.clear();
+		}
+
+		// clean swapped out headparts
+		cleanHead();
+
+		// Todo: This didn't have a null check before, but I don't see why not.
+		if (!this->head.headNode) {
+			this->head.headNode = hdt::make_nismart(headNode);
+			++this->head.id;
+			this->head.prefix = headPrefix(this->head.id);
+		}
+
+		auto it = std::find_if(this->head.headParts.begin(), this->head.headParts.end(), [geometry](const Head::HeadPart& p) {
+			return p.headPart == geometry;
+		});
+
+		if (it != this->head.headParts.end()) {
+			logger::debug("Geometry is already added as head part.");
+			return;
+		}
+
+		this->head.headParts.push_back(Head::HeadPart());
+
+		head.headParts.back().headPart = hdt::make_nismart(geometry);
+		head.headParts.back().clearPhysics();
+
+		// Skinning
+		logger::debug("Skinning geometry to skeleton.");
+
+		if (!geometry->GetGeometryRuntimeData().skinInstance || !geometry->GetGeometryRuntimeData().skinInstance->skinData) {
+			logger::error("Geometry is missing skin instance - how?");
+			return;
+		}
+
+		auto fmd = geometry->GetExtraData<RE::BSFaceGenModelExtraData>("FMD");
+
+		RE::BSGeometry* origGeom = nullptr;
+		RE::NiGeometry* origNiGeom = nullptr;
+
+		if (fmd && fmd->m_model && fmd->m_model->modelMeshData && fmd->m_model->modelMeshData->faceNode) {
+			logger::debug("Original part node found via facegen extra model data.");
+			auto origRootNode = fmd->m_model->modelMeshData->faceNode->AsNode();
+			head.headParts.back().physicsFile = DefaultBBP::instance()->scanBBP(origRootNode);
+			head.headParts.back().origPartRootNode = hdt::make_nismart(origRootNode);
+
+			auto& children = origRootNode->GetChildren();
+			for (uint16_t i = 0; i < children.size(); i++) {
+				if (children[i]) {
+					const auto geo = children[i]->AsGeometry();
+
+					if (geo) {
+						origGeom = geo;
+						break;
+					}
+				}
+			}
+		} else {
+			logger::debug("No facegen extra model data available, loading original facegeometry.");
+			if (!head.npcFaceGeomNode && !head.npcFaceGeomNodeBroken) {
+				if (skeleton->GetUserData() && skeleton->GetUserData()->GetObjectReference()) {
+					auto skeletonNpc = skyrim_cast<RE::TESNPC*>(skeleton->GetUserData()->GetObjectReference());
+					if (skeletonNpc) {
+						char filePath[MAX_PATH];
+						if (TESNPC_GetFaceGeomPath(skeletonNpc, filePath)) {
+							logger::debug("Loading facegeometry via BSModelDB from path {}.", filePath);
+
+							// same DBTraits Bethesda uses for FaceGen (from FUN_1403bbe00 on AE)
+							RE::BSModelDB::DBTraits::ArgsType args;
+							args.LODmult = 0;
+							args.texLoadLevel = 3;
+							args.unk8 = false;
+							args.unk9 = true;
+							args.unkA = false;
+							args.postProcess = true;
+
+							RE::NiPointer<RE::NiNode> loadedModel;
+							auto error = RE::BSModelDB::Demand(filePath, loadedModel, args);
+
+							if (error == RE::BSResource::ErrorCode::kNone && loadedModel) {
+								auto rootFadeNode = loadedModel->AsFadeNode();
+								if (rootFadeNode) {
+									logger::debug("NPC facegeometry root fadeNode successfully loaded.");
+
+									// Because we mutate rootFadeNode, we MUST deep clone the cached model!
+									// The clone can't be null (Otherwise it would CTD internally), so no null checks needed
+									RE::NiCloningProcess c;
+
+									// These just say, copy the original exactly
+									c.copyType = 1;
+									c.scale = { 1.0f, 1.0f, 1.0f };
+
+									auto clonedObj = rootFadeNode->CreateClone(c);
+									rootFadeNode->ProcessClone(c);
+									auto clonedRoot = static_cast<RE::BSFadeNode*>(clonedObj);
+
+									// VR stuff probably still needed?
+									// VR: NiSkinInstance::LinkObject fails to resolve internal bone refs,
+									// storing the bone name as a raw char* instead of a resolved NiNode*.
+									// Bone NiNodes are self-contained in the face geometry NIF, so resolve
+									// them now by name lookup against the loaded tree.
+									// Must run before NiStream_deconstructor while the tree is live.
+									if (REL::Module::IsVR()) {
+										auto& ch = clonedRoot->GetChildren();
+										for (std::uint16_t ci = 0; ci < ch.size(); ++ci) {
+											auto faceChild = ch[ci].get();
+											if (!faceChild || !isValidNiObject(faceChild))
+												continue;
+											auto faceGeo = faceChild->AsGeometry();
+											if (!faceGeo)
+												continue;
+											const auto& grd = faceGeo->GetGeometryRuntimeData();
+											if (!grd.skinInstance || !grd.skinInstance->skinData)
+												continue;
+											std::uint32_t vrResolved = 0, vrFailed = 0;
+											for (std::uint32_t bi = 0; bi < grd.skinInstance->skinData->bones; ++bi) {
+												auto bone = grd.skinInstance->bones[bi];
+												if (!bone || isValidNiObject(bone))
+													continue;
+												// char* case: bone pointer is canonical but its bytes are not a valid vtable.
+												// Guard against truly non-canonical addresses before reading as a string.
+												if (reinterpret_cast<uintptr_t>(bone) > kCanonicalUserSpaceMax)
+													continue;
+												const char* name = reinterpret_cast<const char*>(bone);
+												auto result = findNode(clonedRoot, RE::BSFixedString(name));
+												grd.skinInstance->bones[bi] = result;
+												if (result)
+													++vrResolved;
+												else {
+													++vrFailed;
+													logger::warn("VR bone fix '{}': bone[{}] '{}' not found in NIF tree.", faceGeo->name.c_str(), bi, name);
+												}
+											}
+											if (vrResolved || vrFailed)
+												logger::info("VR bone fix '{}': resolved {}/{} unresolved bone refs in '{}'.", faceGeo->name.c_str(), vrResolved, vrResolved + vrFailed, filePath);
+										}
+									}
+
+									head.npcFaceGeomNode = hdt::make_nismart(clonedRoot);
+								} else {
+									logger::debug("NPC facegeometry root wasn't fadeNode as expected.");
+								}
+							} else {
+								logger::error("Facegeometry rejected by BSModelDB. Possibly a corrupted or unconverted LE mesh.");
+								head.npcFaceGeomNodeBroken = true;
+							}
+						}
+					}
+				}
+			} else
+				logger::debug("Using cached facegeometry.");
+			if (head.npcFaceGeomNode) {
+				head.headParts.back().physicsFile = DefaultBBP::instance()->scanBBP(head.npcFaceGeomNode.get());
+				auto obj = findObject(head.npcFaceGeomNode.get(), geometry->name);
+				if (obj) {
+					auto ob = obj->AsGeometry();
+					if (ob) {
+						origGeom = ob;
+					} else {
+						auto on = obj->AsNiGeometry();
+						if (on) {
+							origNiGeom = on;
+						}
+					}
+				}
+			}
+		}
+
+		bool hasMerged = false;
+		bool hasRenames = false;
+
+		for (uint32_t boneIdx = 0; boneIdx < geometry->GetGeometryRuntimeData().skinInstance->skinData->bones; boneIdx++) {
+			RE::BSFixedString boneName("");
+
+			// skin the way the game does via FMD
+			if (boneIdx <= 7) {
+				if (fmd)
+					boneName = fmd->bones[boneIdx];
+			}
+
+			// BSModelDB guarantees origGeom is perfectly formed, so we check this BEFORE the active geometry
+			if (boneName.empty() && origGeom) {
+				const auto& rd = origGeom->GetGeometryRuntimeData();
+				if (rd.skinInstance && reinterpret_cast<uintptr_t>(rd.skinInstance.get()) <= kCanonicalUserSpaceMax) {
+					auto skinData = rd.skinInstance->skinData.get();
+					if (skinData && reinterpret_cast<uintptr_t>(skinData) <= kCanonicalUserSpaceMax && boneIdx < skinData->bones) {
+						if (rd.skinInstance->bones && reinterpret_cast<uintptr_t>(rd.skinInstance->bones) <= kCanonicalUserSpaceMax) {
+							auto bone = rd.skinInstance->bones[boneIdx];
+							if (isValidNiObject(bone)) {
+								boneName = bone->name;
+							} else {
+								logger::debug("isValidNiObject was false for BSModelDB");
 							}
 						}
 					}
 				}
 			}
 
-			bool hasMerged = false;
-			bool hasRenames = false;
+			// Fallback to active rendering geometry
+			// We only do this if origGeom failed, because FaceGen > 7 leaves garbage in here
+			// This should be dead code, but we keep it just in case..
+			if (boneName.empty()) {
+				const auto& activeSkin = geometry->GetGeometryRuntimeData().skinInstance;
+				if (activeSkin && reinterpret_cast<uintptr_t>(activeSkin.get()) <= kCanonicalUserSpaceMax) {
+					auto skinData = activeSkin->skinData.get();
+					if (skinData && reinterpret_cast<uintptr_t>(skinData) <= kCanonicalUserSpaceMax && boneIdx < skinData->bones) {
+						if (activeSkin->bones && reinterpret_cast<uintptr_t>(activeSkin->bones) <= kCanonicalUserSpaceMax) {
+							auto bone = activeSkin->bones[boneIdx];
+							if (isValidNiObject(bone)) {
+								boneName = bone->name;
+							} else if (bone && reinterpret_cast<uintptr_t>(bone) <= kCanonicalUserSpaceMax) {
+								// Try to salvage what we can to avoid bald NPC's and what not
+								const char* raw = reinterpret_cast<const char*>(bone);
+								bool looksLikeString = true;
+								for (int ci = 0; ci < 64; ++ci) {
+									char ch = raw[ci];
+									if (ch == '\0')
+										break;
 
-			for (uint32_t boneIdx = 0; boneIdx < geometry->GetGeometryRuntimeData().skinInstance->skinData->bones; boneIdx++) {
-				RE::BSFixedString boneName("");
-
-				// skin the way the game does via FMD
-				if (boneIdx <= 7) {
-					if (fmd)
-						boneName = fmd->bones[boneIdx];
-				}
-
-				// BSModelDB guarantees origGeom is perfectly formed, so we check this BEFORE the active geometry
-				if (boneName.empty() && origGeom) {
-					const auto& rd = origGeom->GetGeometryRuntimeData();
-					if (rd.skinInstance && reinterpret_cast<uintptr_t>(rd.skinInstance.get()) <= kCanonicalUserSpaceMax) {
-						auto skinData = rd.skinInstance->skinData.get();
-						if (skinData && reinterpret_cast<uintptr_t>(skinData) <= kCanonicalUserSpaceMax && boneIdx < skinData->bones) {
-							if (rd.skinInstance->bones && reinterpret_cast<uintptr_t>(rd.skinInstance->bones) <= kCanonicalUserSpaceMax) {
-								auto bone = rd.skinInstance->bones[boneIdx];
-								if (isValidNiObject(bone)) {
-									boneName = bone->name;
+									// cast to unsigned char to prevent negative values passing the < 0x20 check
+									if ((unsigned char)ch < 0x20 || (unsigned char)ch > 0x7E) {
+										looksLikeString = false;
+										logger::debug("Hit a corrupted bone name?");
+										break;
+									}
+								}
+								if (looksLikeString && raw[0] != '\0') {
+									boneName = raw;
 								} else {
-									logger::debug("isValidNiObject was false for BSModelDB");
+									logger::debug("Rendering geometry fallback failed to resolve bone names");
 								}
 							}
 						}
 					}
 				}
+			}
 
-				// Fallback to active rendering geometry
-				// We only do this if origGeom failed, because FaceGen > 7 leaves garbage in here
-				// This should be dead code, but we keep it just in case..
-				if (boneName.empty()) {
-					const auto& activeSkin = geometry->GetGeometryRuntimeData().skinInstance;
-					if (activeSkin && reinterpret_cast<uintptr_t>(activeSkin.get()) <= kCanonicalUserSpaceMax) {
-						auto skinData = activeSkin->skinData.get();
-						if (skinData && reinterpret_cast<uintptr_t>(skinData) <= kCanonicalUserSpaceMax && boneIdx < skinData->bones) {
-							if (activeSkin->bones && reinterpret_cast<uintptr_t>(activeSkin->bones) <= kCanonicalUserSpaceMax) {
-								auto bone = activeSkin->bones[boneIdx];
-								if (isValidNiObject(bone)) {
-									boneName = bone->name;
-								} else if (bone && reinterpret_cast<uintptr_t>(bone) <= kCanonicalUserSpaceMax) {
-									// Try to salvage what we can to avoid bald NPC's and what not
-									const char* raw = reinterpret_cast<const char*>(bone);
-									bool looksLikeString = true;
-									for (int ci = 0; ci < 64; ++ci) {
-										char ch = raw[ci];
-										if (ch == '\0')
-											break;
+			auto renameIt = this->head.renameMap.find(boneName.c_str());
+			if (renameIt != this->head.renameMap.end()) {
+				logger::debug("Found renamed bone {} -> {}.", boneName, renameIt->second.c_str());
+				boneName = renameIt->second;
+				hasRenames = true;
+			}
 
-										// cast to unsigned char to prevent negative values passing the < 0x20 check
-										if ((unsigned char)ch < 0x20 || (unsigned char)ch > 0x7E) {
-											looksLikeString = false;
-											logger::debug("Hit a corrupted bone name?");
-											break;
-										}
-									}
-									if (looksLikeString && raw[0] != '\0') {
-										boneName = raw;
-									} else {
-										logger::debug("Rendering geometry fallback failed to resolve bone names");
-									}
-								}
+			auto boneNode = findNode(this->npc.get(), boneName);
+
+			if (!boneNode && !hasMerged) {
+				logger::debug("Bone not found on skeleton, trying skeleton merge.");
+				if (this->head.headParts.back().origPartRootNode) {
+					doSkeletonMerge(npc.get(), head.headParts.back().origPartRootNode.get(), head.prefix, head.renameMap, false);
+				} else if (this->head.npcFaceGeomNode) {
+					logger::debug("Merging facegen into the head node.");
+
+					// Facegen data doesn't have any tree structure to the skeleton. We need to make any new
+					// nodes children of the head node, so that they move properly when there's no physics.
+					// This case never happens to a lurker skeleton, thus we don't need to test.
+					RE::NiNode* npcHeadNode = findNode(head.npcFaceGeomNode.get(), "NPC Head [Head]");
+					if (npcHeadNode) {
+						RE::NiTransform invTransform = npcHeadNode->local.Invert();
+						auto& children = head.npcFaceGeomNode->GetChildren();
+
+						for (int32_t i = static_cast<int32_t>(children.size()) - 1; i >= 0; --i) {
+							auto child = castNiNode(children[static_cast<std::uint16_t>(i)].get());
+
+							if (child && !findNode(npc.get(), child->name)) {
+								// hold a reference so DetachChildAt2 doesn't destroy the node
+								RE::NiPointer<RE::NiNode> ref(child);
+								child->local = invTransform * child->local;
+								head.npcFaceGeomNode->DetachChildAt2(i);
+								npcHeadNode->AttachChild(child, false);
 							}
 						}
 					}
+					doSkeletonMerge(npc.get(), this->head.npcFaceGeomNode.get(), head.prefix, head.renameMap, false);
 				}
 
-				auto renameIt = this->head.renameMap.find(boneName.c_str());
-				if (renameIt != this->head.renameMap.end()) {
-					logger::debug("Found renamed bone {} -> {}.", boneName, renameIt->second.c_str());
-					boneName = renameIt->second;
+				hasMerged = true;
+
+				auto postMergeRenameIt = this->head.renameMap.find(boneName.c_str());
+
+				if (postMergeRenameIt != this->head.renameMap.end()) {
+					logger::debug("Found renamed bone {} -> {}.", boneName, postMergeRenameIt->second.c_str());
+					boneName = postMergeRenameIt->second;
 					hasRenames = true;
 				}
 
-				auto boneNode = findNode(this->npc.get(), boneName);
-
-				if (!boneNode && !hasMerged) {
-					logger::debug("Bone not found on skeleton, trying skeleton merge.");
-					if (this->head.headParts.back().origPartRootNode) {
-						doSkeletonMerge(npc.get(), head.headParts.back().origPartRootNode.get(), head.prefix, head.renameMap, false);
-					} else if (this->head.npcFaceGeomNode) {
-						logger::debug("Merging facegen into the head node.");
-
-						// Facegen data doesn't have any tree structure to the skeleton. We need to make any new
-						// nodes children of the head node, so that they move properly when there's no physics.
-						// This case never happens to a lurker skeleton, thus we don't need to test.
-						RE::NiNode* npcHeadNode = findNode(head.npcFaceGeomNode.get(), "NPC Head [Head]");
-						if (npcHeadNode) {
-							RE::NiTransform invTransform = npcHeadNode->local.Invert();
-							auto& children = head.npcFaceGeomNode->GetChildren();
-
-							for (int32_t i = static_cast<int32_t>(children.size()) - 1; i >= 0; --i) {
-								auto child = castNiNode(children[static_cast<std::uint16_t>(i)].get());
-
-								if (child && !findNode(npc.get(), child->name)) {
-									// hold a reference so DetachChildAt2 doesn't destroy the node
-									RE::NiPointer<RE::NiNode> ref(child);
-									child->local = invTransform * child->local;
-									head.npcFaceGeomNode->DetachChildAt2(i);
-									npcHeadNode->AttachChild(child, false);
-								}
-							}
-						}
-						doSkeletonMerge(npc.get(), this->head.npcFaceGeomNode.get(), head.prefix, head.renameMap, false);
-					}
-
-					hasMerged = true;
-
-					auto postMergeRenameIt = this->head.renameMap.find(boneName.c_str());
-
-					if (postMergeRenameIt != this->head.renameMap.end()) {
-						logger::debug("Found renamed bone {} -> {}.", boneName, postMergeRenameIt->second.c_str());
-						boneName = postMergeRenameIt->second;
-						hasRenames = true;
-					}
-
-					boneNode = findNode(this->npc.get(), boneName);
-				}
-
-				if (!boneNode) {
-					logger::error("Bone {} not found after skeleton merge, geometry cannot be fully skinned.", boneName);
-					continue;
-				}
-
-				geometry->GetGeometryRuntimeData().skinInstance->bones[boneIdx] = boneNode;
-				geometry->GetGeometryRuntimeData().skinInstance->boneWorldTransforms[boneIdx] = &boneNode->world;
+				boneNode = findNode(this->npc.get(), boneName);
 			}
 
-			geometry->GetGeometryRuntimeData().skinInstance->rootParent = headNode;
-
-			if (hasRenames) {
-				for (auto& entry : head.renameMap) {
-					bool inUse = false;
-
-					auto origPartRoot = this->head.headParts.back().origPartRootNode.get();
-					auto npcFaceGeom = this->head.npcFaceGeomNode.get();
-
-					// we must check for BOTH entry.first (original name) and entry.second (renamed name)
-					// If this geometry performed the skeleton merge, renameTree altered the names in the source tree to
-					// entry.second. If another geometry did the merge, the names remain entry.first
-					if (origPartRoot && (findObject(origPartRoot, entry.first) || findObject(origPartRoot, entry.second))) {
-						inUse = true;
-					} else if (npcFaceGeom && (findObject(npcFaceGeom, entry.first) || findObject(npcFaceGeom, entry.second))) {
-						inUse = true;
-					}
-
-					if (inUse) {
-						auto findNode = this->head.nodeUseCount.find(entry.first);
-						if (findNode != this->head.nodeUseCount.end()) {
-							findNode->second += 1;
-							logger::debug("Incrementing use count by 1, it is now {}.", findNode->second);
-						} else {
-							this->head.nodeUseCount.insert(std::make_pair(entry.first, static_cast<uint8_t>(1)));
-							logger::debug("First use of bone, count 1.");
-						}
-						head.headParts.back().renamedBonesInUse.insert(entry.first);
-					}
-				}
+			if (!boneNode) {
+				logger::error("Bone {} not found after skeleton merge, geometry cannot be fully skinned.", boneName);
+				continue;
 			}
 
-			logger::debug("Done skinning part.");
+			geometry->GetGeometryRuntimeData().skinInstance->bones[boneIdx] = boneNode;
+			geometry->GetGeometryRuntimeData().skinInstance->boneWorldTransforms[boneIdx] = &boneNode->world;
 		}
+
+		geometry->GetGeometryRuntimeData().skinInstance->rootParent = headNode;
+
+		if (hasRenames) {
+			for (auto& entry : head.renameMap) {
+				bool inUse = false;
+
+				auto origPartRoot = this->head.headParts.back().origPartRootNode.get();
+				auto npcFaceGeom = this->head.npcFaceGeomNode.get();
+
+				// we must check for BOTH entry.first (original name) and entry.second (renamed name)
+				// If this geometry performed the skeleton merge, renameTree altered the names in the source tree to
+				// entry.second. If another geometry did the merge, the names remain entry.first
+				if (origPartRoot && (findObject(origPartRoot, entry.first) || findObject(origPartRoot, entry.second))) {
+					inUse = true;
+				} else if (npcFaceGeom && (findObject(npcFaceGeom, entry.first) || findObject(npcFaceGeom, entry.second))) {
+					inUse = true;
+				}
+
+				if (inUse) {
+					auto findNode = this->head.nodeUseCount.find(entry.first);
+					if (findNode != this->head.nodeUseCount.end()) {
+						findNode->second += 1;
+						logger::debug("Incrementing use count by 1, it is now {}.", findNode->second);
+					} else {
+						this->head.nodeUseCount.insert(std::make_pair(entry.first, static_cast<uint8_t>(1)));
+						logger::debug("First use of bone, count 1.");
+					}
+					head.headParts.back().renamedBonesInUse.insert(entry.first);
+				}
+			}
+		}
+
+		logger::debug("Done skinning part.");
 	}
+}

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -1120,9 +1120,6 @@ namespace hdt
 					isActive = true;
 					state = SkeletonState::e_ActiveIsPlayer;
 				}
-			} else if (instance()->m_maxPhysicsDistance > 0.f &&
-					   m_distanceFromCamera2 > instance()->m_maxPhysicsDistance * instance()->m_maxPhysicsDistance) {
-				state = SkeletonState::e_InactiveTooFar;
 			} else if (isInPlayerView()) {
 				isActive = true;
 				state = SkeletonState::e_ActiveNearPlayer;

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -132,6 +132,8 @@ namespace hdt
 
 			skeleton.attachArmor(e->armorModel, e->attachedNode);
 		} else {
+			if (!e->armorModel)
+				return RE::BSEventNotifyControl::kContinue;
 			skeleton.addArmor(e->armorModel);
 		}
 
@@ -826,8 +828,7 @@ namespace hdt
 
 	void ActorManager::Skeleton::addArmor(RE::NiNode* armorModel)
 	{
-		if (armorModel)
-			logBrokenNifOnce(armorModel->name.c_str(), armorModel);
+		logBrokenNifOnce(armorModel->name.c_str(), armorModel);
 
 		IDType id = armors.size() ? armors.back().id + 1 : 0;
 		auto prefix = armorPrefix(id);

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -394,6 +394,17 @@ namespace hdt
 		const auto cameraOrientation = cameraTransform.rotate * RE::NiPoint3(0., 1., 0.);  // The camera matrix is relative to the world.
 		m_cameraPositionDuringFrame = cameraPosition;
 
+		m_screenSizeNearPlaneScale = 0.f;
+		m_screenSizeThresholdScale = 0.f;
+		if (m_minScreenSizeFraction > 0.f) {
+			if (auto* cam = RE::Main::WorldRootCamera()) {
+				const auto& f = cam->GetRuntimeData2().viewFrustum;
+				const float screenH = f.fTop - f.fBottom; // near-plane total vertical span in world units
+				m_screenSizeNearPlaneScale = 4.f * f.fNear * f.fNear;
+				m_screenSizeThresholdScale = m_minScreenSizeFraction * m_minScreenSizeFraction * screenH * screenH;
+			}
+		}
+
 		for (auto& skel : m_skeletons)
 			skel.calculateDistanceAndOrientationDifferenceFromSource(cameraPosition, cameraOrientation);
 
@@ -1047,6 +1058,15 @@ namespace hdt
 		if (!skeleton3D || (camera && !camera->NodeInFrustum(skeleton3D)))
 			return false;
 
+		// Is the skeleton too small on screen?
+		// Ie, is the NPC's projected bounding sphere smaller than the allowed fraction of screen height?
+		// screenFraction < minFraction <=> 2r·fNear / (dist·screenH) < fr <=> 4r²·fNear² < fr²·dist²·screenH²
+		if (manager->m_screenSizeThresholdScale > 0.f) {
+			const float r = skeleton3D->worldBound.radius; // the radius of the bounding sphere of the skeleton in world units
+			if (manager->m_screenSizeNearPlaneScale * r * r < manager->m_screenSizeThresholdScale * m_distanceFromCamera2)
+				return false;
+		}
+
 		RE::NiPoint3 hitLocation;
 		auto* obstacle = Actor_CalculateLOS(owner, &manager->m_cameraPositionDuringFrame, &hitLocation, 6.28f);
 		return !obstacle;  // If obstacle, we hit something on the path
@@ -1100,6 +1120,9 @@ namespace hdt
 					isActive = true;
 					state = SkeletonState::e_ActiveIsPlayer;
 				}
+			} else if (instance()->m_maxPhysicsDistance > 0.f &&
+				m_distanceFromCamera2 > instance()->m_maxPhysicsDistance * instance()->m_maxPhysicsDistance) {
+				state = SkeletonState::e_InactiveTooFar;
 			} else if (isInPlayerView()) {
 				isActive = true;
 				state = SkeletonState::e_ActiveNearPlayer;

--- a/src/ActorManager.h
+++ b/src/ActorManager.h
@@ -236,12 +236,16 @@ namespace hdt
 		bool m_autoAdjustMaxSkeletons = true;  // Whether to dynamically change the maxActive skeletons to maintain min_fps
 		int m_maxActiveSkeletons = 20;         // The maximum active skeletons; hard limit
 		float m_minCullingDistance = 500;      // The distance from the camera under which we never cull the skeletons.
+		float m_maxPhysicsDistance = 0.f;      // 0 = disabled; hard cutoff — physics skipped beyond this distance (world units).
+		float m_minScreenSizeFraction = 0.f;   // 0 = disabled; the minimum fraction of screen height the skeleton should occupy to be active - [0,1].
 
 		// @brief Depending on this setting, we avoid to calculate the physics of the PC when it is in 1st person view.
 		bool m_disable1stPersonViewPhysics = false;
 
 	private:
 		RE::NiPoint3 m_cameraPositionDuringFrame;
+		float m_screenSizeNearPlaneScale = 0.f;   // precomputed per frame: 4·fNear²
+		float m_screenSizeThresholdScale = 0.f;  // precomputed per frame: minScreenSizeFraction²·screenH²
 		static RE::NiNode* getCameraNode();
 
 		void setSkeletonsActive(const bool updateMetrics = false);

--- a/src/ActorManager.h
+++ b/src/ActorManager.h
@@ -244,7 +244,7 @@ namespace hdt
 
 	private:
 		RE::NiPoint3 m_cameraPositionDuringFrame;
-		float m_screenSizeNearPlaneScale = 0.f;   // precomputed per frame: 4·fNear²
+		float m_screenSizeNearPlaneScale = 0.f;  // precomputed per frame: 4·fNear²
 		float m_screenSizeThresholdScale = 0.f;  // precomputed per frame: minScreenSizeFraction²·screenH²
 		static RE::NiNode* getCameraNode();
 

--- a/src/ActorManager.h
+++ b/src/ActorManager.h
@@ -243,8 +243,7 @@ namespace hdt
 
 	private:
 		RE::NiPoint3 m_cameraPositionDuringFrame;
-		float m_screenSizeNearPlaneScale = 0.f;  // precomputed per frame: 4·fNear²
-		float m_screenSizeThresholdScale = 0.f;  // precomputed per frame: minScreenSizeFraction²·screenH²
+		float m_screenSizeThresholdScale = 0.f;  // precomputed per frame: minScreenSizeFraction^2 * tan(fov/2)^2
 		static RE::NiNode* getCameraNode();
 
 		void setSkeletonsActive(const bool updateMetrics = false);

--- a/src/ActorManager.h
+++ b/src/ActorManager.h
@@ -236,7 +236,6 @@ namespace hdt
 		bool m_autoAdjustMaxSkeletons = true;  // Whether to dynamically change the maxActive skeletons to maintain min_fps
 		int m_maxActiveSkeletons = 20;         // The maximum active skeletons; hard limit
 		float m_minCullingDistance = 500;      // The distance from the camera under which we never cull the skeletons.
-		float m_maxPhysicsDistance = 0.f;      // 0 = disabled; hard cutoff — physics skipped beyond this distance (world units).
 		float m_minScreenSizeFraction = 0.f;   // 0 = disabled; the minimum fraction of screen height the skeleton should occupy to be active - [0,1].
 
 		// @brief Depending on this setting, we avoid to calculate the physics of the PC when it is in 1st person view.

--- a/src/ActorManager.h
+++ b/src/ActorManager.h
@@ -241,6 +241,8 @@ namespace hdt
 		// @brief Depending on this setting, we avoid to calculate the physics of the PC when it is in 1st person view.
 		bool m_disable1stPersonViewPhysics = false;
 
+		bool m_skipDeadActors = false;
+
 	private:
 		RE::NiPoint3 m_cameraPositionDuringFrame;
 		float m_screenSizeThresholdScale = 0.f;  // precomputed per frame: minScreenSizeFraction^2 * tan(fov/2)^2

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -148,18 +148,18 @@ namespace Hooks
 
 	void BSFaceGenNiNodeHooks::SkinAllGeometry(RE::BSFaceGenNiNode* const a_this, RE::NiNode* a_skeleton, bool a_unk)
 	{
-			const auto& children = a_this->GetChildren();
-			if (children.size() > 0) {
-				for (std::uint16_t i = 0; i < children.size(); i++) {
-					auto child = children[i];
-					if (child) {
-						auto triShape = child->AsTriShape();
-						if (triShape) {
-							SkinSingleGeometry__Hook(a_this, a_skeleton, triShape, a_unk);
-						}
+		const auto& children = a_this->GetChildren();
+		if (children.size() > 0) {
+			for (std::uint16_t i = 0; i < children.size(); i++) {
+				auto child = children[i];
+				if (child) {
+					auto triShape = child->AsTriShape();
+					if (triShape) {
+						SkinSingleGeometry__Hook(a_this, a_skeleton, triShape, a_unk);
 					}
 				}
 			}
+		}
 	}
 
 	void BSFaceGenNiNodeHooks::ApplyBoneLimitFix()

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -31,31 +31,34 @@ namespace Hooks
 	{
 		bool needRegularCall = true;
 		if (hdt::ActorManager::instance()->skeletonNeedsParts(a_skeleton)) {
-			RE::TESForm* form = RE::TESForm::LookupByID(a_skeleton->GetUserData()->formID);
-			RE::Actor* actor = skyrim_cast<RE::Actor*>(form);
-			if (actor) {
-				RE::TESNPC* actorBase = skyrim_cast<RE::TESNPC*>(actor->data.objectReference);
-				uint32_t numHeadParts = 0;
-				RE::BGSHeadPart** Headparts = nullptr;
+			auto* userData = a_skeleton->GetUserData();
+			if (userData) {
+				RE::TESForm* form = RE::TESForm::LookupByID(userData->formID);
+				RE::Actor* actor = skyrim_cast<RE::Actor*>(form);
+				if (actor) {
+					RE::TESNPC* actorBase = skyrim_cast<RE::TESNPC*>(actor->data.objectReference);
+					uint32_t numHeadParts = 0;
+					RE::BGSHeadPart** Headparts = nullptr;
 
-				if (actorBase->HasOverlays()) {
-					numHeadParts = actorBase->GetNumBaseOverlays();
-					Headparts = actorBase->GetBaseOverlays();
-				} else {
-					numHeadParts = actorBase->numHeadParts;
-					Headparts = actorBase->headParts;
-				}
+					if (actorBase->HasOverlays()) {
+						numHeadParts = actorBase->GetNumBaseOverlays();
+						Headparts = actorBase->GetBaseOverlays();
+					} else {
+						numHeadParts = actorBase->numHeadParts;
+						Headparts = actorBase->headParts;
+					}
 
-				if (Headparts) {
-					for (uint32_t i = 0; i < numHeadParts; i++) {
-						if (Headparts[i]) {
-							ProcessHeadPart(a_this, Headparts[i], a_skeleton, a_unk);
+					if (Headparts) {
+						for (uint32_t i = 0; i < numHeadParts; i++) {
+							if (Headparts[i]) {
+								ProcessHeadPart(a_this, Headparts[i], a_skeleton, a_unk);
+							}
 						}
 					}
-				}
 
-				if (a_skeleton->GetUserData() && a_skeleton->GetUserData()->formID == 0x14) {
-					needRegularCall = false;
+					if (userData->formID == 0x14) {
+						needRegularCall = false;
+					}
 				}
 			}
 		}

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -70,6 +70,9 @@ namespace Hooks
 
 	void BSFaceGenNiNodeHooks::SkinSingleGeometry__Hook(RE::BSFaceGenNiNode* const a_this, RE::NiNode* a_skeleton, RE::BSGeometry* a_triShape, [[maybe_unused]] bool a_unk)
 	{
+		if (!a_skeleton)
+			return;
+
 		//
 		const char* name = "";
 		uint32_t formId = 0x0;
@@ -145,7 +148,6 @@ namespace Hooks
 
 	void BSFaceGenNiNodeHooks::SkinAllGeometry(RE::BSFaceGenNiNode* const a_this, RE::NiNode* a_skeleton, bool a_unk)
 	{
-		if (a_skeleton) {
 			const auto& children = a_this->GetChildren();
 			if (children.size() > 0) {
 				for (std::uint16_t i = 0; i < children.size(); i++) {
@@ -158,7 +160,6 @@ namespace Hooks
 					}
 				}
 			}
-		}
 	}
 
 	void BSFaceGenNiNodeHooks::ApplyBoneLimitFix()

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -208,8 +208,8 @@ namespace hdt
 		LOG("smp.autoAdjustMaxSkeletons", a->m_autoAdjustMaxSkeletons);
 		LOG("smp.sampleSize", w->m_sampleSize);
 		LOG("smp.disable1stPersonViewPhysics", a->m_disable1stPersonViewPhysics);
-		LOG("smp.maxPhysicsDistance",          a->m_maxPhysicsDistance);
-		LOG("smp.minScreenSizeFraction",       a->m_minScreenSizeFraction);
+		LOG("smp.maxPhysicsDistance", a->m_maxPhysicsDistance);
+		LOG("smp.minScreenSizeFraction", a->m_minScreenSizeFraction);
 #undef LOG
 	}
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -108,6 +108,8 @@ namespace hdt
 					ActorManager::instance()->m_disable1stPersonViewPhysics = reader.readBool();
 				} else if (reader.GetLocalName() == "minScreenSizeFraction") {
 					ActorManager::instance()->m_minScreenSizeFraction = std::clamp(reader.readFloat(), 0.f, 1.f);
+				} else if (reader.GetLocalName() == "skipDeadActors") {
+					ActorManager::instance()->m_skipDeadActors = reader.readBool();
 				} else {
 					logger::warn("Unknown config : {}", reader.GetLocalName());
 					reader.skipCurrentElement();
@@ -207,6 +209,7 @@ namespace hdt
 		LOG("smp.sampleSize", w->m_sampleSize);
 		LOG("smp.disable1stPersonViewPhysics", a->m_disable1stPersonViewPhysics);
 		LOG("smp.minScreenSizeFraction", a->m_minScreenSizeFraction);
+		LOG("smp.skipDeadActors", a->m_skipDeadActors);
 #undef LOG
 	}
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -106,8 +106,6 @@ namespace hdt
 					SkyrimPhysicsWorld::get()->m_sampleSize = std::max(reader.readInt(), 1);
 				} else if (reader.GetLocalName() == "disable1stPersonViewPhysics") {
 					ActorManager::instance()->m_disable1stPersonViewPhysics = reader.readBool();
-				} else if (reader.GetLocalName() == "maxPhysicsDistance") {
-					ActorManager::instance()->m_maxPhysicsDistance = std::max(reader.readFloat(), 0.f);
 				} else if (reader.GetLocalName() == "minScreenSizeFraction") {
 					ActorManager::instance()->m_minScreenSizeFraction = std::clamp(reader.readFloat(), 0.f, 1.f);
 				} else {
@@ -208,7 +206,6 @@ namespace hdt
 		LOG("smp.autoAdjustMaxSkeletons", a->m_autoAdjustMaxSkeletons);
 		LOG("smp.sampleSize", w->m_sampleSize);
 		LOG("smp.disable1stPersonViewPhysics", a->m_disable1stPersonViewPhysics);
-		LOG("smp.maxPhysicsDistance", a->m_maxPhysicsDistance);
 		LOG("smp.minScreenSizeFraction", a->m_minScreenSizeFraction);
 #undef LOG
 	}

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -106,6 +106,10 @@ namespace hdt
 					SkyrimPhysicsWorld::get()->m_sampleSize = std::max(reader.readInt(), 1);
 				} else if (reader.GetLocalName() == "disable1stPersonViewPhysics") {
 					ActorManager::instance()->m_disable1stPersonViewPhysics = reader.readBool();
+				} else if (reader.GetLocalName() == "maxPhysicsDistance") {
+					ActorManager::instance()->m_maxPhysicsDistance = std::max(reader.readFloat(), 0.f);
+				} else if (reader.GetLocalName() == "minScreenSizeFraction") {
+					ActorManager::instance()->m_minScreenSizeFraction = std::clamp(reader.readFloat(), 0.f, 1.f);
 				} else {
 					logger::warn("Unknown config : {}", reader.GetLocalName());
 					reader.skipCurrentElement();
@@ -204,6 +208,8 @@ namespace hdt
 		LOG("smp.autoAdjustMaxSkeletons", a->m_autoAdjustMaxSkeletons);
 		LOG("smp.sampleSize", w->m_sampleSize);
 		LOG("smp.disable1stPersonViewPhysics", a->m_disable1stPersonViewPhysics);
+		LOG("smp.maxPhysicsDistance",          a->m_maxPhysicsDistance);
+		LOG("smp.minScreenSizeFraction",       a->m_minScreenSizeFraction);
 #undef LOG
 	}
 }

--- a/src/hdtForceUpdateList.cpp
+++ b/src/hdtForceUpdateList.cpp
@@ -1,7 +1,6 @@
 #include "hdtForceUpdateList.h"
 
-static std::unordered_set<RE::BSFixedString, RE::BSCRC32_<RE::BSFixedString>> nodes = 
-{
+static std::unordered_set<RE::BSFixedString, RE::BSCRC32_<RE::BSFixedString>> nodes = {
 	"WeaponAxe",
 	"WeaponMace",
 	"WeaponSword",
@@ -18,8 +17,7 @@ static std::unordered_set<RE::BSFixedString, RE::BSCRC32_<RE::BSFixedString>> no
 	"WeaponStaffLeft"
 };
 
-static std::unordered_set<RE::BSFixedString, RE::BSCRC32_<RE::BSFixedString>> nodes_mov = 
-{
+static std::unordered_set<RE::BSFixedString, RE::BSCRC32_<RE::BSFixedString>> nodes_mov = {
 	"MOV WeaponAxeDefault",
 	"MOV WeaponAxeLeftDefault",
 	"MOV WeaponAxeReverse",
@@ -74,25 +72,22 @@ namespace hdt
 {
 	int GetForceUpdateTypeFromName(const RE::BSFixedString& a_node_name)
 	{
-	    const std::string node_name = a_node_name.c_str();
+		const std::string node_name = a_node_name.c_str();
 
-	    // MOV-prefixed nodes → type 2
-	    if (node_name.rfind("MOV", 0) == 0) 
-		{
-	        if (nodes_mov.find(node_name) != nodes_mov.end()) 
-			{
-	            return 2;
-	        }
+		// MOV-prefixed nodes → type 2
+		if (node_name.rfind("MOV", 0) == 0) {
+			if (nodes_mov.find(node_name) != nodes_mov.end()) {
+				return 2;
+			}
 
-	        return 0;
-	    }
+			return 0;
+		}
 
-	    // All other nodes → type 1
-	    if (nodes.find(node_name) != nodes.end()) 
-		{
-	        return 1;
-	    }
+		// All other nodes → type 1
+		if (nodes.find(node_name) != nodes.end()) {
+			return 1;
+		}
 
-	    return 0;
+		return 0;
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added minScreenSizeFraction setting to skip physics for non-player skeletons when projected on-screen size is below a configured fraction (0 = disabled); available across presets and validated by schema.

* **Bug Fixes**
  * Improved null-safety and early-return handling in armor, skeleton, and geometry processing to reduce crashes and hangs.

* **Chores**
  * Project version bumped to 3.0.4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaymareOn/hdtSMP64/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->