### PR TITLE
chore: fix MSVC toolset in triplet files to ensure dependency builds consistency remotely and locally

### DIFF
--- a/cmake/triplets/_pin_toolset.cmake
+++ b/cmake/triplets/_pin_toolset.cmake
@@ -1,0 +1,16 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+# Pin the MSVC toolset that vcpkg uses to build dependencies.
+#
+# vcpkg selects its own compiler for dependencies independently of the CMake preset
+# toolset, and by default picks the NEWEST installed Visual Studio. On a machine with
+# VS2026 (MSVC 14.50) alongside VS2022 (14.44), that means the dependencies (Bullet,
+# TBB, fmt, ...) get built with 14.50 while the plugin and the CI build use 14.44 --
+# a real codegen mismatch that destabilised the physics. Pinning to 14.44 keeps the
+# dependency compiler aligned with the plugin and with CI on every machine.
+#
+# Included by every overlay triplet (noavx/avx/avx2/avx512) so all four variants
+# build their dependencies with the same compiler.
+set(VCPKG_PLATFORM_TOOLSET_VERSION "14.44")

--- a/cmake/triplets/_pin_toolset.cmake
+++ b/cmake/triplets/_pin_toolset.cmake
@@ -4,13 +4,12 @@ set(VCPKG_LIBRARY_LINKAGE static)
 
 # Pin the MSVC toolset that vcpkg uses to build dependencies.
 #
-# vcpkg selects its own compiler for dependencies independently of the CMake preset
-# toolset, and by default picks the NEWEST installed Visual Studio. On a machine with
-# VS2026 (MSVC 14.50) alongside VS2022 (14.44), that means the dependencies (Bullet,
-# TBB, fmt, ...) get built with 14.50 while the plugin and the CI build use 14.44 --
-# a real codegen mismatch that destabilised the physics. Pinning to 14.44 keeps the
-# dependency compiler aligned with the plugin and with CI on every machine.
+# vcpkg selects its own compiler for dependencies independently of the CMake preset toolset, and by default picks the
+# NEWEST installed Visual Studio. On a machine with VS2026 (MSVC 14.50) alongside VS2022 (14.44), that means the
+# dependencies (Bullet, TBB, fmt, ...) get built with 14.50 while the plugin and the CI build use 14.44 -- a real
+# codegen mismatch that destabilised the physics. Pinning to 14.44 keeps the dependency compiler aligned with the plugin
+# and with CI on every machine.
 #
-# Included by every overlay triplet (noavx/avx/avx2/avx512) so all four variants
-# build their dependencies with the same compiler.
+# Included by every overlay triplet (noavx/avx/avx2/avx512) so all four variants build their dependencies with the same
+# compiler.
 set(VCPKG_PLATFORM_TOOLSET_VERSION "14.44")

--- a/cmake/triplets/_pin_toolset.cmake
+++ b/cmake/triplets/_pin_toolset.cmake
@@ -12,4 +12,5 @@ set(VCPKG_LIBRARY_LINKAGE static)
 #
 # Included by every overlay triplet (noavx/avx/avx2/avx512) so all four variants build their dependencies with the same
 # compiler.
+set(VCPKG_PLATFORM_TOOLSET v143)
 set(VCPKG_PLATFORM_TOOLSET_VERSION "14.44")

--- a/cmake/triplets/x64-windows-static-md-avx.cmake
+++ b/cmake/triplets/x64-windows-static-md-avx.cmake
@@ -1,6 +1,4 @@
-set(VCPKG_TARGET_ARCHITECTURE x64)
-set(VCPKG_CRT_LINKAGE dynamic)
-set(VCPKG_LIBRARY_LINKAGE static)
+include("${CMAKE_CURRENT_LIST_DIR}/_pin_toolset.cmake")
 
 string(APPEND VCPKG_CXX_FLAGS " /arch:AVX")
 string(APPEND VCPKG_C_FLAGS " /arch:AVX")

--- a/cmake/triplets/x64-windows-static-md-avx2.cmake
+++ b/cmake/triplets/x64-windows-static-md-avx2.cmake
@@ -1,6 +1,4 @@
-set(VCPKG_TARGET_ARCHITECTURE x64)
-set(VCPKG_CRT_LINKAGE dynamic)
-set(VCPKG_LIBRARY_LINKAGE static)
+include("${CMAKE_CURRENT_LIST_DIR}/_pin_toolset.cmake")
 
 string(APPEND VCPKG_CXX_FLAGS " /arch:AVX2")
 string(APPEND VCPKG_C_FLAGS " /arch:AVX2")

--- a/cmake/triplets/x64-windows-static-md-avx512.cmake
+++ b/cmake/triplets/x64-windows-static-md-avx512.cmake
@@ -1,6 +1,4 @@
-set(VCPKG_TARGET_ARCHITECTURE x64)
-set(VCPKG_CRT_LINKAGE dynamic)
-set(VCPKG_LIBRARY_LINKAGE static)
+include("${CMAKE_CURRENT_LIST_DIR}/_pin_toolset.cmake")
 
 string(APPEND VCPKG_CXX_FLAGS " /arch:AVX512")
 string(APPEND VCPKG_C_FLAGS " /arch:AVX512")

--- a/cmake/triplets/x64-windows-static-md.cmake
+++ b/cmake/triplets/x64-windows-static-md.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/_pin_toolset.cmake")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated Windows static-library build configurations into a shared toolset include to ensure consistent architecture and linkage across build variants.
  * Pinned the Visual Studio/MSVC toolset used for dependency builds to avoid mismatches with the project preset.
  * Preserved existing CPU-specific compiler flags (AVX/AVX2/AVX512) for optimized builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->