### PR TITLE
perf: drop setlocale for locale-free XML number parsing (continues #334)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SOURCE_FILES
 	"${SOURCE_DIR}/XmlInspector/XmlInspector.hpp"
 	"${SOURCE_DIR}/XmlReader.h"
 	"${SOURCE_DIR}/XmlReader.cpp"
+	"${SOURCE_DIR}/hdtStringUtils.h"
 	"${SOURCE_DIR}/NetImmerseUtils.h"
 	"${SOURCE_DIR}/Validator/hdtAssetValidator.cpp"
 	"${SOURCE_DIR}/Validator/hdtAssetValidator.h"

--- a/src/Validator/Utils/hdtStringUtils.h
+++ b/src/Validator/Utils/hdtStringUtils.h
@@ -1,45 +1,18 @@
 #pragma once
 
+// Domain-specific string helpers for the Validator (XSD/XPath, asset paths, NIF,
+// validation messages). General-purpose string/path helpers live one level up in
+// src/hdtStringUtils.h, included below so existing consumers keep seeing them.
+#include "../../hdtStringUtils.h"
+
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
 #include <string>
-#include <unordered_set>
-#include <vector>
+#include <utility>
 
 namespace hdt
 {
-	// Replace every non-overlapping occurrence of `from` in `s` with `to` in place.
-	inline void ReplaceAllInPlace(std::string& s, const std::string& from, const std::string& to)
-	{
-		if (from.empty())
-			return;
-		size_t pos = 0;
-		while ((pos = s.find(from, pos)) != std::string::npos) {
-			s.replace(pos, from.size(), to);
-			pos += to.size();
-		}
-	}
-
-	// Convert a std::filesystem::path to a UTF-8 std::string.
-	// generic_u8string() returns char8_t data; reinterpret_cast is required to
-	// produce a plain std::string without an explicit loop or locale dependency.
-	inline std::string PathToUtf8(const std::filesystem::path& fp)
-	{
-		auto u8 = fp.generic_u8string();
-		return { reinterpret_cast<const char*>(u8.data()), u8.size() };
-	}
-
-	// Trim ASCII whitespace from both ends of a string.
-	inline std::string TrimAsciiWhitespace(const std::string& s)
-	{
-		auto start = s.find_first_not_of(" \t\r\n");
-		if (start == std::string::npos)
-			return "";
-		auto end = s.find_last_not_of(" \t\r\n");
-		return s.substr(start, end - start + 1);
-	}
-
 	// Strip a namespace prefix token (prefix + ':') from an XPath expression when
 	// it appears on XPath boundaries, avoiding false positives inside literals.
 	inline std::string StripNamespacePrefix(const std::string& expr, const std::string& prefix)
@@ -68,30 +41,6 @@ namespace hdt
 			result += expr[i++];
 		}
 		return result;
-	}
-
-	// Build a sorted, comma-separated string from a set of strings.
-	inline std::string JoinSortedSet(const std::unordered_set<std::string>& values)
-	{
-		std::vector<std::string> sorted(values.begin(), values.end());
-		std::sort(sorted.begin(), sorted.end());
-		std::string result;
-		for (const auto& value : sorted) {
-			if (!result.empty())
-				result += ", ";
-			result += value;
-		}
-		return result;
-	}
-
-	// Normalize a filesystem-like path string for case-insensitive comparisons.
-	// Converts backslashes to forward slashes and lowercases all characters.
-	inline std::string NormalizePathForComparison(std::string path)
-	{
-		std::transform(path.begin(), path.end(), path.begin(), [](unsigned char c) {
-			return c == '\\' ? '/' : static_cast<char>(std::tolower(c));
-		});
-		return path;
 	}
 
 	// Strip the leading "data/" prefix using case-insensitive matching.

--- a/src/XmlReader.cpp
+++ b/src/XmlReader.cpp
@@ -1,12 +1,14 @@
 #include "XmlReader.h"
