### PR TITLE
chore: point nifly submodule at upstream ousnius/nifly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	branch = ng
 [submodule "extern/nifly"]
 	path = extern/nifly
-	url = https://github.com/DaymareOn/nifly.git
+	url = https://github.com/ousnius/nifly.git


### PR DESCRIPTION
## What

Switch the `extern/nifly` submodule URL from the `DaymareOn/nifly` fork to upstream `ousnius/nifly`.

## Why

The fork is a byte-for-byte mirror of upstream with **zero** divergent commits — the pinned SHA `8e98192` ("Migrate tests and CI to Catch2 v3") is the current tip of `ousnius/nifly` main. Verified:

- `ousnius/nifly main..8e98192` → empty (fork adds nothing)
- `8e98192..ousnius/nifly main` → empty (fork misses nothing)

A submodule already pins an exact commit, so tracking upstream directly moves nothing silently. The fork only added a second repo to keep in sync for no functional gain. (If a future nifly-migration phase needs custom patches, a fork can be reintroduced then.)

## Impact

URL-only change. The pinned commit is unchanged, so the checked-out tree is identical — no build or behavior difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external dependency source configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->