### PR TITLE
Single-package delivery: runtime CPU auto-selecting loader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,9 @@ jobs:
         shell: pwsh
         run: |
           $BuildInfo = "${{ needs.prepare.outputs.build_info }}"
-          $DllPath = "out/build/${{ matrix.preset }}/plugins/SKSE/Plugins/hdtSMP64.dll"
+          # Variants now build as hdtSMP64_<variant>.dll under the FSMP subfolder; the bare
+          # hdtSMP64.dll is the loader stub (built only by the no-AVX preset).
+          $DllPath = "out/build/${{ matrix.preset }}/plugins/SKSE/Plugins/FSMP/hdtSMP64_${{ matrix.avx_variant }}.dll"
           $bytes = [System.IO.File]::ReadAllBytes($DllPath)
           $text = [System.Text.Encoding]::UTF8.GetString($bytes)
           if ($text.Contains($BuildInfo)) {
@@ -200,7 +202,7 @@ jobs:
         shell: pwsh
         run: |
           $Variant = "${{ matrix.avx_variant }}"
-          $DllPath = "out/build/${{ matrix.preset }}/plugins/SKSE/Plugins/hdtSMP64.dll"
+          $DllPath = "out/build/${{ matrix.preset }}/plugins/SKSE/Plugins/FSMP/hdtSMP64_${{ matrix.avx_variant }}.dll"
           $ProductVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($DllPath).ProductVersion
           if ($ProductVersion -match [regex]::Escape("($Variant)")) {
             Write-Host "AVX VARIANT VERIFIED: ProductVersion '$ProductVersion' contains '($Variant)'"
@@ -208,6 +210,18 @@ jobs:
             Write-Error "AVX VARIANT MISSING: ProductVersion '$ProductVersion' does not contain '($Variant)' in $DllPath"
             exit 1
           }
+
+      - name: Verify loader stub built (no-AVX preset only)
+        if: matrix.avx_variant == 'noavx'
+        shell: pwsh
+        run: |
+          # The no-AVX configure additionally produces the loader (hdtSMP64.dll) and ships the
+          # default override INI. These are bundled into every install regardless of CPU.
+          $LoaderDll = "out/build/${{ matrix.preset }}/plugins/SKSE/Plugins/hdtSMP64.dll"
+          $LoaderIni = "out/build/${{ matrix.preset }}/plugins/SKSE/Plugins/hdtSMP64_loader.ini"
+          if (!(Test-Path $LoaderDll)) { Write-Error "LOADER MISSING: $LoaderDll not built"; exit 1 }
+          if (!(Test-Path $LoaderIni)) { Write-Error "LOADER INI MISSING: $LoaderIni not present"; exit 1 }
+          Write-Host "LOADER VERIFIED: $LoaderDll and default INI present"
 
       - name: Upload the build folder
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,8 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 add_subdirectory(src)
 
-# The CPU-auto-selecting loader stub. Added after src/ so the CommonLibSSE target it links already
-# exists. It builds only in the no-AVX configure (guarded inside loader/CMakeLists.txt).
+# The CPU-auto-selecting loader stub. Added after src/ so the CommonLibSSE target it links already exists. It builds
+# only in the no-AVX configure (guarded inside loader/CMakeLists.txt).
 add_subdirectory(loader)
 
 include(cmake/packaging.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,4 +39,9 @@ add_definitions(-DBT_USE_SSE_IN_API)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 add_subdirectory(src)
+
+# The CPU-auto-selecting loader stub. Added after src/ so the CommonLibSSE target it links already
+# exists. It builds only in the no-AVX configure (guarded inside loader/CMakeLists.txt).
+add_subdirectory(loader)
+
 include(cmake/packaging.cmake)

--- a/fomod tree/fomod/ModuleConfig.xml
+++ b/fomod tree/fomod/ModuleConfig.xml
@@ -9,6 +9,14 @@
 		<folder source="Scripts" destination="Scripts" priority="1" />
 		<folder source="SKSE" destination="SKSE" priority="1" />
 		<folder source="Source" destination="Source" priority="1" />
+		<!-- The CPU auto-selecting loader picks the right build at runtime, so all variants are
+		     always installed and the user no longer chooses one. raw-vs2022-windows additionally
+		     carries the loader stub (hdtSMP64.dll) and its default INI; the others contribute only
+		     their hdtSMP64_<variant>.dll under SKSE/Plugins/FSMP/. The folders merge into SKSE. -->
+		<folder source="raw-vs2022-windows\SKSE" destination="SKSE" priority="0" />
+		<folder source="raw-vs2022-windows-avx\SKSE" destination="SKSE" priority="0" />
+		<folder source="raw-vs2022-windows-avx2\SKSE" destination="SKSE" priority="0" />
+		<folder source="raw-vs2022-windows-avx512\SKSE" destination="SKSE" priority="0" />
 	</requiredInstallFiles>
 	<installSteps order="Explicit">
 		<installStep name="Introduction">
@@ -49,69 +57,23 @@ Current active developers at the time of this writing, ordered by date of involv
 				</group>
 			</optionalFileGroups>
 		</installStep>
-		<installStep name="AVX">
+		<installStep name="CPU optimization">
 			<optionalFileGroups order="Explicit">
-				<group name="AVX" type="SelectExactlyOne">
+				<group name="CPU optimization" type="SelectAll">
 					<plugins order="Explicit">
-						<plugin name="AVX (recommended)">
-							<description>If your CPU supports the AVX instruction set, select this.
-Performance improvements over no AVX.</description>
+						<plugin name="Automatic (AVX / AVX2 / AVX512 / No AVX)">
+							<description>This version installs a small loader plus every optimized build (No AVX, AVX, AVX2, AVX512). At game launch the loader detects your CPU and automatically loads the fastest build it supports - you no longer need to pick one.
+
+If a build is unstable on your system it will automatically fall back to a lower one on the next launch.
+
+Advanced: to force a specific build, edit SKSE\Plugins\hdtSMP64_loader.ini and set ForceVariant to noavx, avx, avx2 or avx512 (default: auto). The choice will also be exposed in the FSMP MCM.</description>
+							<image path="FSMPLogo.jpg" />
+							<files></files>
 							<conditionFlags>
-								<flag name="AVX">On</flag>
+								<flag name="uselessFlag" />
 							</conditionFlags>
 							<typeDescriptor>
-								<type name="Optional" />
-							</typeDescriptor>
-						</plugin>
-						<plugin name="AVX2">
-							<description>If your CPU supports the AVX2 instructions set, select this.
-
-Should bring performance improvements over AVX, but brings some synchronisation too, so may in some cases bring less performance than AVX.
-Test and choose for yourself :)
-
-idaan300 notes:
-"All intel CPU's that support AVX2 (and the few that support AVX512) use instruction intrinsics to downclock themselves in order to prevent overheating. As soon as an intel CPU sees one AVX2/512 instruction it will downclock itself for the remainder of program execution because AVX uses a lot more of the CPU die and thus generates more heat in general. This downclocking will reduce performance across the whole game because as we all know skyrim loves single threaded performance thus potentially negating any benefits of running this version of the dll.
-
-AMD CPU's in comparison don't downclock themselves on AVX2 workloads (they only downclock based on current temperature) and thus performance can only be increased by using AVX2. Older Ryzen chips (before 3000) won't see any benefit to AVX2 instructions because they have to emulate it using standard AVX (the difference here is in instruction width, AVX2 has 256 bit wide registers and AVX 128 bit. Meaning AVX2 usually can get double the amount of work done at the same time compared to standard AVX. Older zen chips emulate these wider registers but seeing as these are 128 bit it takes twice as long to execute them because the CPU can't fit the whole intended instruction in a given register thus negating any speed improvement AVX2 could add).
-
-It's not recommended running this on Intel chips or anything older than AMD's ryzen 3000 but of course feel free to try it out and see if it works for you."</description>
-							<conditionFlags>
-								<flag name="AVX2">On</flag>
-							</conditionFlags>
-							<typeDescriptor>
-								<type name="Optional" />
-							</typeDescriptor>
-						</plugin>
-						<plugin name="AVX512">
-							<description>NOT SUPPORTED ON INTEL CPU!!!
-Do NOT come with a bug report concerning AVX512 if this bug doesn't happen with the AVX2 build, except if you come with the solution too.
-
-"Intel does not officially support AVX-512 family of instructions on the Alder Lake microprocessors.
-Intel has disabled in silicon (fused off) AVX-512 on recent steppings of Alder Lake microprocessors to prevent customers from enabling AVX-512.
-In older Alder Lake family CPUs with some legacy combinations of BIOS and microcode revisions, it was possible to execute AVX-512 family instructions
-when disabling all the efficiency cores which do not contain the silicon for AVX-512."
-
-If your CPU supports the AVX512 instructions set, select this.
-
-Should bring performance improvements over AVX2 and AVX, but brings some synchronisation too, so may in some cases bring less performance than AVX/AVX2.
-Test and choose for yourself :)</description>
-							<conditionFlags>
-								<flag name="AVX512">On</flag>
-							</conditionFlags>
-							<typeDescriptor>
-								<type name="Optional" />
-							</typeDescriptor>
-						</plugin>
-						<plugin name="No AVX">
-							<description>If your CPU doesn't support the AVX instruction set, select this.
-
-Q: What is AVX?
-A: Advanced_Vector_Extensions are extensions to the instruction sets for microprocessors from AMD and Intel. All Intel CPUs starting with Sandy Bridge in 2011 and AMD processors on their "Bulldozer" architecture and beyond offer this set of instructions.</description>
-							<conditionFlags>
-								<flag name="NOAVX">On</flag>
-							</conditionFlags>
-							<typeDescriptor>
-								<type name="Optional" />
+								<type name="NotUsable" />
 							</typeDescriptor>
 						</plugin>
 					</plugins>
