### PR TITLE
feat: screen-size culling for non-player skeletons (minScreenSizePercent)

### DIFF
--- a/configs/configs.xml
+++ b/configs/configs.xml
@@ -187,6 +187,17 @@
     -->
     <skipDeadActors>false</skipDeadActors>
 
+    <!-- ################## SCREEN SIZE CULLING ########################### -->
+
+    <!--
+      minScreenSizePercent: (float 0-100) physics is skipped for non-player skeletons
+      whose bounding sphere, projected onto the screen, is smaller than this percentage
+      of the screen height. For example, 2 skips skeletons that appear smaller than
+      2% of screen height. The player is never affected. 0 disables the check.
+      If no value is set, default is 0 (disabled).
+    -->
+    <minScreenSizePercent>0</minScreenSizePercent>
+
     <!-- ##################### CUDA ####################################### -->
 
     <!--

--- a/configs/configs.xsd
+++ b/configs/configs.xsd
@@ -117,6 +117,17 @@
                   <xs:documentation>skipDeadActors: (boolean) if set to true, physics is skipped for dead non-player actors (corpses), to save performance. The player is never affected. If no value is set, default is false.</xs:documentation>
                 </xs:annotation>
               </xs:element>
+              <xs:element name="minScreenSizePercent" minOccurs="0">
+                <xs:annotation>
+                  <xs:documentation>minScreenSizePercent: (float 0-100) physics is skipped for non-player skeletons whose bounding sphere, projected onto the screen, is smaller than this percentage of the screen height. The player is never affected. 0 disables the check. If no value is set, default is 0 (disabled).</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                  <xs:restriction base="xs:float">
+                    <xs:minInclusive value="0"/>
+                    <xs:maxInclusive value="100"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
               <xs:element name="enableCuda" type="booleanTextType" minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>enableCuda: (boolean) experimental GPU collision algorithm. Try this if you have a slow CPU and fast GPU. This setting will be ignored if you haven't installed the CUDA-enabled version. If no value is set, default is false.</xs:documentation>

--- a/fomod tree/configs/configs-compatibility.xml
+++ b/fomod tree/configs/configs-compatibility.xml
@@ -176,6 +176,9 @@
     <!-- skipDeadActors: (boolean) skip physics for dead non-player actors. Default false. -->
     <skipDeadActors>false</skipDeadActors>
 
+    <!-- minScreenSizePercent: (float 0-100) skip non-player skeletons smaller than this percent of screen height. Default 0 (off). -->
+    <minScreenSizePercent>0</minScreenSizePercent>
+
   </smp>
   <solver>
 

--- a/fomod tree/configs/configs-performance.xml
+++ b/fomod tree/configs/configs-performance.xml
@@ -176,6 +176,9 @@
     <!-- skipDeadActors: (boolean) skip physics for dead non-player actors. Default false. -->
     <skipDeadActors>true</skipDeadActors>
 
+    <!-- minScreenSizePercent: (float 0-100) skip non-player skeletons smaller than this percent of screen height. Default 0 (off). -->
+    <minScreenSizePercent>2.5</minScreenSizePercent>
+
   </smp>
   <solver>
 

--- a/fomod tree/configs/configs-quality.xml
+++ b/fomod tree/configs/configs-quality.xml
@@ -176,6 +176,9 @@
     <!-- skipDeadActors: (boolean) skip physics for dead non-player actors. Default false. -->
     <skipDeadActors>false</skipDeadActors>
 
+    <!-- minScreenSizePercent: (float 0-100) skip non-player skeletons smaller than this percent of screen height. Default 0 (off). -->
+    <minScreenSizePercent>0</minScreenSizePercent>
+
   </smp>
   <solver>
 

--- a/fomod tree/configs/configs-reasonable.xml
+++ b/fomod tree/configs/configs-reasonable.xml
@@ -176,6 +176,9 @@
     <!-- skipDeadActors: (boolean) skip physics for dead non-player actors. Default false. -->
     <skipDeadActors>false</skipDeadActors>
 
+    <!-- minScreenSizePercent: (float 0-100) skip non-player skeletons smaller than this percent of screen height. Default 0 (off). -->
+    <minScreenSizePercent>1.5</minScreenSizePercent>
+
   </smp>
   <solver>
 

--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -396,6 +396,19 @@ namespace hdt
 		const auto cameraOrientation = cameraTransform.rotate * RE::NiPoint3(0., 1., 0.);  // The camera matrix is relative to the world.
 		m_cameraPositionDuringFrame = cameraPosition;
 
+		// Precompute the screen-size threshold for this frame from the scene FOV (0 = feature disabled).
+		m_screenSizeThresholdScale = 0.f;
+		if (m_minScreenSizePercent > 0.f) {
+			if (auto* worldSceneGraph = RE::DrawWorld::GetSingleton().worldSceneGraph) {
+				const float cameraFOVDegrees = static_cast<RE::BSSceneGraph*>(worldSceneGraph)->GetRuntimeData().cameraFOV;
+				if (cameraFOVDegrees > 0.f && cameraFOVDegrees < 180.f) {
+					const float tanHalfFOV = std::tan(cameraFOVDegrees * std::numbers::pi_v<float> / 360.f);
+					const float fraction = m_minScreenSizePercent * 0.01f;  // percent -> fraction of screen height
+					m_screenSizeThresholdScale = fraction * fraction * tanHalfFOV * tanHalfFOV;
+				}
+			}
+		}
+
 		for (auto& skel : m_skeletons)
 			skel.calculateDistanceAndOrientationDifferenceFromSource(cameraPosition, cameraOrientation);
 