+#include "Validator/Utils/hdtStringUtils.h"
 #include <charconv>
 
 namespace hdt
 {
 	static inline float convertFloat(const std::string& str)
 	{
-		// Replace decimal comma with point
-		std::string s = str;
+		// Trim first (from_chars rejects surrounding spaces), then turn a decimal
+		// comma into a point so locale-independent parsing still accepts it.
+		std::string s = TrimAsciiWhitespace(str);
 		size_t start_pos = s.find(",");
 		if (start_pos != std::string::npos)
 			s.replace(start_pos, 1, ".");
@@ -14,6 +16,9 @@ namespace hdt
 		float ret{};
 		const char* begin = s.data();
 		const char* end = begin + s.size();
+		// strtof accepted a leading '+'; from_chars doesn't, so skip it.
+		if (begin != end && *begin == '+')
+			++begin;
 		auto [ptr, ec] = std::from_chars(begin, end, ret);
 		if (ec != std::errc() || ptr != end)
 			throw std::string("not a float value");
@@ -22,14 +27,18 @@ namespace hdt
 
 	static inline int convertInt(const std::string& str)
 	{
-		const char* begin = str.data();
-		const char* end = begin + str.size();
+		// Trim first: from_chars rejects surrounding spaces and a leading '+'.
+		std::string s = TrimAsciiWhitespace(str);
+		const char* begin = s.data();
+		const char* end = begin + s.size();
+		if (begin != end && *begin == '+')
+			++begin;
 
 		int radix = 10;
-		if (!str.compare(0, 2, "0x")) {
+		if (!s.compare(0, 2, "0x")) {
 			radix = 16;
 			begin += 2;
-		} else if (str.length() > 1 && str[0] == '0') {
+		} else if (s.length() > 1 && s[0] == '0') {
 			begin += 1;
 			radix = 8;
 		}
@@ -43,9 +52,10 @@ namespace hdt
 
 	static inline bool convertBool(const std::string& str)
 	{
-		if (str == "true" || str == "1")
+		const std::string s = TrimAsciiWhitespace(str);
+		if (s == "true" || s == "1")
 			return true;
-		if (str == "false" || str == "0")
+		if (s == "false" || s == "0")
 			return false;
 		throw std::string("not a boolean");
 	}

--- a/src/XmlReader.cpp
+++ b/src/XmlReader.cpp
@@ -1,4 +1,5 @@
 #include "XmlReader.h"
+#include <charconv>
 
 namespace hdt
 {
@@ -10,17 +11,19 @@ namespace hdt
 		if (start_pos != std::string::npos)
 			s.replace(start_pos, 1, ".");
 
-		errno = 0;  // Reinitializing the error global variable (thread-safe)
-		float ret = strtof(s.c_str(), nullptr);
-		if (errno != 0)  // Checking if there has been an error
+		float ret{};
+		const char* begin = s.data();
+		const char* end = begin + s.size();
+		auto [ptr, ec] = std::from_chars(begin, end, ret);
+		if (ec != std::errc() || ptr != end)
 			throw std::string("not a float value");
 		return ret;
 	}
 
 	static inline int convertInt(const std::string& str)
 	{
-		auto begin = str.c_str();
-		char* end;
+		const char* begin = str.data();
+		const char* end = begin + str.size();
 
 		int radix = 10;
 		if (!str.compare(0, 2, "0x")) {
@@ -31,8 +34,9 @@ namespace hdt
 			radix = 8;
 		}
 
-		int ret = strtol(str.c_str(), &end, radix);
-		if (end != str.c_str() + str.length())
+		int ret{};
+		auto [ptr, ec] = std::from_chars(begin, end, ret, radix);
+		if (ec != std::errc() || ptr != end)
 			throw std::string("not a int value");
 		return ret;
 	}

--- a/src/XmlReader.cpp
+++ b/src/XmlReader.cpp
@@ -1,5 +1,5 @@
 #include "XmlReader.h"
-#include "Validator/Utils/hdtStringUtils.h"
+#include "hdtStringUtils.h"
 #include <charconv>
 
 namespace hdt

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -169,13 +169,6 @@ namespace hdt
 			return;
 		}
 
-		// Store original locale
-		char saved_locale[32];
-		strcpy_s(saved_locale, std::setlocale(LC_NUMERIC, nullptr));
-
-		// Set locale to en_US
-		std::setlocale(LC_NUMERIC, "en_US");
-
 		XMLReader reader((uint8_t*)bytes.data(), bytes.size());
 
 		while (reader.Inspect()) {
@@ -188,9 +181,6 @@ namespace hdt
 				}
 			}
 		}
-
-		// Restore original locale
-		std::setlocale(LC_NUMERIC, saved_locale);
 	}
 
 	void logConfig()

