### PR TITLE
smp report: flag nodes missing from the equipped skeleton (#363) + warn on redundant <bone> declarations (#364)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,8 @@ set(SOURCE_FILES
 	"${SOURCE_DIR}/Validator/Parser/hdtNIFBinaryParser.cpp"
 	"${SOURCE_DIR}/Validator/Parser/hdtNIFBinaryParser.h"
 	"${SOURCE_DIR}/Validator/Validators/hdtNIFValidator.h"
+	"${SOURCE_DIR}/Validator/Validators/hdtNIFBoneRefValidator.cpp"
+	"${SOURCE_DIR}/Validator/Validators/hdtNIFBoneRefValidator.h"
 	"${SOURCE_DIR}/Validator/Validators/hdtXSDValidator.cpp"
 	"${SOURCE_DIR}/Validator/Validators/hdtXSDValidator.h"
 	"${SOURCE_DIR}/Validator/Validators/hdtSCHValidator.cpp"

--- a/src/Validator/Utils/hdtTemplateDefaults.cpp
+++ b/src/Validator/Utils/hdtTemplateDefaults.cpp
@@ -780,6 +780,70 @@ namespace hdt
 			}
 		}
 
+		// Build a node's complete effective FieldMap the way the runtime resolves one:
+		// start from the inherited template (a default node inherits via `extends`, an
+		// instance via `template`; both fall back to the unnamed "" default), overlay each
+		// own field tag — counting only the LAST frame tag, since earlier ones are shadowed
+		// — then fold collision lists in as whole replace-semantics sets. Shared by every
+		// walk that needs a node's final settings, so an instance and an equivalent default
+		// normalise to the same map. (The per-child redundancy walk does NOT use this: it
+		// must interleave detection with each overlay, so it keeps its own copy of the loop.)
+		static FieldMap computeNodeEffectiveFields(
+			const pugi::xml_node& node,
+			const Family family,
+			const bool isDefaultNode,
+			const TemplateMap& familyTemplate)
+		{
+			const std::string parentName = isDefaultNode
+				? TrimAsciiWhitespace(node.attribute("extends").as_string())
+				: TrimAsciiWhitespace(node.attribute("template").as_string());
+			FieldMap effective = getEffectiveTemplate(familyTemplate, parentName);
+
+			// Pre-scan for the last frame tag: only it is effective (constraints only;
+			// other families have no frame tags, so this stays empty for them).
+			pugi::xml_node lastFrameTag;
+			for (auto child = node.first_child(); child; child = child.next_sibling()) {
+				if (child.type() != pugi::node_element)
+					continue;
+				if (isFrameTagName(family, std::string(XmlLocalName(child.name()))))
+					lastFrameTag = child;
+			}
+
+			for (auto child = node.first_child(); child; child = child.next_sibling()) {
+				if (child.type() != pugi::node_element)
+					continue;
+
+				const std::string childName = std::string(XmlLocalName(child.name()));
+				std::string fieldKey;
+				std::string currentValue;
+
+				// Collision lists are folded in as whole sets below, not value-by-value.
+				if (isReplaceSemanticsCollisionList(childName))
+					continue;
+
+				if (isFrameTagName(family, childName)) {
+					if (child != lastFrameTag)
+						continue;
+					fieldKey = "__frameSpec";
+					currentValue = normalizeFrameSpec(childName, child);
+				} else {
+					fieldKey = fieldKeyFor(family, childName);
+					if (fieldKey.empty())
+						continue;
+					currentValue = normalizedValueForField(family, fieldKey, child);
+					// weight-threshold sets the threshold of ONE named bone, so keep one
+					// value per bone — templates with thresholds on different bones differ.
+					if (childName == "weight-threshold")
+						fieldKey += "@" + TrimAsciiWhitespace(child.attribute("bone").as_string());
+				}
+
+				effective[fieldKey] = currentValue;
+			}
+
+			applyCollisionListOverrides(node, effective);
+			return effective;
+		}
+
 		// Walk default nodes in document order to compute each one's effective
 		// FieldMap, then detect duplicates by signature.  Two templates are
 		// equivalent when they produce identical canonical field sets after
