### PR TITLE
fix: This is always 0, reduce allocation spam

### DIFF
--- a/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
@@ -263,9 +263,14 @@ namespace hdt
 
 		int operator()()
 		{
-			std::vector<std::pair<ColliderTree*, ColliderTree*>> pairs;
-			pairs.reserve(this->c0->colliders.size() + this->c1->colliders.size());
+			thread_local std::vector<std::pair<ColliderTree*, ColliderTree*>> pairs;
+			pairs.clear();
+
+			if (pairs.capacity() < 256)
+				pairs.reserve(256);
+
 			this->c0->checkCollisionL(this->c1, pairs);
+
 			if (pairs.empty())
 				return 0;
 
@@ -326,7 +331,7 @@ namespace hdt
 
 			if (pairs.size() >= 32)
 				// isolate: thread parked here waiting for inner work must not steal an outer
-				// processCollision task — that would alias thread_local MergeBuffer/listA/listB.
+				// Note: If this is ever changed from isolate, you'll need to review tons of thread_local usage!
 				tbb::this_task_arena::isolate([&] { tbb::parallel_for_each(pairs.begin(), pairs.end(), func); });
 			else
 				for (auto& i : pairs) func(i);


### PR DESCRIPTION
Problem with the original code is `this->c0->colliders.size() + this->c1->colliders.size()` is always `0` since after remapColliders, tree colliders vectors are emptied. So we were just reserving 0, and then constantly thrashing the vector. 

Instead, it just uses a thread_local here since `tbb::this_task_arena::isolate` makes it safe and we don't have to constantly predict what the vector should be resized to. 

This is just a very minor performance gain since realistically this function is only going to get called ~100 times on a normal smp heavy game. 

Made a more concise note about the isolate usage here too since changing that will fundamentally break everything in hdtSkinnedMeshAlgorithm 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance efficiency of collision detection operations.
  
* **Documentation**
  * Updated guidance on thread-safety best practices for developers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaymareOn/hdtSMP64/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->