### PR TITLE
perf: reinstate the compiler and linker perf flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,10 @@ on:
     branches:
       - master
       - dev
-      - betterperfflags2
+      # Publish any branch under ci/ (e.g. ci/betterperfflags) to build all AVX variants
+      # and a prerelease, without editing this file. The "/" lives only in the branch
+      # name; the versioning step below sanitizes it to "-" in the version string.
+      - "ci/**"
     paths:
       - "**.cpp"
       - "**.h"
@@ -25,7 +28,7 @@ on:
     branches:
       - master
       - dev
-      - betterperfflags2
+      - "ci/**"
     paths:
       - "**.cpp"
       - "**.h"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
       - dev
-      - hardenrelease
+      - betterperfflags2
     paths:
       - "**.cpp"
       - "**.h"
@@ -25,8 +25,7 @@ on:
     branches:
       - master
       - dev
-      - hardenrelease
-      - copilot/update-dev-build-versioning
+      - betterperfflags2
     paths:
       - "**.cpp"
       - "**.h"
@@ -150,8 +149,10 @@ jobs:
           path: |
             out/build/${{ matrix.preset }}/vcpkg_installed
             ~\AppData\Local\vcpkg\archives
-          # Adding the preset name to the key ensures the presets don't overwrite each other's cache
-          key: vcpkg-${{ runner.os }}-${{ github.ref_name }}-${{ matrix.preset }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/ports/**') }}
+          # Adding the preset name to the key ensures the presets don't overwrite each other's cache.
+          # cmake/triplets/** is hashed so that changing dependency compile/link flags (e.g. /GL /LTCG /fp:fast in
+          # _perf_flags.cmake) invalidates the cache and forces vcpkg to rebuild the dependencies with the new flags.
+          key: vcpkg-${{ runner.os }}-${{ github.ref_name }}-${{ matrix.preset }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/ports/**', 'cmake/triplets/**') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ github.ref_name }}-${{ matrix.preset }}-
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -194,6 +194,32 @@
       ],
       "name": "vs2022-windows-avx512",
       "toolset": "v143"
+    },
+    {
+      "binaryDir": "${sourceDir}/out/build/pgo-avx2",
+      "cacheVariables": {
+        "FSMP_PGO": {
+          "type": "STRING",
+          "value": "INSTRUMENT"
+        }
+      },
+      "inherits": [
+        "vs2022-windows-avx2"
+      ],
+      "name": "vs2022-windows-avx2-pgo-instrument"
+    },
+    {
+      "binaryDir": "${sourceDir}/out/build/pgo-avx2",
+      "cacheVariables": {
+        "FSMP_PGO": {
+          "type": "STRING",
+          "value": "OPTIMIZE"
+        }
+      },
+      "inherits": [
+        "vs2022-windows-avx2"
+      ],
+      "name": "vs2022-windows-avx2-pgo-optimize"
     }
   ],
   "buildPresets": [
@@ -207,6 +233,18 @@
       "name": "avx2-release",
       "displayName": "Release",
       "configurePreset": "vs2022-windows-avx2",
+      "configuration": "Release"
+    },
+    {
+      "name": "avx2-pgo-instrument",
+      "displayName": "Release (PGO instrument)",
+      "configurePreset": "vs2022-windows-avx2-pgo-instrument",
+      "configuration": "Release"
+    },
+    {
+      "name": "avx2-pgo-optimize",
+      "displayName": "Release (PGO optimize)",
+      "configurePreset": "vs2022-windows-avx2-pgo-optimize",
       "configuration": "Release"
     }
   ],

--- a/cmake/triplets/_perf_flags.cmake
+++ b/cmake/triplets/_perf_flags.cmake
@@ -1,0 +1,19 @@
+# Performance flags carried into every vcpkg dependency (Bullet, TBB, fmt, detours, ...), Release config only.
+#
+# Bullet is statically linked into hdtSMP64.dll and runs the heavy collision/constraint math every frame, so optimising
+# it matters as much as optimising our own code -- but the only way to reach it is through the triplet. These mirror the
+# flags the plugin sets on itself in src/CMakeLists.txt:
+#   /Ob3     most aggressive inline expansion
+#   /Gw      put each global/static in its own COMDAT so /OPT:REF and LTCG can strip/place them
+#   /fp:fast let the compiler emit FMA and reassociate FP math (large for FP-heavy physics; behavioural -- validated)
+#   /GL      whole-program optimization; produces IL object files that the plugin's /LTCG link folds in, extending
+#            cross-module optimization into Bullet itself
+#
+# Release only: Debug dependency builds stay un-LTCG'd and fully debuggable. /GL + /LTCG require the dependency compiler
+# and the plugin compiler to be the *same* MSVC toolset version -- that alignment is what _pin_toolset.cmake guarantees.
+string(APPEND VCPKG_CXX_FLAGS_RELEASE " /Ob3 /Gw /fp:fast /GL")
+string(APPEND VCPKG_C_FLAGS_RELEASE " /Ob3 /Gw /fp:fast /GL")
+
+# /GL (IL) object files require /LTCG at link time for any dependency that produces a DLL/EXE. Static libraries store the
+# IL and are code-generated when the plugin links them with /LTCG, so this mainly future-proofs DLL-producing deps.
+string(APPEND VCPKG_LINKER_FLAGS_RELEASE " /LTCG")

--- a/cmake/triplets/_perf_flags.cmake
+++ b/cmake/triplets/_perf_flags.cmake
@@ -2,18 +2,16 @@
 #
 # Bullet is statically linked into hdtSMP64.dll and runs the heavy collision/constraint math every frame, so optimising
 # it matters as much as optimising our own code -- but the only way to reach it is through the triplet. These mirror the
-# flags the plugin sets on itself in src/CMakeLists.txt:
-#   /Ob3     most aggressive inline expansion
-#   /Gw      put each global/static in its own COMDAT so /OPT:REF and LTCG can strip/place them
-#   /fp:fast let the compiler emit FMA and reassociate FP math (large for FP-heavy physics; behavioural -- validated)
-#   /GL      whole-program optimization; produces IL object files that the plugin's /LTCG link folds in, extending
-#            cross-module optimization into Bullet itself
+# flags the plugin sets on itself in src/CMakeLists.txt: /Ob3     most aggressive inline expansion /Gw      put each
+# global/static in its own COMDAT so /OPT:REF and LTCG can strip/place them /fp:fast let the compiler emit FMA and
+# reassociate FP math (large for FP-heavy physics; behavioural -- validated) /GL      whole-program optimization;
+# produces IL object files that the plugin's /LTCG link folds in, extending cross-module optimization into Bullet itself
 #
 # Release only: Debug dependency builds stay un-LTCG'd and fully debuggable. /GL + /LTCG require the dependency compiler
 # and the plugin compiler to be the *same* MSVC toolset version -- that alignment is what _pin_toolset.cmake guarantees.
 string(APPEND VCPKG_CXX_FLAGS_RELEASE " /Ob3 /Gw /fp:fast /GL")
 string(APPEND VCPKG_C_FLAGS_RELEASE " /Ob3 /Gw /fp:fast /GL")
 
-# /GL (IL) object files require /LTCG at link time for any dependency that produces a DLL/EXE. Static libraries store the
-# IL and are code-generated when the plugin links them with /LTCG, so this mainly future-proofs DLL-producing deps.
+# /GL (IL) object files require /LTCG at link time for any dependency that produces a DLL/EXE. Static libraries store
+# the IL and are code-generated when the plugin links them with /LTCG, so this mainly future-proofs DLL-producing deps.
 string(APPEND VCPKG_LINKER_FLAGS_RELEASE " /LTCG")

--- a/cmake/triplets/x64-windows-static-md-avx.cmake
+++ b/cmake/triplets/x64-windows-static-md-avx.cmake
@@ -1,4 +1,5 @@
 include("${CMAKE_CURRENT_LIST_DIR}/_pin_toolset.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/_perf_flags.cmake")
 
 string(APPEND VCPKG_CXX_FLAGS " /arch:AVX")
 string(APPEND VCPKG_C_FLAGS " /arch:AVX")

--- a/cmake/triplets/x64-windows-static-md-avx2.cmake
+++ b/cmake/triplets/x64-windows-static-md-avx2.cmake
@@ -1,4 +1,5 @@
 include("${CMAKE_CURRENT_LIST_DIR}/_pin_toolset.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/_perf_flags.cmake")
 
 string(APPEND VCPKG_CXX_FLAGS " /arch:AVX2")
 string(APPEND VCPKG_C_FLAGS " /arch:AVX2")

--- a/cmake/triplets/x64-windows-static-md-avx512.cmake
+++ b/cmake/triplets/x64-windows-static-md-avx512.cmake
@@ -1,4 +1,5 @@
 include("${CMAKE_CURRENT_LIST_DIR}/_pin_toolset.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/_perf_flags.cmake")
 
 string(APPEND VCPKG_CXX_FLAGS " /arch:AVX512")
 string(APPEND VCPKG_C_FLAGS " /arch:AVX512")

--- a/cmake/triplets/x64-windows-static-md.cmake
+++ b/cmake/triplets/x64-windows-static-md.cmake
@@ -1,1 +1,2 @@
 include("${CMAKE_CURRENT_LIST_DIR}/_pin_toolset.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/_perf_flags.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,23 +135,66 @@ target_compile_features("${PROJECT_NAME}" PRIVATE cxx_std_20)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	target_compile_options(
 		"${PROJECT_NAME}"
-		PRIVATE "/sdl" # Enable Additional Security Checks
-				"/utf-8" # Set Source and Executable character sets to UTF-8
+		PRIVATE "/utf-8" # Set Source and Executable character sets to UTF-8
 				"/Zi" # Debug Information Format
 				"/permissive-" # Standards conformance
 				"/Zc:preprocessor" # Enable preprocessor conformance mode
 				"/bigobj" # Increase Number of Sections in .obj file
-				"/W4" # Elevated warnings: unreachable code (C4702), unused vars (C4189), etc.
-				"/wd4100" # Suppress: unreferenced formal parameter (pervasive in SKSE callbacks)
-				"/wd4201" # Suppress: nameless struct/union (used throughout CommonLibSSE)
-				"/WX" # Warnings as errors
+				"/W4"            # Elevated warnings: unreachable code (C4702), unused vars (C4189), etc.
+				"/wd4100"        # Suppress: unreferenced formal parameter (pervasive in SKSE callbacks)
+				"/wd4201"        # Suppress: nameless struct/union (used throughout CommonLibSSE)
+				"/WX"            # Warnings as errors
 				"/external:anglebrackets" # Treat angle-bracket includes as external
-				"/external:W0" # No warnings from external headers (vcpkg, system)
-				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->" # Static analysis in Debug only; skip external headers
-				"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/Zc:inline;/JMC-;/Ob3>")
+				"/external:W0"   # No warnings from external headers (vcpkg, system)
+				# /sdl adds extra runtime security checks that cost measurably in the per-frame physics hot loops. Keep
+				# it in Debug; drop it from the shipped Release/Profile builds. (/GS stack cookies are NOT dropped.)
+				# Release/Profile speed flags:
+				#   /Zc:inline strip unreferenced COMDATs  /JMC- disable Just-My-Code  /Ob3 most aggressive inlining
+				#   /Gw       global-data COMDATs so /OPT:REF + LTCG can drop/place statics
+				#   /fp:fast  let the optimizer emit FMA and reassociate FP math (large for FP-heavy physics)
+				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->"  # Static analysis in Debug only; skip external headers
+				"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/Zc:inline;/JMC-;/Ob3;/Gw;/fp:fast>")
 
 	target_link_options("${PROJECT_NAME}" PRIVATE "$<$<CONFIG:DEBUG>:/INCREMENTAL;/OPT:NOREF;/OPT:NOICF>"
 						"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/INCREMENTAL:NO;/OPT:REF;/OPT:ICF;/DEBUG:FULL>")
+endif()
+
+# Whole-program optimization (LTCG/IPO) on the shipped DLL. The hot physics loops span several translation units
+# (collision, body, world) plus statically-linked Bullet, so cross-TU / cross-library inlining is the single biggest
+# "free" runtime win. This mirrors what CommonLibSSE already enables. Release-like configs only; adds /GL to compile and
+# /LTCG to link, which coexist with the /OPT:REF /OPT:ICF above.
+include(CheckIPOSupported)
+check_ipo_supported(RESULT _fsmp_ipo_ok OUTPUT _fsmp_ipo_msg)
+if(_fsmp_ipo_ok)
+	set_property(TARGET "${PROJECT_NAME}" PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+	set_property(TARGET "${PROJECT_NAME}" PROPERTY INTERPROCEDURAL_OPTIMIZATION_PROFILE ON)
+else()
+	message(WARNING "FSMP: IPO/LTCG unsupported; shipping without whole-program optimization: ${_fsmp_ipo_msg}")
+endif()
+
+# Profile-Guided Optimization (opt-in, MSVC only) -- layered on top of LTCG, the largest realistic win for the hot
+# paths. Because Bullet is compiled with /GL (see cmake/triplets/_perf_flags.cmake) and folded into this DLL's LTCG, a
+# single PGO pass over hdtSMP64 also profiles the heavy Bullet math. Two-stage workflow, see docs/PERFORMANCE.md:
+#   -DFSMP_PGO=INSTRUMENT  build an instrumented DLL, then run the standard physics-heavy scene in-game to emit .pgc data
+#   -DFSMP_PGO=OPTIMIZE    rebuild using the merged .pgd profile
+set(FSMP_PGO "OFF" CACHE STRING "Profile-Guided Optimization stage: OFF | INSTRUMENT | OPTIMIZE")
+set_property(CACHE FSMP_PGO PROPERTY STRINGS OFF INSTRUMENT OPTIMIZE)
+if(NOT FSMP_PGO STREQUAL "OFF")
+	if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+		message(FATAL_ERROR "FSMP_PGO is only supported with MSVC (got '${CMAKE_CXX_COMPILER_ID}')")
+	endif()
+	if(NOT _fsmp_ipo_ok)
+		message(FATAL_ERROR "FSMP_PGO requires IPO/LTCG support, which this toolchain reports as unavailable")
+	endif()
+	# PGO requires /GL + /LTCG in whatever configuration is built, so force IPO on for the whole target.
+	set_property(TARGET "${PROJECT_NAME}" PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
+	if(FSMP_PGO STREQUAL "INSTRUMENT")
+		target_link_options("${PROJECT_NAME}" PRIVATE "/GENPROFILE")
+	elseif(FSMP_PGO STREQUAL "OPTIMIZE")
+		target_link_options("${PROJECT_NAME}" PRIVATE "/USEPROFILE")
+	else()
+		message(FATAL_ERROR "FSMP_PGO must be OFF, INSTRUMENT, or OPTIMIZE (got '${FSMP_PGO}')")
+	endif()
 endif()
 
 target_include_directories("${PROJECT_NAME}" PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/src" "${SOURCE_DIR}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,19 +140,18 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 				"/permissive-" # Standards conformance
 				"/Zc:preprocessor" # Enable preprocessor conformance mode
 				"/bigobj" # Increase Number of Sections in .obj file
-				"/W4"            # Elevated warnings: unreachable code (C4702), unused vars (C4189), etc.
-				"/wd4100"        # Suppress: unreferenced formal parameter (pervasive in SKSE callbacks)
-				"/wd4201"        # Suppress: nameless struct/union (used throughout CommonLibSSE)
-				"/WX"            # Warnings as errors
+				"/W4" # Elevated warnings: unreachable code (C4702), unused vars (C4189), etc.
+				"/wd4100" # Suppress: unreferenced formal parameter (pervasive in SKSE callbacks)
+				"/wd4201" # Suppress: nameless struct/union (used throughout CommonLibSSE)
+				"/WX" # Warnings as errors
 				"/external:anglebrackets" # Treat angle-bracket includes as external
-				"/external:W0"   # No warnings from external headers (vcpkg, system)
+				"/external:W0" # No warnings from external headers (vcpkg, system)
 				# /sdl adds extra runtime security checks that cost measurably in the per-frame physics hot loops. Keep
 				# it in Debug; drop it from the shipped Release/Profile builds. (/GS stack cookies are NOT dropped.)
-				# Release/Profile speed flags:
-				#   /Zc:inline strip unreferenced COMDATs  /JMC- disable Just-My-Code  /Ob3 most aggressive inlining
-				#   /Gw       global-data COMDATs so /OPT:REF + LTCG can drop/place statics
-				#   /fp:fast  let the optimizer emit FMA and reassociate FP math (large for FP-heavy physics)
-				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->"  # Static analysis in Debug only; skip external headers
+				# Release/Profile speed flags: /Zc:inline strip unreferenced COMDATs  /JMC- disable Just-My-Code  /Ob3
+				# most aggressive inlining /Gw       global-data COMDATs so /OPT:REF + LTCG can drop/place statics
+				# /fp:fast  let the optimizer emit FMA and reassociate FP math (large for FP-heavy physics)
+				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->" # Static analysis in Debug only; skip external headers
 				"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/Zc:inline;/JMC-;/Ob3;/Gw;/fp:fast>")
 
 	target_link_options("${PROJECT_NAME}" PRIVATE "$<$<CONFIG:DEBUG>:/INCREMENTAL;/OPT:NOREF;/OPT:NOICF>"
@@ -175,9 +174,11 @@ endif()
 # Profile-Guided Optimization (opt-in, MSVC only) -- layered on top of LTCG, the largest realistic win for the hot
 # paths. Because Bullet is compiled with /GL (see cmake/triplets/_perf_flags.cmake) and folded into this DLL's LTCG, a
 # single PGO pass over hdtSMP64 also profiles the heavy Bullet math. Two-stage workflow, see docs/PERFORMANCE.md:
-#   -DFSMP_PGO=INSTRUMENT  build an instrumented DLL, then run the standard physics-heavy scene in-game to emit .pgc data
-#   -DFSMP_PGO=OPTIMIZE    rebuild using the merged .pgd profile
-set(FSMP_PGO "OFF" CACHE STRING "Profile-Guided Optimization stage: OFF | INSTRUMENT | OPTIMIZE")
+# -DFSMP_PGO=INSTRUMENT  build an instrumented DLL, then run the standard physics-heavy scene in-game to emit .pgc data
+# -DFSMP_PGO=OPTIMIZE    rebuild using the merged .pgd profile
+set(FSMP_PGO
+	"OFF"
+	CACHE STRING "Profile-Guided Optimization stage: OFF | INSTRUMENT | OPTIMIZE")
 set_property(CACHE FSMP_PGO PROPERTY STRINGS OFF INSTRUMENT OPTIMIZE)
 if(NOT FSMP_PGO STREQUAL "OFF")
 	if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,11 +148,10 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 				"/external:W0" # No warnings from external headers (vcpkg, system)
 				# /sdl adds extra runtime security checks that cost measurably in the per-frame physics hot loops. Keep
 				# it in Debug; drop it from the shipped Release/Profile builds. (/GS stack cookies are NOT dropped.)
-				# Release/Profile speed flags:
-				#   /Zc:inline strip unreferenced COMDATs  /JMC- disable Just-My-Code  /Ob3 most aggressive inlining
-				#   /Gw       global-data COMDATs so /OPT:REF + LTCG can drop/place static data
-				#   /fp:fast  let the optimizer emit FMA and reassociate FP math (large for FP-heavy physics)
-				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->"  # Static analysis in Debug only; skip external headers
+				# Release/Profile speed flags: /Zc:inline strip unreferenced COMDATs  /JMC- disable Just-My-Code  /Ob3
+				# most aggressive inlining /Gw       global-data COMDATs so /OPT:REF + LTCG can drop/place static data
+				# /fp:fast  let the optimizer emit FMA and reassociate FP math (large for FP-heavy physics)
+				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->" # Static analysis in Debug only; skip external headers
 				"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/Zc:inline;/JMC-;/Ob3;/Gw;/fp:fast>")
 
 	target_link_options("${PROJECT_NAME}" PRIVATE "$<$<CONFIG:DEBUG>:/INCREMENTAL;/OPT:NOREF;/OPT:NOICF>"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,10 +148,11 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 				"/external:W0" # No warnings from external headers (vcpkg, system)
 				# /sdl adds extra runtime security checks that cost measurably in the per-frame physics hot loops. Keep
 				# it in Debug; drop it from the shipped Release/Profile builds. (/GS stack cookies are NOT dropped.)
-				# Release/Profile speed flags: /Zc:inline strip unreferenced COMDATs  /JMC- disable Just-My-Code  /Ob3
-				# most aggressive inlining /Gw       global-data COMDATs so /OPT:REF + LTCG can drop/place statics
-				# /fp:fast  let the optimizer emit FMA and reassociate FP math (large for FP-heavy physics)
-				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->" # Static analysis in Debug only; skip external headers
+				# Release/Profile speed flags:
+				#   /Zc:inline strip unreferenced COMDATs  /JMC- disable Just-My-Code  /Ob3 most aggressive inlining
+				#   /Gw       global-data COMDATs so /OPT:REF + LTCG can drop/place static data
+				#   /fp:fast  let the optimizer emit FMA and reassociate FP math (large for FP-heavy physics)
+				"$<$<CONFIG:DEBUG>:/analyze;/analyze:external->"  # Static analysis in Debug only; skip external headers
 				"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/Zc:inline;/JMC-;/Ob3;/Gw;/fp:fast>")
 
 	target_link_options("${PROJECT_NAME}" PRIVATE "$<$<CONFIG:DEBUG>:/INCREMENTAL;/OPT:NOREF;/OPT:NOICF>"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in Profile-Guided Optimization (PGO) workflows for Release builds with new configure/build presets.
  * Enabled whole-program/link-time optimization when supported.
  * Added Debug-only static-analysis option for debug builds.

* **Chores**
  * Updated CI branch filters and expanded build cache key behavior.
  * Added Release-only performance tuning flags applied to compiler/link settings.
  * Removed a specific MSVC security-check flag from compile options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->