@@ -808,52 +872,8 @@ namespace hdt
 				if (family == Family::None || !isDefaultNodeName(localName))
 					continue;
 
-				const std::string extendsName = TrimAsciiWhitespace(node.attribute("extends").as_string());
 				const std::string templateName = TrimAsciiWhitespace(node.attribute("name").as_string());
-				FieldMap effective = getEffectiveTemplate(familyTemplates[family], extendsName);
-
-				pugi::xml_node lastFrameTag;
-				for (auto child = node.first_child(); child; child = child.next_sibling()) {
-					if (child.type() != pugi::node_element)
-						continue;
-					const std::string childName = std::string(XmlLocalName(child.name()));
-					if (isFrameTagName(family, childName))
-						lastFrameTag = child;
-				}
-
-				for (auto child = node.first_child(); child; child = child.next_sibling()) {
-					if (child.type() != pugi::node_element)
-						continue;
-
-					const std::string childName = std::string(XmlLocalName(child.name()));
-					std::string fieldKey;
-					std::string currentValue;
-
-					// Collision lists are handled as whole sets just after this loop, not one
-					// value at a time, so skip them here.
-					if (isReplaceSemanticsCollisionList(childName))
-						continue;
-
-					if (isFrameTagName(family, childName)) {
-						if (child != lastFrameTag)
-							continue;
-						fieldKey = "__frameSpec";
-						currentValue = normalizeFrameSpec(childName, child);
-					} else {
-						fieldKey = fieldKeyFor(family, childName);
-						if (fieldKey.empty())
-							continue;
-						currentValue = normalizedValueForField(family, fieldKey, child);
-						// One value per bone (see the redundancy loop above): templates with
-						// thresholds on different bones must not count as the same template.
-						if (childName == "weight-threshold")
-							fieldKey += "@" + TrimAsciiWhitespace(child.attribute("bone").as_string());
-					}
-
-					effective[fieldKey] = currentValue;
-				}
-
-				applyCollisionListOverrides(node, effective);
+				FieldMap effective = computeNodeEffectiveFields(node, family, /*isDefaultNode=*/true, familyTemplates[family]);
 
 				familyTemplates[family][templateName] = effective;
 				if (templateName.empty())
@@ -866,6 +886,81 @@ namespace hdt
 			}
 
 			return aliases;
+		}
+
+		// Detect top-level <bone> declarations whose complete effective settings are
+		// identical to the bone the engine auto-creates on demand for an undeclared
+		// node — the unnamed bone-default, a kinematic (mass-0) body.
+		//
+		// Why these are removable: when a node is referenced by a constraint or shape
+		// but has no <bone> of its own, FSMP fabricates one from getBoneTemplate("")
+		// (the unnamed bone-default). So a <bone> that only restates that default adds
+		// nothing — a referenced node would get an identical body anyway, and an
+		// unreferenced one leaves the declaration inert — and can be deleted either way.
+		//
+		// The check reuses the same effective-template machinery as the redundant-child
+		// and template-equivalence walks: step through top-level nodes in document order,
+		// keep boneTemplates[""] current as bone-default nodes are seen, and for each
+		// plain <bone> build its full effective FieldMap (inherited template + own field
+		// tags + collision-list overrides) exactly as a bone-default's is built, then
+		// compare it to boneTemplates[""] at that point.
+		//
+		// It is conservative in both directions. Every element child either overwrites a
+		// known field key or, being unmodelled, injects its own tag-name key — so a bone
+		// carrying anything beyond the defaults (a non-default value, a collision-list
+		// override, an unexpected child) ends up with a FieldMap that differs from the
+		// default and is left alone. And with the .sch defaults absent, boneTemplates[""]
+		// holds fewer keys, so an explicit non-default field can only fail to match —
+		// the walk under-reports rather than ever flagging a non-default bone.
+		static std::vector<RedundantBoneInfo> collectRedundantBoneDeclarations(
+			const pugi::xml_document& doc,
+			const std::string* sourceBytes)
+		{
+			std::vector<RedundantBoneInfo> out;
+			auto sysNode = findSystemNode(doc);
+			if (!sysNode)
+				return out;
+
+			const auto baseDefaults = makeBaseDefaults();
+			TemplateMap boneTemplates;
+			{
+				auto it = baseDefaults.find(Family::Bone);
+				boneTemplates[""] = (it != baseDefaults.end()) ? it->second : FieldMap{};
+			}
+
+			for (auto node = sysNode.first_child(); node; node = node.next_sibling()) {
+				if (node.type() != pugi::node_element)
+					continue;
+
+				const std::string localName = std::string(XmlLocalName(node.name()));
+				// Only the bone family touches boneTemplates; everything else is irrelevant
+				// to both the inheritance state and the candidate set, so skip it.
+				if (familyForNode(localName) != Family::Bone)
+					continue;
+
+				const bool isDefault = isDefaultNodeName(localName);  // "bone-default"
+				// Same effective-map construction as the bone-default templates, so a <bone>
+				// and an equivalent bone-default normalise to the same map and compare equal.
+				FieldMap effective = computeNodeEffectiveFields(node, Family::Bone, isDefault, boneTemplates);
+
+				if (isDefault) {
+					const std::string templateName = TrimAsciiWhitespace(node.attribute("name").as_string());
+					boneTemplates[templateName] = std::move(effective);
+					continue;
+				}
+
+				auto defaultIt = boneTemplates.find("");
+				if (defaultIt != boneTemplates.end() && effective == defaultIt->second) {
+					RedundantBoneInfo info;
+					info.location = BuildNodeLocationPath(node);
+					info.boneName = TrimAsciiWhitespace(node.attribute("name").as_string());
+					if (sourceBytes)
+						info.line = OffsetToLineNumber(*sourceBytes, node.offset_debug());
+					out.push_back(std::move(info));
+				}
+			}
+
+			return out;
 		}
 
 	}  // anonymous namespace
