### PR TITLE
Remove player-character root-rotation guard (#387)

### DIFF
--- a/fomod tree/configs/configs-compatibility.xml
+++ b/fomod tree/configs/configs-compatibility.xml
@@ -34,40 +34,6 @@
     -->
     <disableSMPHairWhenWigEquipped>false</disableSMPHairWhenWigEquipped>
 
-    <!-- ##################### CLAMP ROTATIONS ############################ -->
-
-    <!--
-      clampRotations: (boolean) limits the PC rotation speed when turning a
-      large angle, so that your character rotates slowly instead of instantly.
-      If no value is set, default is true.
-    -->
-    <clampRotations>true</clampRotations>
-
-    <!--
-      rotationSpeedLimit: (float) rotation speed limit of the PC in radians per
-      second. Must be positive.
-      If no value is set, default is 10.0.
-    -->
-    <rotationSpeedLimit>10.0</rotationSpeedLimit>
-
-    <!--
-      unclampedResets: (boolean) when unclamped, if you do a large turn (full
-      180° for example), we will attempt to apply physics for that enormous
-      turn. Setting this to true will instead trigger a physics reset on the
-      actor if the turn is large enough. You can try setting this false and
-      decide if you're OK with the results.
-      If no value is set, default is true.
-    -->
-    <unclampedResets>true</unclampedResets>
-
-    <!--
-      unclampedResetAngle: (int) the angle value in degrees to reset at. You'll
-      probably want to tweak this until you're happy. There is no limitation on
-      value, use your common sense.
-      If no value is set, default is 120°.
-    -->
-    <unclampedResetAngle>130.0</unclampedResetAngle>
-
     <!-- ######################### CLOCK ################################## -->
 
     <!--

--- a/fomod tree/configs/configs-performance.xml
+++ b/fomod tree/configs/configs-performance.xml
@@ -34,40 +34,6 @@
     -->
     <disableSMPHairWhenWigEquipped>true</disableSMPHairWhenWigEquipped>
 
-    <!-- ##################### CLAMP ROTATIONS ############################ -->
-
-    <!--
-      clampRotations: (boolean) limits the PC rotation speed when turning a
-      large angle, so that your character rotates slowly instead of instantly.
-      If no value is set, default is true.
-    -->
-    <clampRotations>true</clampRotations>
-
-    <!--
-      rotationSpeedLimit: (float) rotation speed limit of the PC in radians per
-      second. Must be positive.
-      If no value is set, default is 10.0.
-    -->
-    <rotationSpeedLimit>10.0</rotationSpeedLimit>
-
-    <!--
-      unclampedResets: (boolean) when unclamped, if you do a large turn (full
-      180° for example), we will attempt to apply physics for that enormous
-      turn. Setting this to true will instead trigger a physics reset on the
-      actor if the turn is large enough. You can try setting this false and
-      decide if you're OK with the results.
-      If no value is set, default is true.
-    -->
-    <unclampedResets>true</unclampedResets>
-
-    <!--
-      unclampedResetAngle: (int) the angle value in degrees to reset at. You'll
-      probably want to tweak this until you're happy. There is no limitation on
-      value, use your common sense.
-      If no value is set, default is 120°.
-    -->
-    <unclampedResetAngle>130.0</unclampedResetAngle>
-
     <!-- ######################### CLOCK ################################## -->
 
     <!--

--- a/fomod tree/configs/configs-quality.xml
+++ b/fomod tree/configs/configs-quality.xml
@@ -34,40 +34,6 @@
     -->
     <disableSMPHairWhenWigEquipped>false</disableSMPHairWhenWigEquipped>
 
-    <!-- ##################### CLAMP ROTATIONS ############################ -->
-
-    <!--
-      clampRotations: (boolean) limits the PC rotation speed when turning a
-      large angle, so that your character rotates slowly instead of instantly.
-      If no value is set, default is true.
-    -->
-    <clampRotations>true</clampRotations>
-
-    <!--
-      rotationSpeedLimit: (float) rotation speed limit of the PC in radians per
-      second. Must be positive.
-      If no value is set, default is 10.0.
-    -->
-    <rotationSpeedLimit>10.0</rotationSpeedLimit>
-
-    <!--
-      unclampedResets: (boolean) when unclamped, if you do a large turn (full
-      180° for example), we will attempt to apply physics for that enormous
-      turn. Setting this to true will instead trigger a physics reset on the
-      actor if the turn is large enough. You can try setting this false and
-      decide if you're OK with the results.
-      If no value is set, default is true.
-    -->
-    <unclampedResets>true</unclampedResets>
-
-    <!--
-      unclampedResetAngle: (int) the angle value in degrees to reset at. You'll
-      probably want to tweak this until you're happy. There is no limitation on
-      value, use your common sense.
-      If no value is set, default is 120°.
-    -->
-    <unclampedResetAngle>130.0</unclampedResetAngle>
-
     <!-- ######################### CLOCK ################################## -->
 
     <!--

--- a/fomod tree/configs/configs-reasonable.xml
+++ b/fomod tree/configs/configs-reasonable.xml
@@ -34,40 +34,6 @@
     -->
     <disableSMPHairWhenWigEquipped>true</disableSMPHairWhenWigEquipped>
 
-    <!-- ##################### CLAMP ROTATIONS ############################ -->
-
-    <!--
-      clampRotations: (boolean) limits the PC rotation speed when turning a
-      large angle, so that your character rotates slowly instead of instantly.
-      If no value is set, default is true.
-    -->
-    <clampRotations>true</clampRotations>
-
-    <!--
-      rotationSpeedLimit: (float) rotation speed limit of the PC in radians per
-      second. Must be positive.
-      If no value is set, default is 10.0.
-    -->
-    <rotationSpeedLimit>10.0</rotationSpeedLimit>
-
-    <!--
-      unclampedResets: (boolean) when unclamped, if you do a large turn (full
-      180° for example), we will attempt to apply physics for that enormous
-      turn. Setting this to true will instead trigger a physics reset on the
-      actor if the turn is large enough. You can try setting this false and
-      decide if you're OK with the results.
-      If no value is set, default is true.
-    -->
-    <unclampedResets>true</unclampedResets>
-
-    <!--
-      unclampedResetAngle: (int) the angle value in degrees to reset at. You'll
-      probably want to tweak this until you're happy. There is no limitation on
-      value, use your common sense.
-      If no value is set, default is 120°.
-    -->
-    <unclampedResetAngle>130.0</unclampedResetAngle>
-
     <!-- ######################### CLOCK ################################## -->
 
     <!--

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -85,14 +85,10 @@ namespace hdt
 					ActorManager::instance()->m_skinNPCFaceParts = reader.readBool();
 				} else if (reader.GetLocalName() == "disableSMPHairWhenWigEquipped") {
 					ActorManager::instance()->m_disableSMPHairWhenWigEquipped = reader.readBool();
-				} else if (reader.GetLocalName() == "clampRotations") {
-					SkyrimPhysicsWorld::get()->m_clampRotations = reader.readBool();
-				} else if (reader.GetLocalName() == "rotationSpeedLimit") {
-					SkyrimPhysicsWorld::get()->m_rotationSpeedLimit = reader.readFloat();
-				} else if (reader.GetLocalName() == "unclampedResets") {
-					SkyrimPhysicsWorld::get()->m_unclampedResets = reader.readBool();
-				} else if (reader.GetLocalName() == "unclampedResetAngle") {
-					SkyrimPhysicsWorld::get()->m_unclampedResetAngle = reader.readFloat();
+				} else if (reader.GetLocalName() == "clampRotations" || reader.GetLocalName() == "rotationSpeedLimit" || reader.GetLocalName() == "unclampedResets" || reader.GetLocalName() == "unclampedResetAngle") {
+					// Deprecated (#387): the player-character root-rotation guard was removed. Silently
+					// consume these legacy keys so existing configs.xml files load without warnings.
+					reader.skipCurrentElement();
 				} else if (reader.GetLocalName() == "budgetMs") {
 					SkyrimPhysicsWorld::get()->m_budgetMs = std::clamp(reader.readFloat(), 0.1f, 20.0f);
 				} else if (reader.GetLocalName() == "useRealTime") {
@@ -208,10 +204,6 @@ namespace hdt
 
 		LOG("smp.enableNPCFaceParts", a->m_skinNPCFaceParts);
 		LOG("smp.disableSMPHairWhenWigEquipped", a->m_disableSMPHairWhenWigEquipped);
-		LOG("smp.clampRotations", w->m_clampRotations);
-		LOG("smp.rotationSpeedLimit", w->m_rotationSpeedLimit);
-		LOG("smp.unclampedResets", w->m_unclampedResets);
-		LOG("smp.unclampedResetAngle", w->m_unclampedResetAngle);
 		LOG("smp.budgetMS", w->m_budgetMs);
 		LOG("smp.useRealTime", w->m_useRealTime);
 		LOG("smp.minCullingDistance", a->m_minCullingDistance);

--- a/src/hdtSkyrimPhysicsWorld.h
+++ b/src/hdtSkyrimPhysicsWorld.h
@@ -76,11 +76,6 @@ namespace hdt
 		float m_budgetMs = 3.5f;
 		float m_timeTick = 1 / 60.f;
 		int m_maxSubSteps = 4;
-		bool m_clampRotations = true;
-		// @brief rotation speed limit of the PC in radians per second. Must be positive.
-		float m_rotationSpeedLimit = 10.f;
-		bool m_unclampedResets = true;
-		float m_unclampedResetAngle = 120.0f;
 		float m_2ndStepAverageProcessingTime = 0;
 		float m_averageSMPProcessingTimeInMainLoop = 0;
 		bool disabled = false;

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -105,49 +105,11 @@ namespace hdt
 			if (!this->block_resetting) {
 				updateTransformUpDown(m_skeleton.get(), true);
 			}
-
-			m_lastRootRotation = convertNi(m_skeleton->world.rotate);
-		} else if (m_skeleton->parent == RE::PlayerCharacter::GetSingleton()->Get3D2()) {
-			if (SkyrimPhysicsWorld::get()->m_resetPc > 0) {
-				timeStep = RESET_PHYSICS;
-				updateTransformUpDown(m_skeleton.get(), true);
-				m_lastRootRotation = convertNi(m_skeleton->world.rotate);
-			} else if (!RE::PlayerCamera::GetSingleton()->GetRuntimeData2().isWeapSheathed || RE::PlayerCamera::GetSingleton()->currentState->id == RE::CameraState::kFirstPerson)  // isWeaponSheathed or potentially isCameraFree || cameraState is first person
-			{
-				m_lastRootRotation = convertNi(m_skeleton->world.rotate);
-			} else {
-				btQuaternion newRot = convertNi(m_skeleton->world.rotate);
-				btVector3 rotAxis;
-				float rotAngle;
-				btTransformUtil::calculateDiffAxisAngleQuaternion(m_lastRootRotation, newRot, rotAxis, rotAngle);
-
-				if (SkyrimPhysicsWorld::get()->m_clampRotations) {
-					float limit = SkyrimPhysicsWorld::get()->m_rotationSpeedLimit * timeStep;
-
-					if (rotAngle < -limit || rotAngle > limit) {
-						rotAngle = btClamped(rotAngle, -limit, limit);
-						btQuaternion clampedRot(rotAxis, rotAngle);
-						m_lastRootRotation = clampedRot * m_lastRootRotation;
-						m_skeleton->world.rotate = convertBt(m_lastRootRotation);
-
-						const auto& children = m_skeleton->GetChildren();
-						for (uint16_t i = 0; i < children.size(); ++i) {
-							auto node = castNiNode(children[i].get());
-							if (node) {
-								updateTransformUpDown(node, true);
-							}
-						}
-					}
-				} else if (SkyrimPhysicsWorld::get()->m_unclampedResets) {
-					float limit = SkyrimPhysicsWorld::get()->m_unclampedResetAngle * timeStep;
-
-					if (rotAngle < -limit || rotAngle > limit) {
-						timeStep = RESET_PHYSICS;
-						updateTransformUpDown(m_skeleton.get(), true);
-						m_lastRootRotation = convertNi(m_skeleton->world.rotate);
-					}
-				}
-			}
+		} else if (m_skeleton->parent == RE::PlayerCharacter::GetSingleton()->Get3D2() && SkyrimPhysicsWorld::get()->m_resetPc > 0) {
+			// Coming back from first-person, the body was posed without being simulated; force a
+			// brief reset so physics restarts from the now-visible third-person pose.
+			timeStep = RESET_PHYSICS;
+			updateTransformUpDown(m_skeleton.get(), true);
 		}
 
 		m_oldRoot = hdt::make_nismart(newRoot);

