### PR TITLE
chore: better MSVC warnings: /W4 + targeted suppressions, external-header isolation, Debug /analyze

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,8 +140,19 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 				"/Zi" # Debug Information Format
 				"/permissive-" # Standards conformance
 				"/Zc:preprocessor" # Enable preprocessor conformance mode
+<<<<<<< Updated upstream
 				"/bigobj" # Increase Number of Sections in .obj file
 				"/WX" # Warnings as errors
+=======
+				"/bigobj"        # Increase Number of Sections in .obj file
+				"/W4"            # Elevated warnings: unreachable code (C4702), unused vars (C4189), etc.
+				"/wd4100"        # Suppress: unreferenced formal parameter (pervasive in SKSE callbacks)
+				"/wd4201"        # Suppress: nameless struct/union (used throughout CommonLibSSE)
+				"/WX"            # Warnings as errors
+				"/external:anglebrackets" # Treat angle-bracket includes as external
+				"/external:W0"   # No warnings from external headers (vcpkg, system)
+				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->"  # Static analysis in Debug only; skip external headers
+>>>>>>> Stashed changes
 				"$<$<CONFIG:DEBUG>:>"
 				"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/Zc:inline;/JMC-;/Ob3>")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,7 +148,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 				"/external:anglebrackets" # Treat angle-bracket includes as external
 				"/external:W0"   # No warnings from external headers (vcpkg, system)
 				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->"  # Static analysis in Debug only; skip external headers
-				"$<$<CONFIG:DEBUG>:>"
 				"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/Zc:inline;/JMC-;/Ob3>")
 
 	target_link_options("${PROJECT_NAME}" PRIVATE "$<$<CONFIG:DEBUG>:/INCREMENTAL;/OPT:NOREF;/OPT:NOICF>"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,14 +140,14 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 				"/Zi" # Debug Information Format
 				"/permissive-" # Standards conformance
 				"/Zc:preprocessor" # Enable preprocessor conformance mode
-				"/bigobj"        # Increase Number of Sections in .obj file
-				"/W4"            # Elevated warnings: unreachable code (C4702), unused vars (C4189), etc.
-				"/wd4100"        # Suppress: unreferenced formal parameter (pervasive in SKSE callbacks)
-				"/wd4201"        # Suppress: nameless struct/union (used throughout CommonLibSSE)
-				"/WX"            # Warnings as errors
+				"/bigobj" # Increase Number of Sections in .obj file
+				"/W4" # Elevated warnings: unreachable code (C4702), unused vars (C4189), etc.
+				"/wd4100" # Suppress: unreferenced formal parameter (pervasive in SKSE callbacks)
+				"/wd4201" # Suppress: nameless struct/union (used throughout CommonLibSSE)
+				"/WX" # Warnings as errors
 				"/external:anglebrackets" # Treat angle-bracket includes as external
-				"/external:W0"   # No warnings from external headers (vcpkg, system)
-				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->"  # Static analysis in Debug only; skip external headers
+				"/external:W0" # No warnings from external headers (vcpkg, system)
+				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->" # Static analysis in Debug only; skip external headers
 				"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/Zc:inline;/JMC-;/Ob3>")
 
 	target_link_options("${PROJECT_NAME}" PRIVATE "$<$<CONFIG:DEBUG>:/INCREMENTAL;/OPT:NOREF;/OPT:NOICF>"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,10 +140,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 				"/Zi" # Debug Information Format
 				"/permissive-" # Standards conformance
 				"/Zc:preprocessor" # Enable preprocessor conformance mode
-<<<<<<< Updated upstream
-				"/bigobj" # Increase Number of Sections in .obj file
-				"/WX" # Warnings as errors
-=======
 				"/bigobj"        # Increase Number of Sections in .obj file
 				"/W4"            # Elevated warnings: unreachable code (C4702), unused vars (C4189), etc.
 				"/wd4100"        # Suppress: unreferenced formal parameter (pervasive in SKSE callbacks)
@@ -152,7 +148,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 				"/external:anglebrackets" # Treat angle-bracket includes as external
 				"/external:W0"   # No warnings from external headers (vcpkg, system)
 				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->"  # Static analysis in Debug only; skip external headers
->>>>>>> Stashed changes
 				"$<$<CONFIG:DEBUG>:>"
 				"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/Zc:inline;/JMC-;/Ob3>")
 


### PR DESCRIPTION
## What

Tightens the MSVC compiler-warning configuration in `src/CMakeLists.txt`:

- **`/W4`** elevated warning level, kept fatal via **`/WX`** (warnings as errors)
- **Targeted suppressions** for warnings that are pervasive and not actionable here:
  - `/wd4100` — unreferenced formal parameter (SKSE callback signatures)
  - `/wd4201` — nameless struct/union (used throughout CommonLibSSE)
- **External-header isolation** so third-party code doesn't trip our warnings:
  - `/external:anglebrackets` + `/external:W0`
- **Debug-only static analysis**: `/analyze` (with `/analyze:external-` to skip external headers)

## Files
- `src/CMakeLists.txt` (+8 / −3)

## Notes
- Not yet build-verified on github. Because `/WX` makes any new `/W4` warning fatal, a configure + compile pass is worth doing before merge to confirm the existing code is clean under the elevated level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compiler configuration to enhance code quality checks and error detection during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->