### PR TITLE
fix: harden FaceGen/armor hooks against engine-supplied null pointers

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -132,6 +132,9 @@ namespace hdt
 
 			skeleton.attachArmor(e->armorModel, e->attachedNode);
 		} else {
+			// e->armorModel comes from the engine and can be null. In that case, it's useless.
+			if (!e->armorModel)
+				return RE::BSEventNotifyControl::kContinue;
 			skeleton.addArmor(e->armorModel);
 		}
 
@@ -826,8 +829,7 @@ namespace hdt
 
 	void ActorManager::Skeleton::addArmor(RE::NiNode* armorModel)
 	{
-		if (armorModel)
-			logBrokenNifOnce(armorModel->name.c_str(), armorModel);
+		logBrokenNifOnce(armorModel->name.c_str(), armorModel);
 
 		IDType id = armors.size() ? armors.back().id + 1 : 0;
 		auto prefix = armorPrefix(id);

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -67,6 +67,10 @@ namespace Hooks
 
 	void BSFaceGenNiNodeHooks::SkinSingleGeometry__Hook(RE::BSFaceGenNiNode* const a_this, RE::NiNode* a_skeleton, RE::BSGeometry* a_triShape, [[maybe_unused]] bool a_unk)
 	{
+		// a_skeleton is supplied by the engine and can be null
+		if (!a_skeleton)
+			return;
+
 		//
 		const char* name = "";
 		uint32_t formId = 0x0;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -30,8 +30,11 @@ namespace Hooks
 	void BSFaceGenNiNodeHooks::SkinAllGeometryCalls(RE::BSFaceGenNiNode* const a_this, RE::NiNode* a_skeleton, bool a_unk)
 	{
 		bool needRegularCall = true;
-		if (hdt::ActorManager::instance()->skeletonNeedsParts(a_skeleton)) {
-			RE::TESForm* form = RE::TESForm::LookupByID(a_skeleton->GetUserData()->formID);
+		// userData (engine-supplied, can be null) must exist before we look up head parts. Check it first
+		// because it's a cheap pointer read, while skeletonNeedsParts() walks the skeleton tree.
+		auto* userData = a_skeleton->GetUserData();
+		if (userData && hdt::ActorManager::instance()->skeletonNeedsParts(a_skeleton)) {
+			RE::TESForm* form = RE::TESForm::LookupByID(userData->formID);
 			RE::Actor* actor = skyrim_cast<RE::Actor*>(form);
 			if (actor) {
 				RE::TESNPC* actorBase = skyrim_cast<RE::TESNPC*>(actor->data.objectReference);
@@ -54,7 +57,7 @@ namespace Hooks
 					}
 				}
 
-				if (a_skeleton->GetUserData() && a_skeleton->GetUserData()->formID == 0x14) {
+				if (userData->formID == 0x14) {
 					needRegularCall = false;
 				}
 			}


### PR DESCRIPTION
Three independent null-pointer crash-to-desktop fixes in the FaceGen and armor-attach hooks. Each pointer originates from the game engine (a trust boundary) and can be null; all three were unguarded on `dev`.

## Fixes
- **`SkinSingleGeometry__Hook`** (`closes #368`) — early-return when `a_skeleton` is null, before the first `GetUserData()` dereference.
- **`SkinAllGeometryCalls`** (`closes #369`) — null-check `GetUserData()` before `LookupByID(... ->formID)`. The function already guarded a *later* use of `GetUserData()`, confirming it is nullable; `needRegularCall` stays true so the regular path still runs.
- **`ProcessEvent` → `addArmor`** (`closes #370`) — guard `e->armorModel` before `addArmor`, which forwards it to `scanBBP`/`doSkeletonMerge` (both dereference it unconditionally).

## Notes
- Minimal, behavior-preserving guards only — no refactors, no feature changes.
- Crashes were originally identified on the (now-retired) `protection` branch; ported fresh onto current `dev`.
- Not built locally; relies on CI.

Crashes reported by TonyCubed2 (the `armorModel` guard mechanism suggested by TonyCubed2). Credited per-commit via `Reported-by:` / `Suggested-by:` trailers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes during armor attachment/detachment in edge cases by safely handling missing armor model data
  * Improved character model rendering stability by adding null-safety guards during geometry skinning
  * Prevented errors when expected skeleton/user data is absent during head-part processing and single-geometry handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->