--- a/src/hdtDefaultBBP.cpp
+++ b/src/hdtDefaultBBP.cpp
@@ -36,13 +36,6 @@ namespace hdt
 		if (loaded.empty())
 			return;
 
-		// Store original locale
-		char saved_locale[32];
-		strcpy_s(saved_locale, std::setlocale(LC_NUMERIC, nullptr));
-
-		// Set locale to en_US
-		std::setlocale(LC_NUMERIC, "en_US");
-
 		XMLReader reader((uint8_t*)loaded.data(), loaded.size());
 
 		reader.nextStartElement();
@@ -93,8 +86,6 @@ namespace hdt
 			}
 		}
 
-		// Restore original locale
-		std::setlocale(LC_NUMERIC, saved_locale);
 	}
 
 	DefaultBBP::PhysicsFile_t DefaultBBP::scanDefaultBBP(RE::NiNode* armor)

--- a/src/hdtDefaultBBP.cpp
+++ b/src/hdtDefaultBBP.cpp
@@ -85,7 +85,6 @@ namespace hdt
 				break;
 			}
 		}
-
 	}
 
 	DefaultBBP::PhysicsFile_t DefaultBBP::scanDefaultBBP(RE::NiNode* armor)

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -228,13 +228,6 @@ namespace hdt
 		m_mesh = RE::make_smart<SkyrimSystem>(skeleton);
 		m_boneIndex.clear();
 
-		// Store original locale
-		char saved_locale[32];
-		strcpy_s(saved_locale, std::setlocale(LC_NUMERIC, nullptr));
-
-		// Set locale to en_US
-		std::setlocale(LC_NUMERIC, "en_US");
-
 		// This forces the skeleton into a neutral reference pose, which avoids building invalid shape data
 		// We pull the references directly from havok for the exact same reference data the engine uses
 		std::vector<std::pair<RE::NiAVObject*, RE::NiTransform>> savedPoses;
@@ -360,9 +353,6 @@ namespace hdt
 		}
 
 		m_deferredBuilds.clear();
