### PR TITLE
feat: skip physics for dead actors (perf)

### DIFF
--- a/configs/configs.xml
+++ b/configs/configs.xml
@@ -178,6 +178,15 @@
     -->
     <disable1stPersonViewPhysics>false</disable1stPersonViewPhysics>
 
+    <!-- ################## SKIP DEAD ACTORS ############################## -->
+
+    <!--
+      skipDeadActors: (boolean) if set to true, physics is skipped for dead
+      non-player actors (corpses), to save performance. The player is never
+      affected. If no value is set, default is false.
+    -->
+    <skipDeadActors>false</skipDeadActors>
+
     <!-- ##################### CUDA ####################################### -->
 
     <!--

--- a/configs/configs.xsd
+++ b/configs/configs.xsd
@@ -112,6 +112,11 @@
                   <xs:documentation>disable1stPersonViewPhysics: (boolean) if set to true, the physics of the PC won't be calculated when in 1st person view, to save performance. If no value is set, default is false.</xs:documentation>
                 </xs:annotation>
               </xs:element>
+              <xs:element name="skipDeadActors" type="booleanTextType" minOccurs="0">
+                <xs:annotation>
+                  <xs:documentation>skipDeadActors: (boolean) if set to true, physics is skipped for dead non-player actors (corpses), to save performance. The player is never affected. If no value is set, default is false.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
               <xs:element name="enableCuda" type="booleanTextType" minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>enableCuda: (boolean) experimental GPU collision algorithm. Try this if you have a slow CPU and fast GPU. This setting will be ignored if you haven't installed the CUDA-enabled version. If no value is set, default is false.</xs:documentation>

--- a/fomod tree/configs/configs-compatibility.xml
+++ b/fomod tree/configs/configs-compatibility.xml
@@ -173,7 +173,8 @@
     -->
     <disable1stPersonViewPhysics>false</disable1stPersonViewPhysics>
 
-
+    <!-- skipDeadActors: (boolean) skip physics for dead non-player actors. Default false. -->
+    <skipDeadActors>false</skipDeadActors>
 
   </smp>
   <solver>

--- a/fomod tree/configs/configs-performance.xml
+++ b/fomod tree/configs/configs-performance.xml
@@ -173,7 +173,8 @@
     -->
     <disable1stPersonViewPhysics>true</disable1stPersonViewPhysics>
 
-
+    <!-- skipDeadActors: (boolean) skip physics for dead non-player actors. Default false. -->
+    <skipDeadActors>true</skipDeadActors>
 
   </smp>
   <solver>

--- a/fomod tree/configs/configs-quality.xml
+++ b/fomod tree/configs/configs-quality.xml
@@ -173,7 +173,8 @@
     -->
     <disable1stPersonViewPhysics>true</disable1stPersonViewPhysics>
 
-
+    <!-- skipDeadActors: (boolean) skip physics for dead non-player actors. Default false. -->
+    <skipDeadActors>false</skipDeadActors>
 
   </smp>
   <solver>

--- a/fomod tree/configs/configs-reasonable.xml
+++ b/fomod tree/configs/configs-reasonable.xml
@@ -173,7 +173,8 @@
     -->
     <disable1stPersonViewPhysics>false</disable1stPersonViewPhysics>
 
-
+    <!-- skipDeadActors: (boolean) skip physics for dead non-player actors. Default false. -->
+    <skipDeadActors>false</skipDeadActors>
 
   </smp>
   <solver>

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -430,11 +430,19 @@ namespace hdt
 		activeSkeletons = 0;
 		const float minCullingDistance2 = m_minCullingDistance * m_minCullingDistance;
 		for (auto& i : m_skeletons) {
+			// When enabled, skip physics for dead non-player actors to save performance.
+			bool skipDeadActor = false;
+			if (m_skipDeadActors && !i.isPlayerCharacter()) {
+				const auto actor = skyrim_cast<RE::Actor*>(i.skeletonOwner.get());
+				if (actor && actor->IsDead())
+					skipDeadActor = true;
+			}
+
 			// Skeletons inside the minimum culling distance are kept active even when the budget cap
 			// is exceeded, so a shrinking auto-adjust cap can't strip physics from NPCs next to the camera.
 			const bool forceKeepNear = i.m_distanceFromCamera2 < minCullingDistance2;
 			const bool overBudget = activeSkeletons >= maxActiveSkeletons;
-			if (!i.hasPhysics || !i.updateAttachedState(playerCell, overBudget && !forceKeepNear))
+			if (!i.hasPhysics || !i.updateAttachedState(playerCell, (overBudget && !forceKeepNear) || skipDeadActor))
 				continue;
 
 			activeSkeletons++;

--- a/src/ActorManager.h
+++ b/src/ActorManager.h
@@ -240,6 +240,9 @@ namespace hdt
 		// @brief Depending on this setting, we avoid to calculate the physics of the PC when it is in 1st person view.
 		bool m_disable1stPersonViewPhysics = false;
 
+		// @brief When true, physics is skipped for dead non-player actors, to save performance.
+		bool m_skipDeadActors = false;
+
 	private:
 		RE::NiPoint3 m_cameraPositionDuringFrame;
 		static RE::NiNode* getCameraNode();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -107,6 +107,8 @@ namespace hdt
 					SkyrimPhysicsWorld::get()->m_sampleSize = std::max(reader.readInt(), 1);
 				} else if (reader.GetLocalName() == "disable1stPersonViewPhysics") {
 					ActorManager::instance()->m_disable1stPersonViewPhysics = reader.readBool();
+				} else if (reader.GetLocalName() == "skipDeadActors") {
+					ActorManager::instance()->m_skipDeadActors = reader.readBool();
 				} else {
 					logger::warn("Unknown config : {}", reader.GetLocalName());
 					reader.skipCurrentElement();
@@ -225,6 +227,7 @@ namespace hdt
 		LOG("smp.autoAdjustMaxSkeletons", a->m_autoAdjustMaxSkeletons);
 		LOG("smp.sampleSize", w->m_sampleSize);
 		LOG("smp.disable1stPersonViewPhysics", a->m_disable1stPersonViewPhysics);
+		LOG("smp.skipDeadActors", a->m_skipDeadActors);
 #undef LOG
 	}
 }


### PR DESCRIPTION
Closes #376.

Opt-in performance feature: skip SMP physics for **dead, non-player** actors. Completes the prototype from the retired `protection` branch (which only read the flag in `config.cpp`, with no schema/preset/loop wiring and a stray-brace bug).

## Changes
- **`ActorManager.h`** — `bool m_skipDeadActors = false;`
- **`ActorManager.cpp`** — in the skeleton-activation loop, compute `skipDeadActor` for non-player owners that `IsDead()` and OR it into the `updateAttachedState(...)` deactivate argument (clean, no brace bug; parenthesised for clarity)
- **`config.cpp`** — read `<skipDeadActors>` + add to the settings log
- **`configs/configs.xml`, `configs/configs.xsd`** — documentation + boolean schema element
- **fomod presets** — added the tag; **enabled in `performance`**, disabled in compatibility/quality/reasonable

## Notes
- Player is never affected (`!isPlayerCharacter()` guard).
- Preset default is conservative — only `performance` opts in. Easy to flip `reasonable` to `true` if desired.
- MCM toggle (FSMP-MCM) and wiki docs are tracked separately under the same issue.
- DHDT: assessed as not applicable — this is a global config setting, not a per-actor runtime override.
- Not built locally; relies on CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to skip physics for dead non-player characters. The player character remains unaffected by this setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->