### PR TITLE
perf: don't use setlocale; use C++17 equivalents

### DIFF
--- a/src/XmlReader.cpp
+++ b/src/XmlReader.cpp
@@ -1,4 +1,5 @@
 #include "XmlReader.h"
+#include <charconv>
 
 namespace hdt
 {
@@ -10,17 +11,19 @@ namespace hdt
 		if (start_pos != std::string::npos)
 			s.replace(start_pos, 1, ".");
 
-		errno = 0;  // Reinitializing the error global variable (thread-safe)
-		float ret = strtof(s.c_str(), nullptr);
-		if (errno != 0)  // Checking if there has been an error
+		float ret{};
+		const char* begin = s.data();
+		const char* end = begin + s.size();
+		auto [ptr, ec] = std::from_chars(begin, end, ret);
+		if (ec != std::errc() || ptr != end)
 			throw std::string("not a float value");
 		return ret;
 	}
 
 	static inline int convertInt(const std::string& str)
 	{
-		auto begin = str.c_str();
-		char* end;
+		const char* begin = str.data();
+		const char* end = begin + str.size();
 
 		int radix = 10;
 		if (!str.compare(0, 2, "0x")) {
@@ -31,8 +34,9 @@ namespace hdt
 			radix = 8;
 		}
 
-		int ret = strtol(str.c_str(), &end, radix);
-		if (end != str.c_str() + str.length())
+		int ret{};
+		auto [ptr, ec] = std::from_chars(begin, end, ret, radix);
+		if (ec != std::errc() || ptr != end)
 			throw std::string("not a int value");
 		return ret;
 	}

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -146,13 +146,6 @@ namespace hdt
 			return;
 		}
 
-		// Store original locale
-		char saved_locale[32];
-		strcpy_s(saved_locale, std::setlocale(LC_NUMERIC, nullptr));
-
-		// Set locale to en_US
-		std::setlocale(LC_NUMERIC, "en_US");
-
 		XMLReader reader((uint8_t*)bytes.data(), bytes.size());
 
 		while (reader.Inspect()) {
@@ -165,9 +158,6 @@ namespace hdt
 				}
 			}
 		}
-
-		// Restore original locale
-		std::setlocale(LC_NUMERIC, saved_locale);
 	}
 
 	void logConfig()

--- a/src/hdtDefaultBBP.cpp
+++ b/src/hdtDefaultBBP.cpp
@@ -36,13 +36,6 @@ namespace hdt
 		if (loaded.empty())
 			return;
 
-		// Store original locale
-		char saved_locale[32];
-		strcpy_s(saved_locale, std::setlocale(LC_NUMERIC, nullptr));
-
-		// Set locale to en_US
-		std::setlocale(LC_NUMERIC, "en_US");
-
 		XMLReader reader((uint8_t*)loaded.data(), loaded.size());
 
 		reader.nextStartElement();
@@ -93,8 +86,6 @@ namespace hdt
 			}
 		}
 
-		// Restore original locale
-		std::setlocale(LC_NUMERIC, saved_locale);
 	}
 
 	DefaultBBP::PhysicsFile_t DefaultBBP::scanDefaultBBP(RE::NiNode* armor)

--- a/src/hdtDefaultBBP.cpp
+++ b/src/hdtDefaultBBP.cpp
@@ -85,7 +85,6 @@ namespace hdt
 				break;
 			}
 		}
-
 	}
 
 	DefaultBBP::PhysicsFile_t DefaultBBP::scanDefaultBBP(RE::NiNode* armor)

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -228,13 +228,6 @@ namespace hdt
 		m_mesh = RE::make_smart<SkyrimSystem>(skeleton);
 		m_boneIndex.clear();
 
-		// Store original locale
-		char saved_locale[32];
-		strcpy_s(saved_locale, std::setlocale(LC_NUMERIC, nullptr));
-
-		// Set locale to en_US
-		std::setlocale(LC_NUMERIC, "en_US");
-
 		// This forces the skeleton into a neutral reference pose, which avoids building invalid shape data
 		// We pull the references directly from havok for the exact same reference data the engine uses
 		std::vector<std::pair<RE::NiAVObject*, RE::NiTransform>> savedPoses;
@@ -360,9 +353,6 @@ namespace hdt
 		}
 
 		m_deferredBuilds.clear();
-
-		// Restore original locale
-		std::setlocale(LC_NUMERIC, saved_locale);
 
 		if (m_reader->GetErrorCode() != Xml::ErrorCode::None) {
 			logger::error("xml parse error - {}", m_reader->GetErrorMessage());


### PR DESCRIPTION
as dumb as it is, setlocale even once pollutes CRT functions making them a LOT slower (even if you revert it back)
Do note that this is NOT tested on 2022 visual studio/v143 tools, but on 2026/v145 instead.
Loading screen bench, time spent in _stricmp_l before: 4950ms; after: 30ms


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric parsing in configuration files with stricter validation.
  * Enhanced decimal number handling during XML parsing.

* **Refactor**
  * Streamlined locale handling during configuration loading by removing unnecessary temporary locale switches.
  * Modernized numeric conversion methods for better reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaymareOn/hdtSMP64/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->