@@ -149,40 +111,4 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 			</optionalFileGroups>
 		</installStep>
 	</installSteps>
-	<conditionalFileInstalls>
-		<patterns>
-			<pattern>
-				<dependencies>
-					<flagDependency flag="NOAVX" value="On" />
-				</dependencies>
-				<files>
-					<folder source="raw-vs2022-windows\SKSE" destination="SKSE" priority="0" />
-				</files>
-			</pattern>
-			<pattern>
-				<dependencies>
-					<flagDependency flag="AVX" value="On" />
-				</dependencies>
-				<files>
-					<folder source="raw-vs2022-windows-avx\SKSE" destination="SKSE" priority="0" />
-				</files>
-			</pattern>
-			<pattern>
-				<dependencies>
-					<flagDependency flag="AVX2" value="On" />
-				</dependencies>
-				<files>
-					<folder source="raw-vs2022-windows-avx2\SKSE" destination="SKSE" priority="0" />
-				</files>
-			</pattern>
-			<pattern>
-				<dependencies>
-					<flagDependency flag="AVX512" value="On" />
-				</dependencies>
-				<files>
-					<folder source="raw-vs2022-windows-avx512\SKSE" destination="SKSE" priority="0" />
-				</files>
-			</pattern>
-		</patterns>
-	</conditionalFileInstalls>
 </config>

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -1,11 +1,10 @@
 # Faster HDT-SMP loader stub.
 #
-# A tiny SKSE plugin compiled WITHOUT any /arch:AVX* flag, so it executes on every x64 CPU. It is
-# the only DLL SKSE auto-loads; at runtime it detects the CPU and loads the best optimized variant
-# from SKSE/Plugins/FSMP/. It is therefore only meaningful - and only safe - in the no-AVX configure:
-# that configure carries no /arch in the global flags, which also guarantees the CommonLibSSE it
-# links was built without AVX. In the AVX/AVX2/AVX512 configures we skip it entirely so we never emit
-# an AVX-tainted "runs everywhere" loader.
+# A tiny SKSE plugin compiled WITHOUT any /arch:AVX* flag, so it executes on every x64 CPU. It is the only DLL SKSE
+# auto-loads; at runtime it detects the CPU and loads the best optimized variant from SKSE/Plugins/FSMP/. It is
+# therefore only meaningful - and only safe - in the no-AVX configure: that configure carries no /arch in the global
+# flags, which also guarantees the CommonLibSSE it links was built without AVX. In the AVX/AVX2/AVX512 configures we
+# skip it entirely so we never emit an AVX-tainted "runs everywhere" loader.
 if(NOT AVX_VARIANT STREQUAL "noavx")
 	return()
 endif()