--- a/src/hdtSkyrimSystem.h
+++ b/src/hdtSkyrimSystem.h
@@ -30,6 +30,12 @@ namespace hdt
 		SkinnedMeshBody* findBody(const RE::BSFixedString& name);
 		int findBoneIdx(const RE::BSFixedString& name);
 
+		/// Decides whether this frame's physics should run normally or be reset, then returns the
+		/// (possibly overridden) timeStep. A reset is forced when the skeleton's root node changed
+		/// (teleport / fast-travel / cell load), on first use, or when the player just returned from
+		/// first-person (m_resetPc). On a reset we re-propagate the current pose down the tree so the
+		/// simulation restarts from where the body actually is. Otherwise the root rotation is left
+		/// untouched and flows into physics as-is.
 		float prepareForRead(float timeStep) override;
 
 		const std::vector<RE::BSTSmartPointer<SkinnedMeshBody>>& meshes() const { return m_meshes; }
@@ -38,9 +44,6 @@ namespace hdt
 		RE::NiPointer<RE::NiNode> m_oldRoot;
 		bool m_initialized = false;
 		float m_windFactor = 1.f;  // wind factor for the system (i.e., full actor/skeleton) (calculated based off obstructions)
-
-		// angular velocity damper
-		btQuaternion m_lastRootRotation;
 	};
 
 	class XMLReader;