@@ -918,6 +1013,13 @@ namespace hdt
 		const pugi::xml_document& doc)
 	{
 		return collectEquivalentDefaultTemplateAliases(doc);
+	}
+
+	std::vector<RedundantBoneInfo> CollectRedundantBoneDeclarations(
+		const pugi::xml_document& doc,
+		const std::string* sourceBytes)
+	{
+		return collectRedundantBoneDeclarations(doc, sourceBytes);
 	}
 
 }  // namespace hdt

--- a/src/Validator/Utils/hdtTemplateDefaults.h
+++ b/src/Validator/Utils/hdtTemplateDefaults.h
@@ -43,4 +43,21 @@ namespace hdt
 	std::unordered_map<std::string, std::string> CollectEquivalentDefaultTemplateAliases(
 		const pugi::xml_document& doc);
 
+	// One top-level <bone> declaration found to be redundant: its complete effective
+	// settings match the bone the engine would auto-create for an undeclared node.
+	struct RedundantBoneInfo
+	{
+		std::string location;  // positional path, e.g. /system[1]/bone[5]
+		std::string boneName;  // value of the bone's name attribute (for the message)
+		int line = 0;
+	};
+
+	// Find top-level <bone> declarations that only restate the auto-created default
+	// bone (the unnamed bone-default) and are therefore removable with no behavioural
+	// change. Reuses the effective-default machinery; see the .cpp for the conservative
+	// comparison. When sourceBytes is provided, line numbers are computed from offsets.
+	std::vector<RedundantBoneInfo> CollectRedundantBoneDeclarations(
+		const pugi::xml_document& doc,
+		const std::string* sourceBytes = nullptr);
+
 }  // namespace hdt

