### PR TITLE
fix: Raise the mid limit a bit

### DIFF
--- a/src/hdtSkinnedMesh/hdtCollider.h
+++ b/src/hdtSkinnedMesh/hdtCollider.h
@@ -5,7 +5,7 @@
 
 namespace hdt
 {
-	static const int MaxCollisionPairs = 4024;
+	static const int MaxCollisionPairs = 6024;
 
 	struct alignas(16) Collider
 	{


### PR DESCRIPTION
Some armors are failing this instantly. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the maximum collision capacity from 4,024 to 6,024 pairs to support more complex interaction scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaymareOn/hdtSMP64/pull/340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->