### PR DESCRIPTION
Closes #387.

## What

Removes the player-character-only root-rotation guard in `SkyrimSystem::prepareForRead` — the weapon/camera gate, the per-frame angular-speed **clamp** (`clampRotations`/`rotationSpeedLimit`), and the large-turn **physics reset** (`unclampedResets`/`unclampedResetAngle`). The PC root rotation now flows into physics unmodified, exactly like every NPC.

## Why

Large, instant root rotations are rare in modern modded Skyrim, and the cases that remain are already covered or already exempt:

- **Killmoves** reorient the root instantly but run with the weapon **drawn** -> the old gate already skipped the guard.
- **Teleport / fast-travel / cell change** swap the skeleton **root node** -> handled by the existing `m_oldRoot != newRoot` reset (kept).
- The guard fought the animation system, making cloth/hair lag or snap on deliberate turns.

## Kept

Root-change reset, first-init reset, `m_resetPc` (first->third-person reset), and `RESET_PHYSICS`.

## Back-compat

The four legacy config keys are silently consumed in `config.cpp`, so existing user `configs.xml` files load without `Unknown config` warnings. The four shipped `configs.xml` profiles have their CLAMP ROTATIONS doc block removed.

## Accepted risk

Third-person + weapon-sheathed sit-down / mount / scripted teleport (same root, no node change) could briefly spike player hair/cloth. Accepted per maintainer judgment.

## Verification

Builds clean (vs2022 avx2 release), `hdtsmp64.dll` produced, no warnings on changed files. In-game smoke test of the residual-risk cases (sit / mount / fast-travel, third-person + sheathed) still TODO before merge.

## Follow-up (separate repo)

FSMP-MCM `configs.xml` + presets still carry the four keys. They load fine via the back-compat stub; cosmetic cleanup can follow there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved physics reset behavior when returning from first-person and after major scene changes, helping animations restart from the visible pose more reliably.
  * Removed deprecated rotation-clamping options from the available settings, simplifying configuration and avoiding inactive controls.

* **Refactor**
  * Streamlined configuration handling by ignoring legacy rotation-related values and removing unused rotation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->