--- a/src/Validator/Validators/hdtNIFBoneRefValidator.cpp
+++ b/src/Validator/Validators/hdtNIFBoneRefValidator.cpp
@@ -1,0 +1,120 @@
+#include "hdtNIFBoneRefValidator.h"
+
+#include "../Utils/hdtTemplateDefaults.h"  // isDefaultNodeName
+#include "../Utils/hdtValidatorFamily.h"   // familyForNode
+#include "NetImmerseUtils.h"               // readAllFile2
+#include "hdtNIFValidator.h"               // CollectNamedSkeletonNodes
+
+#include <pugixml.hpp>
+
+#include <algorithm>
+#include <string>
+#include <unordered_set>
+
+namespace hdt
+{
+	namespace
+	{
+		// Mirror of SkyrimSystemCreator::getRenamedBone: a mapped name resolves to its
+		// merged-skeleton form, an unmapped name is looked up verbatim.
+		std::string applyRename(const std::string& name,
+			const std::unordered_map<std::string, std::string>& renameMap)
+		{
+			auto it = renameMap.find(name);
+			return it == renameMap.end() ? name : it->second;
+		}
+
+		// Per-resolved-name accumulator: how many times, and in what roles, the XML reaches
+		// a node that the skeleton does not provide.
+		struct MissingAcc
+		{
+			std::string referenced;  // first-seen written form
+			bool usedAsBone = false;
+			int constraintRefs = 0;
+		};
+
+		// Depth-first walk over every element, classifying bone/constraint references.
+		// Recursion (rather than first-level children) is needed because constraints may be
+		// nested inside <constraint-group> and bones/shapes are siblings under <system>.
+		void collectReferences(pugi::xml_node node,
+			const std::unordered_set<std::string>& nodeSet,
+			const std::unordered_map<std::string, std::string>& renameMap,
+			std::unordered_map<std::string, MissingAcc>& missingByResolved)
+		{
+			auto record = [&](const char* written, bool asBone) {
+				if (!written || written[0] == '\0')
+					return;
+				std::string resolved = applyRename(written, renameMap);
+				if (nodeSet.count(resolved))
+					return;  // resolves fine — SMP would find it
+				auto& acc = missingByResolved[resolved];
+				if (acc.referenced.empty())
+					acc.referenced = written;
+				if (asBone)
+					acc.usedAsBone = true;
+				else
+					++acc.constraintRefs;
+			};
+
+			for (pugi::xml_node child = node.first_child(); child; child = child.next_sibling()) {
+				if (child.type() != pugi::node_element)
+					continue;
+				// Classify by element family, but skip "-default" template nodes: their
+				// name/bodyA/bodyB carry a template class name, not a skeleton node.
+				const std::string tag = child.name();
+				if (!isDefaultNodeName(tag)) {
+					switch (familyForNode(tag)) {
+					case Family::Bone:
+						record(child.attribute("name").value(), true);
+						break;
+					case Family::Generic:
+					case Family::StiffSpring:
+					case Family::ConeTwist:
+						record(child.attribute("bodyA").value(), false);
+						record(child.attribute("bodyB").value(), false);
+						break;
+					default:
+						break;
+					}
+				}
+				collectReferences(child, nodeSet, renameMap, missingByResolved);
+			}
+		}
+	}  // namespace
+
+	std::vector<MissingBoneRef> FindMissingPhysicsXmlBoneRefs(
+		RE::NiNode* skeletonRoot,
+		const std::string& xmlPath,
+		const std::unordered_map<std::string, std::string>& renameMap)
+	{
+		// A missing/malformed XML yields no findings on purpose: reporting bad XML is the
+		// schema validator's job, and it runs over these same equipped XMLs in the report.
+		std::string bytes = readAllFile2(xmlPath.c_str());
+		pugi::xml_document doc;
+		if (!doc.load_buffer(bytes.data(), bytes.size()))
+			return {};
+
+		std::vector<std::string> nodeNames;
+		CollectNamedSkeletonNodes(skeletonRoot, nodeNames);
+		std::unordered_set<std::string> nodeSet(nodeNames.begin(), nodeNames.end());
+
+		std::unordered_map<std::string, MissingAcc> missingByResolved;
+		collectReferences(doc, nodeSet, renameMap, missingByResolved);
+
+		std::vector<MissingBoneRef> missing;
+		missing.reserve(missingByResolved.size());
+		for (auto& [resolved, acc] : missingByResolved) {
+			MissingBoneRef m;
+			m.referencedName = acc.referenced;
+			m.resolvedName = resolved;
+			m.usedAsBone = acc.usedAsBone;
+			m.constraintRefs = acc.constraintRefs;
+			missing.push_back(std::move(m));
+		}
+		// Deterministic report ordering.
+		std::sort(missing.begin(), missing.end(),
+			[](const MissingBoneRef& a, const MissingBoneRef& b) { return a.resolvedName < b.resolvedName; });
+
+		return missing;
+	}
+}  // namespace hdt

