### PR TITLE
refactor: reuse already-found NPC node in head-geometry event

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -219,7 +219,8 @@ namespace hdt
 		fixArmorNameMaps();
 
 		auto& skeleton = getSkeletonData(e->skeleton);
-		skeleton.npc = hdt::make_nismart(getNpcNode(e->skeleton));
+		// Non-lurker here (see above), so getNpcNode() would just re-find this same "NPC" node — reuse it.
+		skeleton.npc = hdt::make_nismart(npc);
 
 		skeleton.processGeometry(e->headNode, e->geometry);
 


### PR DESCRIPTION
## What

In `ActorManager::ProcessEvent(SkinSingleHeadGeometryEvent)`, the handler already locates the skeleton's `"NPC"` node via `findNode` for its null-check, then discarded it and called `getNpcNode()` to re-find the same node:

```cpp
auto npc = findNode(e->skeleton, "NPC");   // used only for the null-check
if (npc == nullptr) return kContinue;
...
skeleton.npc = hdt::make_nismart(getNpcNode(e->skeleton));   // re-finds the same node
```

This change reuses the local `npc` instead:

```cpp
skeleton.npc = hdt::make_nismart(npc);
```

## Why it's safe

`getNpcNode()` only diverges from `findNode(skeleton, "NPC")` for **lurker** skeletons (it returns `"NPC Root [Root]"` in that case). This handler carries a documented invariant — `// This case never happens to a lurker skeleton` — so `getNpcNode()` provably resolves to exactly the `"NPC"` node already in `npc`. The substitution is behaviour-preserving and type-identical (both `findNode` and `getNpcNode` return `RE::NiNode*`).

## Effect

Drops a redundant full skeleton-tree walk plus the per-call lurker detection (`GetUserData` / `skyrim_cast` / `strcmp`) on every head-geometry skinning event.

## Verification

Not yet locally built — relying on CI. Logic is a type-identical variable reuse with no signature or control-flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance by optimizing node processing logic in skeleton geometry handling.
  * Enhanced internal documentation for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->