### PR TITLE
style: apply pre-commit.ci formatting for #365

### DIFF
--- a/src/Validator/Utils/hdtTemplateDefaults.cpp
+++ b/src/Validator/Utils/hdtTemplateDefaults.cpp
@@ -794,9 +794,7 @@ namespace hdt
 			const bool isDefaultNode,
 			const TemplateMap& familyTemplate)
 		{
-			const std::string parentName = isDefaultNode
-				? TrimAsciiWhitespace(node.attribute("extends").as_string())
-				: TrimAsciiWhitespace(node.attribute("template").as_string());
+			const std::string parentName = isDefaultNode ? TrimAsciiWhitespace(node.attribute("extends").as_string()) : TrimAsciiWhitespace(node.attribute("template").as_string());
 			FieldMap effective = getEffectiveTemplate(familyTemplate, parentName);
 
 			// Pre-scan for the last frame tag: only it is effective (constraints only;

--- a/src/Validator/hdtAssetValidator.cpp
+++ b/src/Validator/hdtAssetValidator.cpp
@@ -619,14 +619,14 @@ namespace hdt
 			std::string effect;
 			if (m.usedAsBone && m.constraintRefs > 0)
 				effect = "its <bone> body is skipped and " + std::to_string(m.constraintRefs) +
-						 " constraint(s) referencing it are dropped";
+				         " constraint(s) referencing it are dropped";
 			else if (m.usedAsBone)
 				effect = "its <bone> body is skipped (no physics body created)";
 			else
 				effect = std::to_string(m.constraintRefs) + " constraint(s) referencing it are dropped";
 
 			std::string line = xmlPath + ": node '" + m.resolvedName + "' is absent from the '" +
-							   skeletonName + "' skeleton — " + effect;
+			                   skeletonName + "' skeleton — " + effect;
 			if (m.referencedName != m.resolvedName)
 				line += " (XML name '" + m.referencedName + "' renamed to '" + m.resolvedName + "')";
 			if (m.constraintRefs > 0)


### PR DESCRIPTION
Lands the pre-commit.ci autofix (`cdb0c98`) that was pushed to the branch after
#365 was merged, so `dev` gets the clang-format result for the files touched
there. Formatting-only — no behavioural change.

Follow-up to #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