--- a/src/Validator/Validators/hdtNIFBoneRefValidator.h
+++ b/src/Validator/Validators/hdtNIFBoneRefValidator.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace RE
+{
+	class NiNode;
+}
+
+namespace hdt
+{
+	// A single physics-XML node reference that does not resolve to any node in the
+	// skeleton the XML is applied to. `usedAsBone`/`constraintRefs` record how the XML
+	// reaches the node so the report can state the concrete effect of its absence.
+	struct MissingBoneRef
+	{
+		std::string referencedName;  // name exactly as written in the XML (before renameMap)
+		std::string resolvedName;    // name after renameMap — what SMP looks up; == referencedName when unmapped
+		bool usedAsBone = false;     // referenced by at least one <bone name="…"> definition
+		int constraintRefs = 0;      // count of constraint endpoints (bodyA/bodyB) referencing it
+	};
+
+	// Returns the physics-XML node references that do NOT resolve to any node in
+	// `skeletonRoot` — the NPC node SMP resolves bones against at load time, which already
+	// contains the equipped item's merged + renamed nodes.
+	//
+	// Algorithm: (1) read+parse the XML; (2) collect the skeleton's node-name set via
+	// CollectNamedSkeletonNodes; (3) walk every element, gathering each <bone>'s `name`
+	// and each generic-/stiffspring-/conetwist-constraint's `bodyA`/`bodyB`; (4) push each
+	// reference through `renameMap` (mirroring SkyrimSystemCreator::getRenamedBone) and
+	// keep the ones whose resolved name is not in the set, merged per resolved name and
+	// sorted by it.
+	//
+	// A returned entry means SMP would also fail the lookup and therefore silently skip
+	// the bone / drop the constraint. The "-default" template element variants are ignored
+	// because their `name`/`bodyA`/`bodyB` carry template class names, not node references.
+	// Returns empty when the XML is missing or unparseable: reporting bad XML belongs to the
+	// schema validator, which runs over the same equipped XMLs. `renameMap` may be empty.
+	std::vector<MissingBoneRef> FindMissingPhysicsXmlBoneRefs(
+		RE::NiNode* skeletonRoot,
+		const std::string& xmlPath,
+		const std::unordered_map<std::string, std::string>& renameMap);
+}

--- a/src/Validator/Validators/hdtNIFStructureValidator.cpp
+++ b/src/Validator/Validators/hdtNIFStructureValidator.cpp
@@ -15,28 +15,6 @@ namespace hdt
 		constexpr float kMaxSaneScale = 1000.f;
 		constexpr float kRootScaleDeviationThreshold = 0.5f;
 
-		/// Recursively collects non-empty NiNode names from a skeleton subtree.
-		/// The collected names are used as a simple bone inventory for diagnostics.
-		void collectNamedSkeletonNodes(RE::NiNode* node, std::vector<std::string>& boneNames)
-		{
-			if (!node)
-				return;
-
-			const char* name = node->name.c_str();
-			if (name && name[0] != '\0') {
-				boneNames.push_back(name);
-			}
-
-			for (auto& child : node->GetChildren()) {
-				if (!child)
-					continue;
-				RE::NiNode* childNode = castNiNode(child.get());
-				if (childNode) {
-					collectNamedSkeletonNodes(childNode, boneNames);
-				}
-			}
-		}
-
 		/// Validates a single node transform for numeric sanity and plausible scale range.
 		/// Appends descriptive errors for NaN/inf values or extreme scale values.
 		/// Returns true when all checks pass, false otherwise.
@@ -145,6 +123,26 @@ namespace hdt
 
 	}  // namespace
 
