### PR TITLE
fix(validator): warn on orphaned physics marker instead of false missing-XML

### DIFF
--- a/src/Validator/Validators/hdtNIFPhysicsXMLExtractor.cpp
+++ b/src/Validator/Validators/hdtNIFPhysicsXMLExtractor.cpp
@@ -59,9 +59,12 @@ namespace hdt
 				while (begin > 0 && isPathByte(data[begin - 1]))
 					--begin;
 
-				size_t end = i + 4;
-				while (end < data.size() && isPathByte(data[end]))
-					++end;
+				// The path ends at its ".xml" extension; don't scan past it. NIF
+				// string-table entries are length-prefixed (not null-terminated), so the
+				// byte right after ".xml" is the next entry's length prefix, whose low
+				// byte can be a path-valid character (e.g. 0x31 = '1') that would
+				// otherwise be wrongly appended to the path.
+				const size_t end = i + 4;
 
 				if (end <= begin)
 					continue;
@@ -224,9 +227,12 @@ namespace hdt
 					if (!result.allPhysicsXmlPaths.empty()) {
 						result.physicsXmlPath = result.allPhysicsXmlPaths[0];
 					} else {
-						applyFallbackPaths(result, data);
-						if (result.allPhysicsXmlPaths.empty())
-							result.errors.push_back("Physics marker found but no XML references were extracted: " + nifPath);
+						// The marker string is present but no NiStringExtraData block
+						// references it — a leftover/orphaned marker (e.g. the physics
+						// extra-data block was stripped, leaving its strings in the table).
+						// The NIF has no functional physics; flag it for a warning rather
+						// than treating its stale string-table paths as real references.
+						result.hasOrphanedPhysicsMarker = true;
 					}
 				}
 				return result;

--- a/src/Validator/Validators/hdtNIFValidator.h
+++ b/src/Validator/Validators/hdtNIFValidator.h
@@ -19,6 +19,7 @@ namespace hdt
 		std::vector<std::string> allPhysicsXmlPaths;  // all found, for duplicate detection
 		bool hasGeometry = false;
 		bool hasSkinning = false;
+		bool hasOrphanedPhysicsMarker = false;  // marker string present but no NiStringExtraData block references it
 		std::vector<std::string> errors;
 	};
 

--- a/src/Validator/hdtAssetValidator.cpp
+++ b/src/Validator/hdtAssetValidator.cpp
@@ -868,6 +868,7 @@ namespace hdt
 						PhysicsAsset asset;
 						asset.nifPath = pathStr;
 						asset.nifExists = true;
+						asset.hasOrphanedPhysicsMarker = scanRes.hasOrphanedPhysicsMarker;
 						asset.relatedTRIPaths = discoverRelatedTRIFiles(pathStr);
 						asset.allPhysicsXmlPaths = scanRes.allPhysicsXmlPaths;
 
@@ -1039,6 +1040,16 @@ namespace hdt
 
 		for (const auto& asset : nifAssets) {
 			out << "  [NIF]  " << asset.nifPath << "\n";
+
+			// Warn about a leftover physics marker with no backing data block.
+			if (asset.hasOrphanedPhysicsMarker) {
+				report.warnings.push_back(asset.nifPath +
+					": has the \"HDT Skinned Mesh Physics Object\" marker string but no"
+					" NiStringExtraData physics block; the marker is leftover and no physics is applied.");
+				report.hasWarnings = true;
+				out << "    [WARNING] Leftover \"HDT Skinned Mesh Physics Object\" marker with no"
+					   " NiStringExtraData block; no physics applied\n";
+			}
 
 			// Warn if multiple "HDT Skinned Mesh Physics Object" blocks found
 			if (asset.allPhysicsXmlPaths.size() > 1) {

--- a/src/Validator/hdtAssetValidator.h
+++ b/src/Validator/hdtAssetValidator.h
@@ -24,6 +24,7 @@ namespace hdt
 		std::vector<std::string> allPhysicsXmlPaths;  // all "HDT Skinned Mesh Physics Object" blocks
 		bool nifExists = false;
 		bool xmlExists = false;
+		bool hasOrphanedPhysicsMarker = false;  // marker string present but no NiStringExtraData block
 	};
 
 	// ── Validation ────────────────────────────────────────────────────────────


### PR DESCRIPTION
A NIF can carry the "HDT Skinned Mesh Physics Object" marker string in its header string table with no NiStringExtraData block referencing it (e.g. the physics extra-data block was stripped, leaving the strings behind). It has no functional physics, yet the extractor fell back to a raw-byte scan that reported the leftover string-table paths as references — and that scan over-read past ".xml" into the next entry's length prefix (0x31 = '1'), yielding paths like "tome_book_blm_0.xml1".

- When the marker is present but no NiStringExtraData block references it, flag it (hasOrphanedPhysicsMarker) and emit a WARNING that the marker is leftover and no physics is applied, instead of a false "missing XML" error.
- Harden the raw-byte fallback (now used only on parse failure) to stop at the ".xml" extension so it cannot append the next entry's length byte.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed physics marker path extraction to prevent subsequent bytes from being incorrectly appended during data parsing.
  * Improved physics marker handling to avoid spurious error generation during extraction failures.

* **New Features**
  * Enhanced asset validation with orphaned physics marker detection, generating clear warnings when markers exist without proper data references in asset configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->