-
-		// Restore original locale
-		std::setlocale(LC_NUMERIC, saved_locale);
 
 		if (m_reader->GetErrorCode() != Xml::ErrorCode::None) {
 			logger::error("xml parse error - {}", m_reader->GetErrorMessage());

--- a/src/hdtStringUtils.h
+++ b/src/hdtStringUtils.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+// General-purpose string and path helpers shared across the whole plugin (runtime
+// XML parsing and the Validator alike). Domain-specific helpers (XSD/XPath/NIF/
+// validation messages) live in Validator/Utils/hdtStringUtils.h instead.
+namespace hdt
+{
+	// Replace every non-overlapping occurrence of `from` in `s` with `to` in place.
+	inline void ReplaceAllInPlace(std::string& s, const std::string& from, const std::string& to)
+	{
+		if (from.empty())
+			return;
+		size_t pos = 0;
+		while ((pos = s.find(from, pos)) != std::string::npos) {
+			s.replace(pos, from.size(), to);
+			pos += to.size();
+		}
+	}
+
+	// Convert a std::filesystem::path to a UTF-8 std::string.
+	// generic_u8string() returns char8_t data; reinterpret_cast is required to
+	// produce a plain std::string without an explicit loop or locale dependency.
+	inline std::string PathToUtf8(const std::filesystem::path& fp)
+	{
+		auto u8 = fp.generic_u8string();
+		return { reinterpret_cast<const char*>(u8.data()), u8.size() };
+	}
+
+	// Trim ASCII whitespace from both ends of a string.
+	inline std::string TrimAsciiWhitespace(const std::string& s)
+	{
+		auto start = s.find_first_not_of(" \t\r\n");
+		if (start == std::string::npos)
+			return "";
+		auto end = s.find_last_not_of(" \t\r\n");
+		return s.substr(start, end - start + 1);
+	}
+
+	// Build a sorted, comma-separated string from a set of strings.
+	inline std::string JoinSortedSet(const std::unordered_set<std::string>& values)
+	{
+		std::vector<std::string> sorted(values.begin(), values.end());
+		std::sort(sorted.begin(), sorted.end());
+		std::string result;
+		for (const auto& value : sorted) {
+			if (!result.empty())
+				result += ", ";
+			result += value;
+		}
+		return result;
+	}
+
+	// Normalize a filesystem-like path string for case-insensitive comparisons.
+	// Converts backslashes to forward slashes and lowercases all characters.
+	inline std::string NormalizePathForComparison(std::string path)
+	{
+		std::transform(path.begin(), path.end(), path.begin(), [](unsigned char c) {
+			return c == '\\' ? '/' : static_cast<char>(std::tolower(c));
+		});
+		return path;
+	}
+}  // namespace hdt


### PR DESCRIPTION
Continues @SimplisticMind's #334 (rebased onto current `dev`) and adds input-tolerance hardening plus a small layering cleanup.

## Why
`std::setlocale(LC_NUMERIC, ...)` permanently flips MSVC's CRT onto a slow locale-aware path — even after restoring the locale — making `_stricmp_l` and friends far slower for the rest of the process. Original report: time in `_stricmp_l` on a loading-screen bench dropped **4950 ms → 30 ms**. The four save/set/restore blocks are removed and the two number parsers switched to locale-independent `std::from_chars`. As a bonus this removes a latent global-state data race (`setlocale` mutates process-wide state from a load path).

## Hardening added on top of #334
`std::from_chars` is stricter than the `strtof`/`strtol` it replaces: it rejects leading/trailing whitespace and a leading `+`. XML values arrive **untrimmed** from the parser, and a single throw aborts the *entire* physics build (`catch` → `return nullptr`), so a stray space could silently kill physics for a mesh. This branch:

- routes `convertFloat`/`convertInt`/`convertBool` through `hdt::TrimAsciiWhitespace` (reused, not duplicated);
- skips a single leading `+` in both numeric parsers (strtof/strtol accepted it);
- keeps the true-garbage rejection that #334 introduced (improvement over the old silent `0.0`).

`convertBool` now also tolerates surrounding whitespace, which it never did before.

## Layering cleanup
`TrimAsciiWhitespace` lived under `Validator/Utils/` but is now used by runtime `XmlReader`. The general-purpose helpers (`TrimAsciiWhitespace`, `ReplaceAllInPlace`, `PathToUtf8`, `NormalizePathForComparison`, `JoinSortedSet`) move to a top-level `src/hdtStringUtils.h`; the Validator header keeps its domain helpers (XSD/XPath/NIF/validation) and includes the general one, so its five consumers are untouched. Separate `refactor:` commit.

## Notes
- Rebased cleanly onto current `dev` (no conflicts); supersedes #334 — close that one if this lands.
- **Built locally with the v143 toolset** (VS2022, MSVC 14.44, avx2 Release) after each change — clean, **zero errors and zero warnings under `/W4 /WX`** (all six affected TUs recompiled). #334 was untested on v143; this confirms it compiles there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * XML configuration and related parsing now validates numeric and boolean values more strictly, with whitespace trimming, decimal comma normalization, optional leading `+`, and full-string consumption checks.
  * Removed locale switching side effects during XML numeric parsing to improve cross-platform consistency.

* **Code & Build Improvements**
  * Introduced shared string/path utility helpers and updated validator utilities to reuse them, reducing duplicate implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->