+	void CollectNamedSkeletonNodes(RE::NiNode* root, std::vector<std::string>& outNames)
+	{
+		if (!root)
+			return;
+
+		const char* name = root->name.c_str();
+		if (name && name[0] != '\0') {
+			outNames.push_back(name);
+		}
+
+		for (auto& child : root->GetChildren()) {
+			if (!child)
+				continue;
+			RE::NiNode* childNode = castNiNode(child.get());
+			if (childNode) {
+				CollectNamedSkeletonNodes(childNode, outNames);
+			}
+		}
+	}
+
 	/// Validates runtime NIF structure rooted at a NiNode.
 	/// Performs bone discovery, transform sanity checks, and skinning integrity checks,
 	/// then returns a consolidated structural validation result with errors/warnings.
@@ -158,7 +156,7 @@ namespace hdt
 			return result;
 		}
 
-		collectNamedSkeletonNodes(root, result.boneNames);
+		CollectNamedSkeletonNodes(root, result.boneNames);
 		result.boneCount = static_cast<uint32_t>(result.boneNames.size());
 
 		if (result.boneCount == 0) {

--- a/src/Validator/Validators/hdtNIFValidator.h
+++ b/src/Validator/Validators/hdtNIFValidator.h
@@ -42,4 +42,9 @@ namespace hdt
 	// Can be called at runtime when the NIF has been loaded by the game.
 	NIFStructuralResult ValidateNIFStructure(RE::NiNode* root, const std::string& nifPath);
 
+	// Recursively appends every non-empty NiNode name in the subtree rooted at `root`
+	// to `outNames`. Used both as a diagnostic bone inventory and as the lookup set the
+	// bone-reference validator resolves physics-XML node references against.
+	void CollectNamedSkeletonNodes(RE::NiNode* root, std::vector<std::string>& outNames);
+
 }  // namespace hdt

--- a/src/Validator/hdtAssetValidator.cpp
+++ b/src/Validator/hdtAssetValidator.cpp
@@ -18,6 +18,7 @@
 #include "Utils/hdtTemplateDefaults.h"
 #include "Utils/hdtTimeUtils.h"
 #include "Utils/hdtXMLUtils.h"
+#include "Validators/hdtNIFBoneRefValidator.h"
 #include "Validators/hdtNIFValidator.h"
 #include "Validators/hdtSCHValidator.h"
 #include "Validators/hdtXSDValidator.h"
@@ -568,6 +569,45 @@ namespace hdt
 		FindClose(h);
 	}
 
+	/// Cross-references an equipped item's physics XML node references against the live
+	/// actor skeleton and appends one violation line per node the skeleton does not
+	/// provide. Each line names the affected element role and the runtime consequence so
+	/// an author can see why their physics detaches. Emits nothing when the skeleton root
+	/// is null (the caller already reported that) or the XML is missing/malformed (the
+	/// schema-validation pass over these same equipped XMLs is what reports XML validity).
+	static void appendMissingBoneRefViolations(RE::NiNode* skeletonRoot, const std::string& xmlPath,
+		const std::unordered_map<RE::BSFixedString, RE::BSFixedString>& renameMap,
+		const std::string& skeletonName, std::vector<std::string>& out)
+	{
+		if (!skeletonRoot || xmlPath.empty())
+			return;
+
+		std::unordered_map<std::string, std::string> rename;
+		rename.reserve(renameMap.size());
+		for (const auto& kv : renameMap)
+			rename.emplace(kv.first.c_str(), kv.second.c_str());
+
+		for (const auto& m : FindMissingPhysicsXmlBoneRefs(skeletonRoot, xmlPath, rename)) {
+			std::string effect;
+			if (m.usedAsBone && m.constraintRefs > 0)
+				effect = "its <bone> body is skipped and " + std::to_string(m.constraintRefs) +
+						 " constraint(s) referencing it are dropped";
+			else if (m.usedAsBone)
+				effect = "its <bone> body is skipped (no physics body created)";
+			else
+				effect = std::to_string(m.constraintRefs) + " constraint(s) referencing it are dropped";
+
+			std::string line = xmlPath + ": node '" + m.resolvedName + "' is absent from the '" +
+							   skeletonName + "' skeleton — " + effect;
+			if (m.referencedName != m.resolvedName)
+				line += " (XML name '" + m.referencedName + "' renamed to '" + m.resolvedName + "')";
+			if (m.constraintRefs > 0)
+				line += "; dynamic bones anchored only through it may detach/sag";
+			line += ".";
+			out.push_back(std::move(line));
+		}
+	}
+
 	/// Discovers physics-enabled assets from either filesystem or runtime.
 	/// When equippedOnly=false: Scans data/ (or the configured physical mods dir) for NIF files.
 	///   Phase 1 (serial + parallel): directory walk to collect .nif paths.