@@ -13,8 +12,8 @@ endif()
 set(ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 set(LOADER_NAME hdtSMP64_loader)
 
-# The loader reuses the same version template as the physics plugin so its SKSE version data (name,
-# version, compatible runtimes) is guaranteed to match. AVX_VARIANT here is "noavx".
+# The loader reuses the same version template as the physics plugin so its SKSE version data (name, version, compatible
+# runtimes) is guaranteed to match. AVX_VARIANT here is "noavx".
 set(LOADER_VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/Plugin.h")
 configure_file("${ROOT_DIR}/cmake/Plugin.h.in" "${LOADER_VERSION_HEADER}" @ONLY)
 configure_file("${ROOT_DIR}/cmake/version.rc.in" "${CMAKE_CURRENT_BINARY_DIR}/version.rc" @ONLY)
@@ -29,11 +28,8 @@ set(LOADER_SOURCES
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/VariantSelector.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp")
 
-add_library(
-	"${LOADER_NAME}" SHARED
-	${LOADER_SOURCES}
-	"${LOADER_VERSION_HEADER}"
-	"${CMAKE_CURRENT_BINARY_DIR}/version.rc")
+add_library("${LOADER_NAME}" SHARED ${LOADER_SOURCES} "${LOADER_VERSION_HEADER}"
+									"${CMAKE_CURRENT_BINARY_DIR}/version.rc")
 
 # Output is hdtSMP64.dll - the exact name SKSE auto-loads, replacing the old single-variant DLL.
 set_target_properties("${LOADER_NAME}" PROPERTIES OUTPUT_NAME "hdtSMP64")
@@ -42,12 +38,12 @@ target_compile_features("${LOADER_NAME}" PRIVATE cxx_std_20)
 target_compile_definitions("${LOADER_NAME}" PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
 target_include_directories("${LOADER_NAME}" PRIVATE "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-# CommonLibSSE is defined while processing src/ (added before this subdirectory); its alias target is
-# global, so it is visible here. spdlog, however, is an IMPORTED target whose visibility is limited to
-# the directory that called find_package (src/) and below - so we must find it again in this scope.
-# The loader uses CommonLibSSE only for the SKSE plugin types/constants and logging; it does NOT call
-# SKSE::Init (all real init happens inside the variant it forwards to). spdlog is linked explicitly
-# because the loader uses the file sink directly, not only through CommonLibSSE's logger helpers.
+# CommonLibSSE is defined while processing src/ (added before this subdirectory); its alias target is global, so it is
+# visible here. spdlog, however, is an IMPORTED target whose visibility is limited to the directory that called
+# find_package (src/) and below - so we must find it again in this scope. The loader uses CommonLibSSE only for the SKSE
+# plugin types/constants and logging; it does NOT call SKSE::Init (all real init happens inside the variant it forwards
+# to). spdlog is linked explicitly because the loader uses the file sink directly, not only through CommonLibSSE's
+# logger helpers.
 find_package(spdlog CONFIG REQUIRED)
 target_link_libraries("${LOADER_NAME}" PRIVATE CommonLibSSE::CommonLibSSE spdlog::spdlog)
 
@@ -66,9 +62,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 				"/external:anglebrackets"
 				"/external:W0"
 				"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/Zc:inline>")
-	target_link_options(
-		"${LOADER_NAME}" PRIVATE
-		"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/INCREMENTAL:NO;/OPT:REF;/OPT:ICF;/DEBUG:FULL>")
+	target_link_options("${LOADER_NAME}" PRIVATE
+						"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/INCREMENTAL:NO;/OPT:REF;/OPT:ICF;/DEBUG:FULL>")
 endif()
 
 install(
@@ -84,9 +79,8 @@ install(
 	DESTINATION "/"
 	COMPONENT "pdbs")
 
-# Local dev convenience: drop the loader DLL and the default INI next to the game's plugins so a
-# from-source build is immediately runnable. The variant target performs the matching copy into the
-# FSMP subfolder.
+# Local dev convenience: drop the loader DLL and the default INI next to the game's plugins so a from-source build is
+# immediately runnable. The variant target performs the matching copy into the FSMP subfolder.
 if("${COPY_OUTPUT}")
 	add_custom_command(
 		TARGET "${LOADER_NAME}"

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -1,0 +1,100 @@
+# Faster HDT-SMP loader stub.
+#
+# A tiny SKSE plugin compiled WITHOUT any /arch:AVX* flag, so it executes on every x64 CPU. It is
+# the only DLL SKSE auto-loads; at runtime it detects the CPU and loads the best optimized variant
+# from SKSE/Plugins/FSMP/. It is therefore only meaningful - and only safe - in the no-AVX configure:
+# that configure carries no /arch in the global flags, which also guarantees the CommonLibSSE it
+# links was built without AVX. In the AVX/AVX2/AVX512 configures we skip it entirely so we never emit
+# an AVX-tainted "runs everywhere" loader.
+if(NOT AVX_VARIANT STREQUAL "noavx")
+	return()
+endif()
+
+set(ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
+set(LOADER_NAME hdtSMP64_loader)
+
+# The loader reuses the same version template as the physics plugin so its SKSE version data (name,
+# version, compatible runtimes) is guaranteed to match. AVX_VARIANT here is "noavx".
+set(LOADER_VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/Plugin.h")
+configure_file("${ROOT_DIR}/cmake/Plugin.h.in" "${LOADER_VERSION_HEADER}" @ONLY)
+configure_file("${ROOT_DIR}/cmake/version.rc.in" "${CMAKE_CURRENT_BINARY_DIR}/version.rc" @ONLY)
+
+set(LOADER_SOURCES
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/AvxVariant.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/CpuFeatures.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/CpuFeatures.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/CrashState.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/CrashState.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/VariantSelector.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/VariantSelector.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp")
+
+add_library(
+	"${LOADER_NAME}" SHARED
+	${LOADER_SOURCES}
+	"${LOADER_VERSION_HEADER}"
+	"${CMAKE_CURRENT_BINARY_DIR}/version.rc")
+
+# Output is hdtSMP64.dll - the exact name SKSE auto-loads, replacing the old single-variant DLL.
+set_target_properties("${LOADER_NAME}" PROPERTIES OUTPUT_NAME "hdtSMP64")
+
+target_compile_features("${LOADER_NAME}" PRIVATE cxx_std_20)
+target_compile_definitions("${LOADER_NAME}" PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
+target_include_directories("${LOADER_NAME}" PRIVATE "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+# CommonLibSSE is defined while processing src/ (added before this subdirectory); its alias target is
+# global, so it is visible here. spdlog, however, is an IMPORTED target whose visibility is limited to
+# the directory that called find_package (src/) and below - so we must find it again in this scope.
+# The loader uses CommonLibSSE only for the SKSE plugin types/constants and logging; it does NOT call
+# SKSE::Init (all real init happens inside the variant it forwards to). spdlog is linked explicitly
+# because the loader uses the file sink directly, not only through CommonLibSSE's logger helpers.
+find_package(spdlog CONFIG REQUIRED)
+target_link_libraries("${LOADER_NAME}" PRIVATE CommonLibSSE::CommonLibSSE spdlog::spdlog)
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+	target_compile_options(
+		"${LOADER_NAME}"
+		PRIVATE "/sdl"
+				"/utf-8"
+				"/Zi"
+				"/permissive-"
+				"/Zc:preprocessor"
+				"/bigobj"
+				"/W4"
+				"/wd4100" # unreferenced formal parameter (pervasive in SKSE callbacks)
+				"/WX"
+				"/external:anglebrackets"
+				"/external:W0"
+				"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/Zc:inline>")
+	target_link_options(
+		"${LOADER_NAME}" PRIVATE
+		"$<$<OR:$<CONFIG:RELEASE>,$<CONFIG:PROFILE>>:/INCREMENTAL:NO;/OPT:REF;/OPT:ICF;/DEBUG:FULL>")
+endif()
+
+install(
+	FILES "$<TARGET_FILE:${LOADER_NAME}>"
+	DESTINATION "SKSE/Plugins"
+	COMPONENT "main")
+install(
+	FILES "${CMAKE_CURRENT_SOURCE_DIR}/hdtSMP64_loader.ini"
+	DESTINATION "SKSE/Plugins"
+	COMPONENT "main")
+install(
+	FILES "$<TARGET_PDB_FILE:${LOADER_NAME}>"
+	DESTINATION "/"
+	COMPONENT "pdbs")
+
+# Local dev convenience: drop the loader DLL and the default INI next to the game's plugins so a
+# from-source build is immediately runnable. The variant target performs the matching copy into the
+# FSMP subfolder.
+if("${COPY_OUTPUT}")
+	add_custom_command(
+		TARGET "${LOADER_NAME}"
+		POST_BUILD
+		COMMAND "${CMAKE_COMMAND}" -E make_directory "${CompiledPluginsPath}/SKSE/Plugins"
+		COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:${LOADER_NAME}>"
+				"${CompiledPluginsPath}/SKSE/Plugins/"
+		COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/hdtSMP64_loader.ini"
+				"${CompiledPluginsPath}/SKSE/Plugins/"
+		VERBATIM)
+endif()

--- a/loader/hdtSMP64_loader.ini
+++ b/loader/hdtSMP64_loader.ini
@@ -1,0 +1,19 @@
+; Faster HDT-SMP loader configuration
+;
+; hdtSMP64.dll is a small loader that auto-detects your CPU and loads the best-matching
+; optimized build from SKSE\Plugins\FSMP\. You normally do not need to touch this file.
+;
+; ForceVariant pins a specific build instead of auto-detecting. Use it for testing or if a
+; higher tier is unstable on your system. The loader never runs an instruction set your CPU
+; lacks, so forcing a tier above your hardware is clamped down to what is supported.
+;
+;   auto    - detect the highest instruction set the CPU+OS support (default, recommended)
+;   noavx   - plain build, runs on any x64 CPU
+;   avx     - AVX
+;   avx2    - AVX2 (+FMA)
+;   avx512  - AVX-512
+;
+; Changes take effect on the next game launch.
+
+[Loader]
+ForceVariant = auto

--- a/loader/src/AvxVariant.h
+++ b/loader/src/AvxVariant.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <array>
+#include <string_view>
+
+namespace loader
+{
+	// The CPU instruction-set tiers we ship an optimized build for, ordered from least to most
+	// capable. The integer value doubles as a ranking: a higher value needs a more capable CPU and
+	// is preferred whenever the hardware (and the persisted crash ceiling) allow it. Comparisons
+	// such as `a < b` therefore mean "tier a is less advanced than tier b".
+	enum class Variant : int
+	{
+		NoAvx = 0,
+		Avx = 1,
+		Avx2 = 2,
+		Avx512 = 3,
+	};
+
+	// Every variant, highest preference first. Used to walk down from a starting tier to the
+	// guaranteed-safe NoAvx fallback when building the candidate list.
+	inline constexpr std::array<Variant, 4> kVariantsHighToLow{
+		Variant::Avx512,
+		Variant::Avx2,
+		Variant::Avx,
+		Variant::NoAvx
+	};
+
+	// The lowercase token used both in the variant DLL filename (hdtSMP64_<token>.dll) and in the
+	// override INI / crash-state files. Kept in one place so the build, the loader, and the docs
+	// can never disagree about spelling.
+	constexpr std::string_view variantToken(Variant v) noexcept
+	{
+		switch (v) {
+		case Variant::Avx512:
+			return "avx512";
+		case Variant::Avx2:
+			return "avx2";
+		case Variant::Avx:
+			return "avx";
+		case Variant::NoAvx:
+		default:
+			return "noavx";
+		}
+	}
+
+	// Turn a token back into a Variant. The input is expected to be already trimmed and lowercased
+	// (it crosses a trust boundary: it comes from a user-editable INI or an on-disk state file), so
+	// anything unrecognized is rejected by returning false and leaving `out` untouched.
+	inline bool variantFromToken(std::string_view token, Variant& out) noexcept
+	{
+		if (token == "avx512") {
+			out = Variant::Avx512;
+		} else if (token == "avx2") {
+			out = Variant::Avx2;
+		} else if (token == "avx") {
+			out = Variant::Avx;
+		} else if (token == "noavx") {
+			out = Variant::NoAvx;
+		} else {
+			return false;
+		}
+		return true;
+	}
+
+	// The next-lower tier, used when a crash forces us to step down. NoAvx is the floor and maps to
+	// itself: if even NoAvx is implicated there is nothing safer to fall back to.
+	constexpr Variant oneTierLower(Variant v) noexcept
+	{
+		switch (v) {
+		case Variant::Avx512:
+			return Variant::Avx2;
+		case Variant::Avx2:
+			return Variant::Avx;
+		case Variant::Avx:
+		case Variant::NoAvx:
+		default:
+			return Variant::NoAvx;
+		}
+	}
+}

--- a/loader/src/CpuFeatures.cpp
+++ b/loader/src/CpuFeatures.cpp
@@ -1,0 +1,74 @@
+#include "CpuFeatures.h"
+
+#include <intrin.h>
+
+namespace loader
+{
+	namespace
+	{
+		// Read extended control register XCR0 via XGETBV. XCR0 records which register files the OS
+		// has agreed to save/restore across context switches; if a bit is clear the corresponding
+		// instructions trap even when CPUID claims support. Index 0 selects XCR0 (the only register
+		// we need); wrapped in a helper so the call site reads as intent, not magic numbers.
+		unsigned long long readXcr0() noexcept
+		{
+			return _xgetbv(0);
+		}
+	}
+
+	Variant detectHighestSupportedVariant() noexcept
+	{
+		int regs[4] = { 0, 0, 0, 0 };
+
+		// Leaf 0 reports the highest standard leaf the CPU understands, so we don't blindly query
+		// leaf 7 (AVX2/AVX-512 bits) on CPUs too old to have it.
+		__cpuid(regs, 0);
+		const int maxLeaf = regs[0];
+
+		// Leaf 1, ECX: SSE/AVX/FMA feature bits plus OSXSAVE (bit 27), which tells us XGETBV is even
+		// legal to execute. Without OSXSAVE we must assume the OS has enabled no extended state.
+		__cpuid(regs, 1);
+		const unsigned int ecx1 = static_cast<unsigned int>(regs[2]);
+		const bool osxsave = (ecx1 & (1u << 27)) != 0;
+		const bool cpuAvx = (ecx1 & (1u << 28)) != 0;
+		const bool cpuFma = (ecx1 & (1u << 12)) != 0;
+
+		bool osYmm = false;  // OS saves XMM (XCR0 bit 1) + YMM (bit 2): required for any AVX
+		bool osZmm = false;  // additionally OPMASK (bit 5) + ZMM_Hi256 (bit 6) + Hi16_ZMM (bit 7)
+		if (osxsave) {
+			const unsigned long long xcr0 = readXcr0();
+			osYmm = (xcr0 & 0x6u) == 0x6u;
+			osZmm = osYmm && (xcr0 & 0xE0u) == 0xE0u;
+		}
+
+		// No usable AVX at all -> the plain (NoAvx) build is the only safe choice.
+		if (!(cpuAvx && osYmm)) {
+			return Variant::NoAvx;
+		}
+
+		bool cpuAvx2 = false;
+		bool cpuAvx512 = false;
+		if (maxLeaf >= 7) {
+			__cpuidex(regs, 7, 0);
+			const unsigned int ebx7 = static_cast<unsigned int>(regs[1]);
+			cpuAvx2 = (ebx7 & (1u << 5)) != 0;
+
+			// MSVC /arch:AVX512 may emit instructions from F, CD, DQ, BW and VL, so require them all
+			// before trusting the AVX-512 build; F alone is not enough.
+			const bool f = (ebx7 & (1u << 16)) != 0;
+			const bool dq = (ebx7 & (1u << 17)) != 0;
+			const bool cd = (ebx7 & (1u << 28)) != 0;
+			const bool bw = (ebx7 & (1u << 30)) != 0;
+			const bool vl = (ebx7 & (1u << 31)) != 0;
+			cpuAvx512 = f && dq && cd && bw && vl;
+		}
+
+		if (cpuAvx512 && osZmm) {
+			return Variant::Avx512;
+		}
+		if (cpuAvx2 && cpuFma) {
+			return Variant::Avx2;
+		}
+		return Variant::Avx;
+	}
+}

--- a/loader/src/CpuFeatures.h
+++ b/loader/src/CpuFeatures.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "AvxVariant.h"
+
+namespace loader
+{
+	// Probe the running CPU *and* the OS and return the highest instruction-set tier that is safe to
+	// actually execute. Two checks are required for each tier, not one:
+	//   1. The CPUID feature bits must advertise the instructions.
+	//   2. The OS must have enabled the matching register state (queried via XGETBV/XCR0). A feature
+	//      bit set while the OS has not enabled YMM/ZMM state means the instructions still fault with
+	//      an illegal-instruction (#UD) — so the OS check is what makes auto-selection crash-safe.
+	//
+	// The tiers also encode the requirements of our actual builds, not just the bare ISA name:
+	//   - Avx2 additionally requires FMA, because the hand-written AVX2 path uses _mm_fmadd_ps.
+	//   - Avx512 requires the F+CD+DQ+BW+VL subsets, the full surface MSVC's /arch:AVX512 may emit.
+	Variant detectHighestSupportedVariant() noexcept;
+}

--- a/loader/src/CrashState.cpp
+++ b/loader/src/CrashState.cpp
@@ -1,0 +1,157 @@
+#include "CrashState.h"
+
+#include <charconv>
+#include <fstream>
+#include <string>
+#include <string_view>
+
+namespace loader
+{
+	namespace
+	{
+		// Trim ASCII whitespace from both ends of a view. The state file is machine-written but may
+		// be touched by a user, so we stay lenient about stray spaces around the values.
+		std::string_view trim(std::string_view s) noexcept
+		{
+			const auto notSpace = [](char c) { return c != ' ' && c != '\t' && c != '\r' && c != '\n'; };
+			while (!s.empty() && !notSpace(s.front())) {
+				s.remove_prefix(1);
+			}
+			while (!s.empty() && !notSpace(s.back())) {
+				s.remove_suffix(1);
+			}
+			return s;
+		}
+	}
+
+	CrashState::CrashState(std::filesystem::path file) :
+		m_file(std::move(file))
+	{
+	}
+
+	void CrashState::load()
+	{
+		// Reset to defaults first so a partial/garbage file degrades to "no history" rather than to
+		// stale in-memory values.
+		m_ceiling = Variant::Avx512;
+		m_attempt.reset();
+		m_strikes = 0;
+
+		std::ifstream ifs(m_file);
+		if (!ifs) {
+			return;
+		}
+
+		std::string line;
+		while (std::getline(ifs, line)) {
+			const auto eq = line.find('=');
+			if (eq == std::string::npos) {
+				continue;
+			}
+			const std::string_view key = trim(std::string_view(line).substr(0, eq));
+			const std::string_view value = trim(std::string_view(line).substr(eq + 1));
+
+			if (key == "strikes") {
+				// A small non-negative integer; anything unparsable stays 0.
+				int n = 0;
+				const auto [ptr, errc] = std::from_chars(value.data(), value.data() + value.size(), n);
+				if (errc == std::errc{} && n >= 0) {
+					m_strikes = n;
+				}
+				continue;
+			}
+
+			Variant parsed{};
+			if (!variantFromToken(value, parsed)) {
+				continue;  // unknown token -> ignore the line, keep the default
+			}
+			if (key == "ceiling") {
+				m_ceiling = parsed;
+			} else if (key == "attempt") {
+				m_attempt = parsed;
+			}
+		}
+	}
+
+	CrashState::Check CrashState::consumePendingCrash()
+	{
+		if (!m_attempt.has_value()) {
+			// Last session cleared its attempt -> it reached stability. A clean run resets strikes.
+			if (m_strikes != 0) {
+				m_strikes = 0;
+				save();
+			}
+			return Check::CleanLastSession;
+		}
+
+		// The recorded attempt was never marked stable -> the previous session ended before the
+		// stability window. That may be a crash or just an early quit, so count it as a strike rather
+		// than demoting immediately.
+		const Variant blamed = *m_attempt;
+		++m_strikes;
+		m_attempt.reset();
+
+		if (m_strikes < kStrikeLimit) {
+			save();
+			return Check::StrikeRecorded;
+		}
+
+		// Enough consecutive unstable sessions: blame the variant. Cap the ceiling one step below it,
+		// keeping the lower value if it was already demoted further, then reset the strike count.
+		const Variant lowered = oneTierLower(blamed);
+		if (lowered < m_ceiling) {
+			m_ceiling = lowered;
+		}
+		m_strikes = 0;
+		save();
+		return Check::CeilingLowered;
+	}
+
+	void CrashState::beginAttempt(Variant v)
+	{
+		m_attempt = v;
+		save();
+	}
+
+	void CrashState::markStable()
+	{
+		m_attempt.reset();
+		m_strikes = 0;
+		save();
+	}
+
+	void CrashState::blame(Variant v)
+	{
+		const Variant lowered = oneTierLower(v);
+		if (lowered < m_ceiling) {
+			m_ceiling = lowered;
+		}
+		m_attempt.reset();
+		m_strikes = 0;
+		save();
+	}
+
+	void CrashState::resetCeiling()
+	{
+		m_ceiling = Variant::Avx512;
+		m_attempt.reset();
+		m_strikes = 0;
+		save();
+	}
+
+	void CrashState::save() const
+	{
+		std::error_code ec;
+		std::filesystem::create_directories(m_file.parent_path(), ec);
+
+		std::ofstream ofs(m_file, std::ios::out | std::ios::trunc);
+		if (!ofs) {
+			return;  // best effort: if we cannot persist, crash-fallback simply won't engage
+		}
+		ofs << "ceiling=" << variantToken(m_ceiling) << '\n';
+		ofs << "strikes=" << m_strikes << '\n';
+		if (m_attempt.has_value()) {
+			ofs << "attempt=" << variantToken(*m_attempt) << '\n';
+		}
+	}
+}

--- a/loader/src/CrashState.h
+++ b/loader/src/CrashState.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "AvxVariant.h"
+
+#include <filesystem>
+#include <optional>
+
+namespace loader
+{
+	// Persisted "safe mode" state that survives across game launches so a variant which destabilizes
+	// the game is not retried forever. It is the mechanism behind the requested behaviour "fall back
+	// to a lesser AVX if the current one crashes" for crashes that happen *after* load (mid-game),
+	// which in-process exception handling cannot catch.
+	//
+	// A single tiny text file holds three facts:
+	//   - ceiling: the highest variant we are still willing to attempt. Lowered one tier when a
+	//              variant is judged guilty; never raised automatically (only an explicit user choice
+	//              or deleting the file resets it).
+	//   - attempt: the variant we are about to load this session. Written *before* the load and
+	//              cleared once the session has run stably for a short window. If, on the next
+	//              launch, an attempt is still recorded, the previous session ended before reaching
+	//              stability.
+	//   - strikes: how many consecutive sessions ended before stability. A single early exit (e.g.
+	//              the user alt-F4s at the main menu) is NOT a crash, so one strike does not demote
+	//              anything; only when strikes reach the limit do we blame the variant and lower the
+	//              ceiling. This keeps clean quick-quits from silently downgrading a working build.
+	//
+	// (The in-process SEH path uses blame() instead, which demotes immediately because a hardware
+	// fault during load is unambiguous - no strike accounting needed.)
+	//
+	// Threading: every method except markStable() runs on the SKSE load thread during
+	// SKSEPlugin_Load and they run in a fixed sequence (load -> consumePendingCrash -> beginAttempt).
+	// markStable() runs later on a single detached timer thread after SKSEPlugin_Load has returned,
+	// so it never overlaps the others; no locking is required.
+	class CrashState
+	{
+	public:
+		// Outcome of inspecting the previous session, for logging.
+		enum class Check
+		{
+			CleanLastSession,  // last session shut down stably (or there was no prior session)
+			StrikeRecorded,    // last session ended early; counted, but ceiling left unchanged
+			CeilingLowered     // strikes reached the limit; the variant was blamed and demoted
+		};
+
+		explicit CrashState(std::filesystem::path file);
+
+		// Read the state file into memory. A missing or malformed file is not an error: it simply
+		// yields the defaults (ceiling = highest tier, no pending attempt, no strikes).
+		void load();
+
+		// Inspect whether the previous session left a pending attempt (ended before stability). If so
+		// record a strike and, once the strike limit is reached, lower the ceiling one tier below the
+		// blamed variant and reset the strike count. Always clears the stale attempt and persists.
+		Check consumePendingCrash();
+
+		// Highest variant still permitted by past crash history (Avx512 if nothing was ever blamed).
+		Variant ceiling() const noexcept { return m_ceiling; }
+
+		// Record that we are about to load `v`, and flush to disk immediately so that a hard crash
+		// during the variant's load or first seconds of running is observable on the next launch.
+		void beginAttempt(Variant v);
+
+		// Declare the current attempt stable: drop the pending attempt, reset the strike count, and
+		// persist. Called from the stability timer once the process has survived the watch window.
+		void markStable();
+
+		// Permanently blame a variant whose load/init faulted in-process (the SEH path), capping the
+		// ceiling one tier below it and clearing any pending attempt and strikes. This both lets the
+		// current session fall through to a lower variant and stops future launches from retrying the
+		// bad tier. Persists.
+		void blame(Variant v);
+
+		// Forget all crash history (ceiling back to the maximum, no pending attempt, no strikes).
+		// Used when the user makes an explicit choice (forces a variant, or selects auto in the MCM),
+		// so an old crash no longer constrains a deliberate decision.
+		void resetCeiling();
+
+	private:
+		// Consecutive unstable sessions required before a variant is demoted. Two means a single
+		// clean early-exit is forgiven; a genuinely crashing build still trips it on the next launch.
+		static constexpr int kStrikeLimit = 2;
+
+		void save() const;
+
+		std::filesystem::path m_file;
+		Variant m_ceiling{ Variant::Avx512 };
+		std::optional<Variant> m_attempt;
+		int m_strikes{ 0 };
+	};
+}

--- a/loader/src/VariantSelector.cpp
+++ b/loader/src/VariantSelector.cpp
@@ -1,0 +1,99 @@
+#include "VariantSelector.h"
+
+#include <cctype>
+#include <fstream>
+#include <string>
+#include <string_view>
+
+namespace loader
+{
+	namespace
+	{
+		std::string_view trim(std::string_view s) noexcept
+		{
+			const auto isSpace = [](char c) { return c == ' ' || c == '\t' || c == '\r' || c == '\n'; };
+			while (!s.empty() && isSpace(s.front())) {
+				s.remove_prefix(1);
+			}
+			while (!s.empty() && isSpace(s.back())) {
+				s.remove_suffix(1);
+			}
+			return s;
+		}
+
+		std::string toLowerAscii(std::string_view s)
+		{
+			std::string out;
+			out.reserve(s.size());
+			for (const char c : s) {
+				out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+			}
+			return out;
+		}
+	}
+
+	ForceResult readForcedVariant(const std::filesystem::path& iniFile) noexcept
+	{
+		ForceResult result{};
+
+		std::ifstream ifs(iniFile);
+		if (!ifs) {
+			return result;  // no INI -> auto, and not an explicit choice
+		}
+
+		std::string line;
+		while (std::getline(ifs, line)) {
+			std::string_view view = trim(line);
+			if (view.empty() || view.front() == ';' || view.front() == '#' || view.front() == '[') {
+				continue;  // blank, comment, or [section] header
+			}
+			const auto eq = view.find('=');
+			if (eq == std::string_view::npos) {
+				continue;
+			}
+			const std::string key = toLowerAscii(trim(view.substr(0, eq)));
+			if (key != "forcevariant") {
+				continue;
+			}
+
+			const std::string value = toLowerAscii(trim(view.substr(eq + 1)));
+			if (value == "auto") {
+				// Explicit "auto" means: ignore past crashes and let detection decide.
+				result.variant.reset();
+				result.explicitChoice = true;
+			} else {
+				Variant parsed{};
+				if (variantFromToken(value, parsed)) {
+					result.variant = parsed;
+					result.explicitChoice = true;
+				}
+				// An unrecognized value falls through as a non-explicit "auto" so a typo cannot pin
+				// the user to a broken state.
+			}
+			// Last meaningful ForceVariant wins; keep scanning in case of duplicates.
+		}
+
+		return result;
+	}
+
+	Selection buildSelection(Variant cpuMax, Variant ceiling, std::optional<Variant> forced)
+	{
+		Variant start;
+		if (forced.has_value()) {
+			// Honour the pin, but never above what the silicon supports.
+			start = (*forced < cpuMax) ? *forced : cpuMax;
+		} else {
+			// Auto: bounded by both the hardware and the crash ceiling.
+			start = (cpuMax < ceiling) ? cpuMax : ceiling;
+		}
+
+		Selection selection;
+		selection.start = start;
+		for (const Variant v : kVariantsHighToLow) {
+			if (!(start < v)) {  // v <= start
+				selection.candidates.push_back(v);
+			}
+		}
+		return selection;
+	}
+}

--- a/loader/src/VariantSelector.h
+++ b/loader/src/VariantSelector.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "AvxVariant.h"
+
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+namespace loader
+{
+	// The decision of which variants to try, in order. Produced by buildSelection and consumed by
+	// the load loop in main.cpp.
+	struct Selection
+	{
+		std::vector<Variant> candidates;  // most-preferred first; always ends with NoAvx
+		Variant start{ Variant::NoAvx };  // the first/preferred candidate (for logging)
+	};
+
+	// Outcome of reading the override INI's ForceVariant key.
+	struct ForceResult
+	{
+		std::optional<Variant> variant;  // a pinned tier, or nullopt for "auto"/missing/garbage
+		bool explicitChoice{ false };    // true when the key was present and meaningful (variant or
+		                                 // the literal "auto") -> the crash ceiling should be reset
+	};
+
+	// Read the optional override INI and extract `ForceVariant`. The file crosses a trust boundary
+	// (user- or MCM-editable), so parsing is defensive: comments (';'/'#') and unknown keys are
+	// skipped, the value is trimmed and lowercased, and only the known tokens (auto/noavx/avx/avx2/
+	// avx512) are honoured. A missing file or unparsable value is treated as "auto".
+	ForceResult readForcedVariant(const std::filesystem::path& iniFile) noexcept;
+
+	// Build the ordered list of variants to attempt. The starting tier is:
+	//   - the forced variant, clamped down to what the CPU actually supports (we never execute an
+	//     ISA the hardware lacks, even when explicitly pinned), or
+	//   - when not forced, the lower of the CPU maximum and the persisted crash ceiling.
+	// From the start tier the list walks downward through every lower tier to NoAvx, so a candidate
+	// that fails to load always has a safer fallback and physics can never be left entirely off.
+	Selection buildSelection(Variant cpuMax, Variant ceiling, std::optional<Variant> forced);
+}

--- a/loader/src/VariantSelector.h
+++ b/loader/src/VariantSelector.h
@@ -21,7 +21,7 @@ namespace loader
 	{
 		std::optional<Variant> variant;  // a pinned tier, or nullopt for "auto"/missing/garbage
 		bool explicitChoice{ false };    // true when the key was present and meaningful (variant or
-		                                 // the literal "auto") -> the crash ceiling should be reset
+										 // the literal "auto") -> the crash ceiling should be reset
 	};
 
 	// Read the optional override INI and extract `ForceVariant`. The file crosses a trust boundary

--- a/loader/src/main.cpp
+++ b/loader/src/main.cpp
@@ -137,9 +137,9 @@ namespace
 			// that must not be torn out from under the game.
 			return fn(a_skse) ? 1 : 0;
 		} __except ((GetExceptionCode() == EXCEPTION_ILLEGAL_INSTRUCTION ||
-						GetExceptionCode() == EXCEPTION_PRIV_INSTRUCTION)
-					   ? EXCEPTION_EXECUTE_HANDLER
-					   : EXCEPTION_CONTINUE_SEARCH) {
+						GetExceptionCode() == EXCEPTION_PRIV_INSTRUCTION) ?
+						EXCEPTION_EXECUTE_HANDLER :
+						EXCEPTION_CONTINUE_SEARCH) {
 			return -1;
 		}
 	}

--- a/loader/src/main.cpp
+++ b/loader/src/main.cpp
@@ -1,0 +1,277 @@
+// hdtSMP64 loader stub
+//
+// This DLL is the only one SKSE auto-loads. It contains NO physics code and NO AVX instructions, so
+// it runs on every x64 CPU. At SKSEPlugin_Load it:
+//   1. detects the highest instruction-set tier the CPU+OS can safely run,
+//   2. applies an optional INI override and a persisted crash "ceiling",
+//   3. LoadLibrary's the best matching optimized variant from SKSE/Plugins/FSMP/, and
+//   4. forwards the SKSE LoadInterface to that variant's own SKSEPlugin_Load.
+//
+// Because the variant receives the exact same LoadInterface (and therefore the same SKSE plugin
+// handle and name as this loader declares), the FSMP plugin API - which is published purely through
+// SKSE messaging under Plugin::NAME - keeps working for other mods unchanged.
+
+// CommonLibSSE-NG umbrella first, in the same order as the physics plugin's PCH: RE/Skyrim.h sets up
+// the standard-library prerequisites (std::mutex/span) and the CommonLibSSE `stl` helpers that the
+// REL/SKSE headers below rely on. Without it those headers fail to compile.
+#include <RE/Skyrim.h>
+#include <REL/Relocation.h>
+#include <SKSE/SKSE.h>
+
+#include "CpuFeatures.h"
+#include "CrashState.h"
+#include "VariantSelector.h"
+
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <thread>
+
+#include <Windows.h>
+
+#include "Plugin.h"
+
+#define DLLEXPORT __declspec(dllexport)
+
+namespace logger = SKSE::log;
+
+using namespace std::literals;
+
+namespace
+{
+	// How long a session must run without crashing before we trust the loaded variant. The pending
+	// attempt marker is cleared after this window; a crash before it elapses lowers the ceiling on
+	// the next launch. Chosen generously so early cell loads (the first time physics actually runs)
+	// are comfortably inside the window.
+	constexpr auto kStabilityWindow = std::chrono::seconds(120);
+
+	// Subfolder (under the loader) that holds the optimized variant DLLs. It is deliberately NOT the
+	// Plugins root: SKSE scans Plugins non-recursively, so keeping the variants one level down stops
+	// SKSE from auto-loading them (which would double-load and could run an unsupported ISA).
+	constexpr auto kVariantSubfolder = L"FSMP";
+
+	// Resolve a module's full path, growing the buffer until it fits (MO2's virtualized paths can be
+	// longer than MAX_PATH). Returns empty on failure.
+	std::wstring moduleFilePath(HMODULE mod)
+	{
+		std::wstring buf(MAX_PATH, L'\0');
+		for (;;) {
+			const DWORD n = GetModuleFileNameW(mod, buf.data(), static_cast<DWORD>(buf.size()));
+			if (n == 0) {
+				return {};
+			}
+			if (n < buf.size()) {
+				buf.resize(n);
+				return buf;
+			}
+			if (buf.size() >= 0x8000) {
+				return {};  // absurdly long; give up rather than loop forever
+			}
+			buf.resize(buf.size() * 2);
+		}
+	}
+
+	// The directory this loader DLL lives in, used to locate the variant subfolder and the INI. We
+	// resolve our own module by address (a function inside this DLL) rather than assuming the EXE's
+	// directory, so it is correct regardless of the process current directory.
+	std::filesystem::path loaderDirectory()
+	{
+		HMODULE self = nullptr;
+		if (!GetModuleHandleExW(
+				GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+				reinterpret_cast<LPCWSTR>(&moduleFilePath),
+				&self)) {
+			return {};
+		}
+		const std::wstring path = moduleFilePath(self);
+		if (path.empty()) {
+			return {};
+		}
+		return std::filesystem::path(path).parent_path();
+	}
+
+	// Send the loader's own diagnostics to <SKSE log dir>/hdtsmp64_loader.log, separate from the
+	// physics plugin's hdtsmp64.log so it is obvious which component reported what. Falls back
+	// silently to no logging if the standard directory can't be resolved.
+	void initLog()
+	{
+		auto dir = logger::log_directory();
+		if (!dir) {
+			return;
+		}
+		*dir /= fmt::format("{}_loader.log"sv, Plugin::NAME);
+
+		auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(dir->string(), true);
+		auto log = std::make_shared<spdlog::logger>("loader log"s, std::move(sink));
+		log->set_level(spdlog::level::info);
+		log->flush_on(spdlog::level::info);
+		spdlog::set_default_logger(std::move(log));
+		spdlog::set_pattern("[%H:%M:%S.%e] [%L] %v"s);
+	}
+
+	// Load one variant DLL and forward the SKSE load call into it, fully isolated by Structured
+	// Exception Handling so a hardware fault (e.g. an illegal instruction) becomes a recoverable
+	// "try the next variant" instead of crashing the game. The return contract:
+	//     1  -> the variant loaded and its SKSEPlugin_Load returned true (success)
+	//     0  -> a clean miss: file absent, missing export, or the variant returned false
+	//    -1  -> a structured exception during load or init
+	// Kept free of any C++ object with a destructor, as required for __try/__except.
+	int tryLoadAndForward(const wchar_t* dllPath, const SKSE::LoadInterface* a_skse) noexcept
+	{
+		__try {
+			HMODULE mod = LoadLibraryW(dllPath);
+			if (!mod) {
+				return 0;
+			}
+			using LoadFn = bool(__cdecl*)(const SKSE::LoadInterface*);
+			auto fn = reinterpret_cast<LoadFn>(GetProcAddress(mod, "SKSEPlugin_Load"));
+			if (!fn) {
+				FreeLibrary(mod);
+				return 0;
+			}
+			// On success the module stays resident for the process lifetime. On a `false` return we
+			// intentionally do NOT FreeLibrary: a declining variant may already have installed hooks
+			// that must not be torn out from under the game.
+			return fn(a_skse) ? 1 : 0;
+		} __except ((GetExceptionCode() == EXCEPTION_ILLEGAL_INSTRUCTION ||
+						GetExceptionCode() == EXCEPTION_PRIV_INSTRUCTION)
+					   ? EXCEPTION_EXECUTE_HANDLER
+					   : EXCEPTION_CONTINUE_SEARCH) {
+			return -1;
+		}
+	}
+}
+
+extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Query(const SKSE::QueryInterface* a_skse, SKSE::PluginInfo* a_info)
+{
+	// Legacy handshake (needed for Skyrim SE 1.5.x, which predates the version-data mechanism). The
+	// declared identity must match the physics plugin so other mods still recognise us by name.
+	a_info->infoVersion = SKSE::PluginInfo::kVersion;
+	a_info->name = Plugin::NAME.data();
+	a_info->version = Plugin::VERSION.pack();
+
+	if (a_skse->IsEditor()) {
+		return false;
+	}
+
+	const auto ver = a_skse->RuntimeVersion();
+	if ((REL::Module::IsSE() && ver < SKSE::RUNTIME_SSE_1_5_39) ||
+		(REL::Module::IsVR() && ver < SKSE::RUNTIME_LATEST_VR)) {
+		return false;
+	}
+
+	return true;
+}
+
+// Modern handshake. These must mirror the physics plugin's declaration exactly: SKSE validates this
+// data on the loader (the only DLL it scans), never on the variants we load manually, so the
+// loader is what advertises runtime compatibility and address-library use on behalf of the variant.
+extern "C" DLLEXPORT constinit auto SKSEPlugin_Version = []() {
+	SKSE::PluginVersionData v;
+
+	v.PluginVersion(Plugin::VERSION);
+	v.PluginName(Plugin::NAME);
+	v.UsesAddressLibrary();
+	v.CompatibleVersions({ SKSE::RUNTIME_SSE_LATEST_SE, SKSE::RUNTIME_SSE_LATEST, SKSE::RUNTIME_1_6_1179, SKSE::RUNTIME_LATEST_VR });
+	v.UsesNoStructs();
+
+	return v;
+}();
+
+extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_skse)
+{
+	initLog();
+
+	if constexpr (Plugin::BUILD_INFO.empty()) {
+		logger::info("{} loader v{}"sv, Plugin::NAME, Plugin::VERSION.string());
+	} else {
+		logger::info("{} loader v{}-{}"sv, Plugin::NAME, Plugin::VERSION.string(), Plugin::BUILD_INFO);
+	}
+
+	const std::filesystem::path dir = loaderDirectory();
+	if (dir.empty()) {
+		logger::error("could not resolve loader directory; cannot locate variant DLLs"sv);
+		return false;
+	}
+
+	// 1) What can the hardware actually run?
+	const loader::Variant cpuMax = loader::detectHighestSupportedVariant();
+	logger::info("CPU supports up to: {}"sv, loader::variantToken(cpuMax));
+
+	// 2) Persisted crash history (kept in the real, writable SKSE log dir, not the virtualized Data
+	//    tree). Static so the stability timer thread can safely reference it for the process life.
+	auto stateDir = logger::log_directory();
+	static loader::CrashState crashState(
+		(stateDir ? *stateDir : dir) / fmt::format("{}_loader.state"sv, Plugin::NAME));
+	crashState.load();
+	switch (crashState.consumePendingCrash()) {
+	case loader::CrashState::Check::CeilingLowered:
+		logger::warn("previous sessions repeatedly unstable; crash ceiling lowered to {}"sv,
+			loader::variantToken(crashState.ceiling()));
+		break;
+	case loader::CrashState::Check::StrikeRecorded:
+		logger::warn("previous session ended before stability (strike recorded); keeping ceiling {}"sv,
+			loader::variantToken(crashState.ceiling()));
+		break;
+	case loader::CrashState::Check::CleanLastSession:
+		break;
+	}
+
+	// 3) Optional override from the (user/MCM-editable) INI next to the loader.
+	const loader::ForceResult force = loader::readForcedVariant(dir / fmt::format("{}_loader.ini"sv, Plugin::NAME));
+	if (force.explicitChoice) {
+		// A deliberate choice clears stale crash history so it isn't second-guessed.
+		crashState.resetCeiling();
+		if (force.variant) {
+			logger::info("INI forces variant: {}"sv, loader::variantToken(*force.variant));
+		} else {
+			logger::info("INI forces auto-detection"sv);
+		}
+	}
+
+	// 4) Build the ordered candidate list and try each, stepping down on failure.
+	const loader::Selection selection = loader::buildSelection(cpuMax, crashState.ceiling(), force.variant);
+	logger::info("selected variant: {} (will fall back to lower tiers on failure)"sv,
+		loader::variantToken(selection.start));
+
+	for (const loader::Variant candidate : selection.candidates) {
+		const std::filesystem::path dll =
+			dir / kVariantSubfolder / fmt::format("{}_{}.dll"sv, Plugin::NAME, loader::variantToken(candidate));
+
+		if (!std::filesystem::exists(dll)) {
+			logger::warn("variant DLL missing, skipping: {}"sv, dll.string());
+			continue;
+		}
+
+		crashState.beginAttempt(candidate);
+		logger::info("loading variant {}: {}"sv, loader::variantToken(candidate), dll.string());
+
+		const int result = tryLoadAndForward(dll.c_str(), a_skse);
+		if (result == 1) {
+			logger::info("variant {} loaded successfully"sv, loader::variantToken(candidate));
+
+			// Clear the pending attempt once we've run stably for a while, so a clean session does
+			// not look like a crash next launch. Detached: the load thread must return promptly.
+			std::thread([] {
+				std::this_thread::sleep_for(kStabilityWindow);
+				crashState.markStable();
+			}).detach();
+
+			return true;
+		}
+
+		if (result < 0) {
+			logger::error("variant {} faulted during load/init; blaming it and falling back"sv,
+				loader::variantToken(candidate));
+			crashState.blame(candidate);
+		} else {
+			logger::warn("variant {} declined to load; trying next tier"sv, loader::variantToken(candidate));
+		}
+	}
+
+	logger::critical("no usable hdtSMP64 variant could be loaded"sv);
+	return false;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,6 +167,11 @@ endif()
 add_library("${PROJECT_NAME}" SHARED ${SOURCE_FILES} "${VERSION_HEADER}" "${CMAKE_CURRENT_BINARY_DIR}/version.rc"
 									 "${ROOT_DIR}/.clang-format" "${ROOT_DIR}/.editorconfig")
 
+# Each AVX configure produces a distinctly-named DLL (hdtSMP64_noavx/avx/avx2/avx512.dll). They are
+# loaded at runtime by the no-AVX loader stub (hdtSMP64.dll) from the FSMP subfolder, never directly
+# by SKSE, so they must NOT keep the bare "hdtSMP64" name that SKSE auto-scans.
+set_target_properties("${PROJECT_NAME}" PROPERTIES OUTPUT_NAME "hdtSMP64_${AVX_VARIANT}")
+
 target_compile_features("${PROJECT_NAME}" PRIVATE cxx_std_20)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
@@ -267,9 +272,11 @@ target_link_libraries(
 
 target_precompile_headers("${PROJECT_NAME}" PRIVATE "${SOURCE_DIR}/PCH.h")
 
+# Variants live under SKSE/Plugins/FSMP/ (a subfolder SKSE does not scan), so only the loader stub
+# is ever auto-loaded.
 install(
 	FILES "$<TARGET_FILE:${PROJECT_NAME}>"
-	DESTINATION "SKSE/Plugins"
+	DESTINATION "SKSE/Plugins/FSMP"
 	COMPONENT "main")
 
 install(
@@ -281,9 +288,10 @@ if("${COPY_OUTPUT}")
 	add_custom_command(
 		TARGET "${PROJECT_NAME}"
 		POST_BUILD
+		COMMAND "${CMAKE_COMMAND}" -E make_directory "${CompiledPluginsPath}/SKSE/Plugins/FSMP"
 		COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:${PROJECT_NAME}>"
-				"${CompiledPluginsPath}/SKSE/Plugins/"
+				"${CompiledPluginsPath}/SKSE/Plugins/FSMP/"
 		COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_PDB_FILE:${PROJECT_NAME}>"
-				"${CompiledPluginsPath}/SKSE/Plugins/"
+				"${CompiledPluginsPath}/SKSE/Plugins/FSMP/"
 		VERBATIM)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,9 +167,9 @@ endif()
 add_library("${PROJECT_NAME}" SHARED ${SOURCE_FILES} "${VERSION_HEADER}" "${CMAKE_CURRENT_BINARY_DIR}/version.rc"
 									 "${ROOT_DIR}/.clang-format" "${ROOT_DIR}/.editorconfig")
 
-# Each AVX configure produces a distinctly-named DLL (hdtSMP64_noavx/avx/avx2/avx512.dll). They are
-# loaded at runtime by the no-AVX loader stub (hdtSMP64.dll) from the FSMP subfolder, never directly
-# by SKSE, so they must NOT keep the bare "hdtSMP64" name that SKSE auto-scans.
+# Each AVX configure produces a distinctly-named DLL (hdtSMP64_noavx/avx/avx2/avx512.dll). They are loaded at runtime by
+# the no-AVX loader stub (hdtSMP64.dll) from the FSMP subfolder, never directly by SKSE, so they must NOT keep the bare
+# "hdtSMP64" name that SKSE auto-scans.
 set_target_properties("${PROJECT_NAME}" PROPERTIES OUTPUT_NAME "hdtSMP64_${AVX_VARIANT}")
 
 target_compile_features("${PROJECT_NAME}" PRIVATE cxx_std_20)
@@ -272,8 +272,7 @@ target_link_libraries(
 
 target_precompile_headers("${PROJECT_NAME}" PRIVATE "${SOURCE_DIR}/PCH.h")
 
-# Variants live under SKSE/Plugins/FSMP/ (a subfolder SKSE does not scan), so only the loader stub
-# is ever auto-loaded.
+# Variants live under SKSE/Plugins/FSMP/ (a subfolder SKSE does not scan), so only the loader stub is ever auto-loaded.
 install(
 	FILES "$<TARGET_FILE:${PROJECT_NAME}>"
 	DESTINATION "SKSE/Plugins/FSMP"


### PR DESCRIPTION
Closes #384.

## What
Replaces the four user-picked AVX builds with **one package** that auto-selects the best build at runtime. A tiny no-AVX **loader stub** (`hdtSMP64.dll`) becomes the only DLL SKSE auto-loads; at `SKSEPlugin_Load` it detects the CPU+OS, loads the best variant from `SKSE/Plugins/FSMP/`, and forwards the SKSE `LoadInterface` to the variant's own `SKSEPlugin_Load`.

```
SKSE/Plugins/hdtSMP64.dll            <- loader (no-AVX, only DLL SKSE scans)
SKSE/Plugins/hdtSMP64_loader.ini     <- optional ForceVariant override
SKSE/Plugins/FSMP/hdtSMP64_noavx.dll
SKSE/Plugins/FSMP/hdtSMP64_avx.dll
SKSE/Plugins/FSMP/hdtSMP64_avx2.dll
SKSE/Plugins/FSMP/hdtSMP64_avx512.dll
```

Variants live in a subfolder SKSE does **not** scan, so they are never double-loaded. The loader declares the same plugin **name** and forwards the same **handle**, so the messaging-based FSMP plugin API keeps working for other mods unchanged.

## Selection & safety
- **Policy:** highest ISA the CPU+OS supports (AVX512 > AVX2 > AVX > NoAVX), gated on both CPUID feature bits **and** `XGETBV` OS-state (a feature bit alone would still `#UD`). AVX2 also requires FMA; AVX512 requires F+CD+DQ+BW+VL (the full `/arch:AVX512` surface).
- **Crash → lesser ISA (load-time):** SEH around each variant's load/init falls through to the next-lower tier on a hardware fault, same session.
- **Crash → lesser ISA (mid-game):** a persisted ceiling in the SKSE log dir demotes a variant that destabilizes the game on the next launch. A **2-strike rule** stops a clean early quit (alt-F4 at the menu) from being mistaken for a crash.
- **Override:** `hdtSMP64_loader.ini` `ForceVariant = auto|noavx|avx|avx2|avx512`, clamped to what the CPU supports. Intended to also be written by the MCM.

## Build / CI / FOMOD
- New loader target builds **only in the no-AVX configure** (so it links a non-AVX CommonLibSSE and runs everywhere). Physics builds now emit `hdtSMP64_<variant>.dll` under `FSMP/`.
- CI verifies the renamed variant DLLs and the loader stub + default INI.
- FOMOD drops the manual AVX picker and always installs the loader + all four variants.

## Verification
- Loader **compiles and links clean** (no errors/warnings); exports `SKSEPlugin_Load/Query/Version`; default INI ships. Physics targets only changed output name/location (no source change); the full 4-variant matrix runs in CI here.
- **Not done:** an in-game smoke test of the runtime forwarding (needs the running game) — recommended before release.

## Follow-ups
- No `CMakeLists.txt` version bump (handled on `master` at release).
- MCM "Force AVX variant" dropdown tracked in DaymareOn/FSMP-MCM#17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic CPU capability detection that selects the optimal performance tier at runtime.
  * Implemented crash recovery that automatically downgrades to a lower-performance variant if instability is detected.
  * Added configuration file support for manual performance tier override.
  * Updated installer to include all CPU variant builds, with runtime auto-selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->