### PR TITLE
chore: fix codespell failures keeping pre-commit.ci red

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        args: [--ignore-words-list, "ue,nd,fo,hin,inout,numer,gool,fre,oord,accessort,toi,isse"]
+        args: [--ignore-words-list, "ue,nd,fo,hin,inout,numer,gool,fre,oord,accessort,toi,isse,lod"]
 
 ci:
     autofix_commit_msg: |

--- a/src/Validator/Validators/hdtNIFBoneRefValidator.h
+++ b/src/Validator/Validators/hdtNIFBoneRefValidator.h
@@ -36,7 +36,7 @@ namespace hdt
 	// A returned entry means SMP would also fail the lookup and therefore silently skip
 	// the bone / drop the constraint. The "-default" template element variants are ignored
 	// because their `name`/`bodyA`/`bodyB` carry template class names, not node references.
-	// Returns empty when the XML is missing or unparseable: reporting bad XML belongs to the
+	// Returns empty when the XML is missing or unparsable: reporting bad XML belongs to the
 	// schema validator, which runs over the same equipped XMLs. `renameMap` may be empty.
 	std::vector<MissingBoneRef> FindMissingPhysicsXmlBoneRefs(
 		RE::NiNode* skeletonRoot,


### PR DESCRIPTION
Turns `pre-commit.ci` green. Two non-functional fixes:

- `style:` correct the `unparseable` -> `unparsable` codespell typo in the
  `FindMissingPhysicsXmlBoneRefs` doc comment (introduced by the #363 code in #365).
- `chore:` add `lod` to the codespell `--ignore-words-list`. `LOD` (Level Of Detail)
  is used throughout `hdtNifSchema.cpp` and is a long-standing codespell false
  positive that kept pre-commit.ci red on every PR (pre-existing, not from #365).

Verified: `codespell` clean over `src/` (excluding submodules) with the updated
ignore list. No behaviour change.

Follow-up to #365 / #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality tooling configuration to enhance misspelling detection
  * Corrected spelling in internal documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->