### PR TITLE
chore: complete Nexus auto-upload (pin upload-action beta.7 + primary download)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -348,7 +348,8 @@ jobs:
           name: FSMP-${{ needs.prepare.outputs.tag_version }}
 
       - name: Upload to Nexus Mods
-        uses: Nexus-Mods/upload-action@v1.0.0-beta.4
+        # v1.0.0-beta.7 (SHA-pinned: beta.7 is the first release where display_name is a valid input)
+        uses: Nexus-Mods/upload-action@0bf670d75d46988c176c9bfacc94ca0144e0fe3f
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
           file_group_id: ${{ secrets.NEXUSMODS_FILE_GROUP_ID }}
@@ -356,3 +357,4 @@ jobs:
           version: ${{ needs.prepare.outputs.new_version }}
           display_name: FSMP ${{ needs.prepare.outputs.new_version }}
           file_category: main
+          primary_mod_manager_download: true


### PR DESCRIPTION
Completes the automated Nexus Mods publish begun in #293. Closes #350.

## What
- SHA-pins `Nexus-Mods/upload-action` from `v1.0.0-beta.4` to `v1.0.0-beta.7` (`0bf670d75d46988c176c9bfacc94ca0144e0fe3f`).
- Adds `primary_mod_manager_download: true`.

## Why
`display_name: FSMP <version>` was being **silently dropped**: that input didn't exist until beta.6, but the job pinned beta.4 (GitHub ignores unknown inputs without erroring). Upgrading to beta.7 makes `display_name` valid and moves the action onto the Node 24 runtime. The pin is by commit SHA to neutralise the mutable beta tag.

## Status
- Repo secrets `NEXUSMODS_API_KEY` and `NEXUSMODS_FILE_GROUP_ID` are already configured.
- All `with:` keys verified against beta.7's `action.yml`.
- After merge to `master`, the deploy fires on a push whose message starts with `chore: bump FSMP to version <X.Y.Z>` (version read from `CMakeLists.txt`). Note: there is no dry-run — `workflow_dispatch` does not trigger `nexus_upload`, so the first bump is a real publish to mod 57339 (`archive_existing_file` left at default `false`, so it won't clobber the existing file).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build infrastructure for improved deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->