@@ -1056,6 +1069,21 @@ namespace hdt
 
 		if (!skeleton3D || (camera && !camera->NodeInFrustum(skeleton3D)))
 			return false;
+
+		// Skip non-player skeletons whose projected bounding sphere is below the screen-size threshold.
+		// screenFraction < minFraction <=> r / (distance * tan(fov/2)) < fr <=> r^2 < fr^2 * distance^2 * tan(fov/2)^2
+		if (manager->m_screenSizeThresholdScale > 0.f) {
+			const auto& bound = skeleton3D->worldBound;
+			const auto cameraToBound = bound.center - manager->m_cameraPositionDuringFrame;
+			const float distanceToBound2 = cameraToBound.x * cameraToBound.x + cameraToBound.y * cameraToBound.y + cameraToBound.z * cameraToBound.z;
+
+			if (distanceToBound2 > bound.radius * bound.radius) {
+				// Use the nearest point on the sphere for a conservative size estimate.
+				const float visibleDistance = std::sqrt(distanceToBound2) - bound.radius;
+				if (bound.radius * bound.radius < manager->m_screenSizeThresholdScale * visibleDistance * visibleDistance)
+					return false;
+			}
+		}
 
 		RE::NiPoint3 hitLocation;
 		auto* obstacle = Actor_CalculateLOS(owner, &manager->m_cameraPositionDuringFrame, &hitLocation, 6.28f);

--- a/src/ActorManager.h
+++ b/src/ActorManager.h
@@ -243,8 +243,12 @@ namespace hdt
 		// @brief When true, physics is skipped for dead non-player actors, to save performance.
 		bool m_skipDeadActors = false;
 
+		// @brief Min percent of screen height a non-player skeleton must occupy to stay active; 0 = disabled. [0,100]
+		float m_minScreenSizePercent = 0.f;
+
 	private:
 		RE::NiPoint3 m_cameraPositionDuringFrame;
+		float m_screenSizeThresholdScale = 0.f;  // precomputed per frame: (minScreenSizePercent/100)^2 * tan(fov/2)^2
 		static RE::NiNode* getCameraNode();
 
 		void setSkeletonsActive(const bool updateMetrics = false);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -109,6 +109,8 @@ namespace hdt
 					ActorManager::instance()->m_disable1stPersonViewPhysics = reader.readBool();
 				} else if (reader.GetLocalName() == "skipDeadActors") {
 					ActorManager::instance()->m_skipDeadActors = reader.readBool();
+				} else if (reader.GetLocalName() == "minScreenSizePercent") {
+					ActorManager::instance()->m_minScreenSizePercent = std::clamp(reader.readFloat(), 0.f, 100.f);
 				} else {
 					logger::warn("Unknown config : {}", reader.GetLocalName());
 					reader.skipCurrentElement();
@@ -228,6 +230,7 @@ namespace hdt
 		LOG("smp.sampleSize", w->m_sampleSize);
 		LOG("smp.disable1stPersonViewPhysics", a->m_disable1stPersonViewPhysics);
 		LOG("smp.skipDeadActors", a->m_skipDeadActors);
+		LOG("smp.minScreenSizePercent", a->m_minScreenSizePercent);
 #undef LOG
 	}
 }


### PR DESCRIPTION
Closes #379.

Skip SMP physics for **non-player** NPCs whose projected bounding sphere is below `minScreenSizePercent` of screen height (FOV-aware). 0 disables it; the player is never affected. Ported from the retired `protection` branch (`6596e6e`/`e3c8a8c`/`b377fdc`); the crude `maxPhysicsDistance` alternative is intentionally excluded.

## Changes
- **`ActorManager.h/.cpp`** — per-frame threshold from scene FOV (`(percent/100)² · tan(fov/2)²`); screen-size test in `isInPlayerView` after the frustum check (nearest-point estimate)
- **`config.cpp`** — read `<minScreenSizePercent>` (clamped [0,100]) + log
- **`configs.xml`/`.xsd`** — docs + schema (float 0–100)
- **fomod presets** — Performance 2.5, Reasonable 1.5, others 0

## Notes
- Value is a **percentage** of screen height (0–100), not a 0–1 fraction.
- Built locally (avx2 Release) and tested in-game via FSMP-dev.
- MCM slider companion: FSMP-MCM (separate PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added screen-size culling for non-player skeleton physics. The new `minScreenSizePercent` configuration parameter (0–100%) allows skipping physics calculations for skeletons when their projected on-screen size falls below the configured threshold. Disabled by default (0%). Multiple preset configurations provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->