@@ -624,6 +664,7 @@ namespace hdt
 							if (!nifDiskPath.empty())
 								outNifScanViolations->push_back(nifDiskPath + ": equipped armor node is not a NiNode (physics XML: " + asset.xmlPath + ")");
 						}
+						appendMissingBoneRefViolations(skeleton.npc.get(), xmlPath, armor.renameMap, skeleton.name(), *outNifScanViolations);
 					}
 					result.push_back(std::move(asset));
 				}
@@ -658,6 +699,7 @@ namespace hdt
 							if (!nifDiskPath.empty())
 								outNifScanViolations->push_back(nifDiskPath + ": equipped headpart node is not a NiNode (physics XML: " + asset.xmlPath + ")");
 						}
+						appendMissingBoneRefViolations(skeleton.npc.get(), xmlPath, skeleton.head.renameMap, skeleton.name(), *outNifScanViolations);
 					}
 					result.push_back(std::move(asset));
 				}

--- a/src/Validator/hdtAssetValidator.cpp
+++ b/src/Validator/hdtAssetValidator.cpp
@@ -162,13 +162,23 @@ namespace hdt
 
 	using XMLValidationPair = std::pair<XSDValidationResult, SCHValidationResult>;
 
-	// Load xmlPath from disk and collect per-element redundancy info.
-	// Called by appendXmlViolationsToReport to cross-reference SCH default-value
-	// warnings against actual runtime-effective template inheritance — a warning is
-	// suppressed when the tag is not redundant relative to the inherited template.
-	static std::vector<TemplateRedundantChildInfo> collectTemplateRedundantChildrenForXml(const std::string& xmlPath)
+	// The two flavours of template redundancy reported for one XML file: per-element
+	// tags that restate an inherited default, and whole <bone> declarations that only
+	// restate the auto-created default bone.
+	struct XmlRedundancyInfo
 	{
-		std::vector<TemplateRedundantChildInfo> result;
+		std::vector<TemplateRedundantChildInfo> redundantChildren;
+		std::vector<RedundantBoneInfo> redundantBones;
+	};
+
+	// Load xmlPath from disk once and collect both redundancy flavours from the parsed
+	// document. The per-element info lets appendXmlViolationsToReport cross-reference SCH
+	// default-value warnings against actual runtime-effective template inheritance — a
+	// warning is suppressed when the tag is not redundant relative to the inherited
+	// template — while the bone info drives the redundant-<bone> warnings directly.
+	static XmlRedundancyInfo collectXmlRedundancyInfo(const std::string& xmlPath)
+	{
+		XmlRedundancyInfo result;
 
 		std::string bytes = readAllFile2(xmlPath.c_str());
 		if (bytes.empty())
@@ -179,7 +189,9 @@ namespace hdt
 		if (!parseResult)
 			return result;
 
-		return CollectTemplateRedundantChildrenInfo(doc, &bytes);
+		result.redundantChildren = CollectTemplateRedundantChildrenInfo(doc, &bytes);
+		result.redundantBones = CollectRedundantBoneDeclarations(doc, &bytes);
+		return result;
 	}
 
 	/// Appends XSD violations, SCH violations, and template-redundant warnings for one XML
