### PR TITLE
refactor: migrate REL::VariantID to RELOCATION_ID for VR-safe addressing

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -16,10 +16,10 @@ namespace hdt
 	typedef RE::NiStream* (*_NiStream_constructor)(RE::NiStream*);
 	typedef RE::NiStream* (*_NiStream_deconstructor)(RE::NiStream*);
 
-	REL::Relocation<_Actor_CalculateLOS> Actor_CalculateLOS{ REL::VariantID(36754, 37770, 0x0605B10) };          // 0x5FD2C0
-	REL::Relocation<_TESNPC_GetFaceGeomPath> TESNPC_GetFaceGeomPath{ REL::VariantID(24222, 24726, 0x0372B30) };  // 0x363210
-	REL::Relocation<_NiStream_constructor> NiStream_constructor{ REL::VariantID(68971, 70324, 0x0C9EC40) };      // 0xC59690
-	REL::Relocation<_NiStream_deconstructor> NiStream_deconstructor{ REL::VariantID(68972, 70325, 0x0C9EEA0) };  // 0xC598F0
+	REL::Relocation<_Actor_CalculateLOS> Actor_CalculateLOS{ RELOCATION_ID(36754, 37770) };          // SE 0x5FD2C0, VR id-mapped
+	REL::Relocation<_TESNPC_GetFaceGeomPath> TESNPC_GetFaceGeomPath{ RELOCATION_ID(24222, 24726) };  // SE 0x363210, VR id-mapped
+	REL::Relocation<_NiStream_constructor> NiStream_constructor{ RELOCATION_ID(68971, 70324) };      // SE 0xC59690, VR id-mapped
+	REL::Relocation<_NiStream_deconstructor> NiStream_deconstructor{ RELOCATION_ID(68972, 70325) };  // SE 0xC598F0, VR id-mapped
 
 	static bool IsHair(RE::TESBoundObject* a_ref)
 	{

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -350,7 +350,7 @@ namespace Hooks
 
 	void BSFaceGenNiNodeHooks::HookSetBoneName()
 	{
-		static REL::Relocation<uintptr_t> addr{ REL::VariantID(26303, 26886, 0x3E44E0) };
+		static REL::Relocation<uintptr_t> addr{ RELOCATION_ID(26303, 26886) };
 		_SetBoneName = reinterpret_cast<SetBoneName_t*>(addr.address());
 		DetourAttach((PVOID*)&_SetBoneName, (PVOID)SetBoneName_Hook);
 	}

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -11,7 +11,7 @@ namespace Hooks
 
 		static void Hook()
 		{
-			REL::Relocation<uintptr_t> SkinSingleGeometryCode1{ REL::VariantID(26466, 27061, 0x03EBB30), REL::VariantOffset(0x108, 0x10F, 0x108) };  // 0x03dc1c0, 0x03F6770, 0x03EBB30 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
+			REL::Relocation<uintptr_t> SkinSingleGeometryCode1{ RELOCATION_ID(26466, 27061), REL::VariantOffset(0x108, 0x10F, 0x108) };  // 0x03dc1c0, 0x03F6770, 0x03EBB30 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
 
 			//
 			auto& trampoline = SKSE::GetTrampoline();
@@ -89,8 +89,8 @@ namespace Hooks
 	public:
 		static void Hook()
 		{
-			REL::Relocation<uintptr_t> UpdateHook1{ REL::VariantID(35551, 36544, 0x05B6D70), REL::VariantOffset(0x11F, 0x160, 0x11F) };  // 0x05AF3D0, 0x05E7EE0, 0x05B6D70 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
-			REL::Relocation<uintptr_t> UpdateHook2{ REL::VariantID(35565, 36564, 0x05BAB10), REL::VariantOffset(0x56D, 0x9DC, 0x611) };  // 0x05B2FF0, 0x05EC240, 0x05BAB10 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
+			REL::Relocation<uintptr_t> UpdateHook1{ RELOCATION_ID(35551, 36544), REL::VariantOffset(0x11F, 0x160, 0x11F) };  // 0x05AF3D0, 0x05E7EE0, 0x05B6D70 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
+			REL::Relocation<uintptr_t> UpdateHook2{ RELOCATION_ID(35565, 36564), REL::VariantOffset(0x56D, 0x9DC, 0x611) };  // 0x05B2FF0, 0x05EC240, 0x05BAB10 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
 
 			logger::debug("Applying MainHooks hooks!");
 
@@ -137,7 +137,7 @@ namespace Hooks
 		using func_t = decltype(func);
 
 	private:
-		static inline func_t* _func{ (func_t*)REL::VariantID(37945, 38901, 0x06411A0).address() };  // 0x0638190, 0x0670210, 0x06411A0 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
+		static inline func_t* _func{ (func_t*)RELOCATION_ID(37945, 38901).address() };  // 0x0638190, 0x0670210, 0x06411A0 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
 	};
 
 	class BipedAnimHooks
@@ -163,7 +163,7 @@ namespace Hooks
 		using func_t = decltype(func);
 
 	private:
-		static inline func_t* _func{ (func_t*)REL::VariantID(15535, 15712, 0x01DB9E0).address() };  // 0x01CAFB0, 0x01D83B0, 0x01DB9E0 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
+		static inline func_t* _func{ (func_t*)RELOCATION_ID(15535, 15712).address() };  // 0x01CAFB0, 0x01D83B0, 0x01DB9E0 (SE/1.5.97.0, AE/1.6.640.0, VR/1.4.15.0)
 	};
 
 	// Intended for hooks that may get drowned out by other mods.


### PR DESCRIPTION
## What

Replaces every remaining `REL::VariantID(se, ae, vrOffset)` with `RELOCATION_ID(se, ae)`.

## Why

Per @Alandtse (VR maintainer): `VariantID` should not be used. On VR it returns the hardcoded `vrOffset` **verbatim**, with no address-library lookup ([ID.h](extern/CommonLibSSE/include/REL/ID.h) `VariantID::offset()` → `return _vrOffset`). A wrong or missing offset then **crashes silently**.

`RELOCATION_ID(se, ae)` sets `_vrID = seID` and resolves it through the VR address library (`id2offset`). A missing id **fails loudly at load** instead of jumping to a bad address.

## Changes

| File | Relocations converted |
|---|---|
| `ActorManager.cpp` | `Actor_CalculateLOS`, `TESNPC_GetFaceGeomPath`, `NiStream_constructor`, `NiStream_deconstructor` |
| `Hooks.h` | `SkinSingleGeometryCode1`, `UpdateHook1`, `UpdateHook2`, `ActorEquipManagerHooks::_func`, `BipedAnimHooks::_func` |
| `Hooks.cpp` | `HookSetBoneName` SetBoneName address |

`REL::VariantOffset` is kept where present (it's a per-runtime byte offset, not an address lookup). Address-documenting comments are retained.

The `GeometrySkinningBoneFix` relocation in `ApplyBoneLimitFix` is converted separately in #383 to avoid a merge conflict.

## Verification

- Builds clean (`user-vs2022-windows-avx2`, SE+AE+VR enabled): `Hooks.cpp` + `ActorManager.cpp` recompile, `hdtsmp64.dll` links, zero errors/warnings beyond the pre-existing `/Ob3` notices.
- **SE/AE**: address resolution unchanged (same ids).
- **VR**: resolution now goes through the address library. I could not exercise the VR runtime locally — this should be smoke-tested on VR before merge. If any SE id is absent from the VR address library it will now fail loudly at load (the intended, safer behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)