@@ -189,9 +201,9 @@ namespace hdt
 		AssetValidationResult& report, std::ostream& out)
 	{
 		const auto& [xsdResult, schResult] = pair;
-		const auto templateRedundantChildren = collectTemplateRedundantChildrenForXml(xmlPath);
+		const auto redundancyInfo = collectXmlRedundancyInfo(xmlPath);
 		std::unordered_map<std::string, TemplateRedundantChildInfo> templateRedundantByLocation;
-		for (const auto& info : templateRedundantChildren)
+		for (const auto& info : redundancyInfo.redundantChildren)
 			templateRedundantByLocation[info.location] = info;
 		std::unordered_set<std::string> emittedTemplateRedundantLocations;
 
@@ -290,6 +302,22 @@ namespace hdt
 				continue;
 
 			emitTemplateRedundantWarning(info);
+		}
+
+		// Whole <bone> declarations that only restate the auto-created default bone:
+		// the engine would fabricate an identical body on demand, so the declaration
+		// is removable. See CollectRedundantBoneDeclarations for the comparison.
+		for (const auto& bone : redundancyInfo.redundantBones) {
+			const std::string named = bone.boneName.empty() ? std::string() : " \"" + bone.boneName + "\"";
+			std::string msg = xmlPath + ":" + std::to_string(bone.line) + ": " + bone.location +
+			                  " - <bone>" + named +
+			                  " only restates the default bone settings; the engine creates an"
+			                  " identical bone on demand, so this declaration is unnecessary and can be removed.";
+			report.warnings.push_back(msg);
+			report.hasWarnings = true;
+			out << "    [WARNING] " << bone.location << " (line " << bone.line << "): <bone>" << named
+				<< " only restates the default bone settings; the engine creates an identical bone on"
+				   " demand, so this declaration can be removed.\n";
 		}
 	}
 

--- a/src/Validator/hdtAssetValidator.cpp
+++ b/src/Validator/hdtAssetValidator.cpp
@@ -1415,6 +1415,13 @@ namespace hdt
 			bodyStream << "  Scanned " << filesystemNifFilesDiscovered << " NIF file(s) in data/meshes.\n";
 			bodyStream << "  Found " << nifAssets.size() << " NIF file(s) referencing physics configs.\n";
 			bodyStream << "  Identified " << relatedTRINorm.size() << " related TRI file(s).\n";
+			// The skeleton missing-node cross-reference is gear-only by design: a filesystem
+			// scan has no equipped actor, so there is no skeleton to resolve <bone>/constraint
+			// node names against. Say so here so a full-scan reader doesn't assume it ran.
+			bodyStream << "  Note: the skeleton missing-node check (each <bone> name and each constraint\n"
+					   << "        bodyA/bodyB vs the actor's skeleton) runs only in 'smp report gear';\n"
+					   << "        a full filesystem scan has no equipped skeleton to check against, so it\n"
+					   << "        is skipped here. Run 'smp report gear' to perform it.\n";
 
 			if (!nifScanViolations.empty()) {
 				bodyStream << "\n  -- NIF Scan Violations --\n";


### PR DESCRIPTION
## Summary

Two `smp report` validator improvements, verified in-game.

### #363 — missing skeleton-node detection (gear scan)
- `feat(validator): flag physics-XML nodes absent from the equipped skeleton` — cross-references every node a physics XML binds to (each `<bone>` `name` and each constraint `bodyA`/`bodyB`) against the live equipped-actor skeleton, applying the runtime rename map, and reports each missing node with its role and runtime consequence as an `[ERROR]`. Gear-only by design: a filesystem scan has no equipped skeleton to resolve against.
- `docs(#363)` — the full scan now prints a note that this check is gear-only and was skipped, so a clean full-scan report isn't misread as having verified skeleton bindings.

### #364 — redundant `<bone>` warning (full + gear)
- `feat(#364)` — warns when a top-level `<bone>` only restates the bone FSMP auto-creates for an undeclared node (the unnamed bone-default): a referenced node would get an identical body on demand, an unreferenced one is inert, so the declaration is removable. Reuses the existing effective-default machinery (extracted into a shared `computeNodeEffectiveFields` helper, also used by the template-equivalence walk) rather than a parallel comparator. Conservative — any non-default field, collision-list override, or unmodelled child differs and is left alone.

## Testing
- Release build clean; exercised in-game via `smp report` and `smp report gear`.

## Docs
Wiki (`Validating-your-mods-with-smp-report`) updated separately: redundant-`<bone>` warning row + gear-only note.

Closes #363
Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection of redundant bone declarations in physics XML documents that restate default engine settings
  * Added validation for equipped gear to identify missing bone references against skeleton nodes
  * Enhanced validation reports with more specific warnings for XML redundancy and missing reference issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->