### PR TITLE
smpview Phase 0: standalone smpcore physics lib (decouple core from CommonLibSSE)

### DIFF
--- a/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.h
@@ -12,6 +12,9 @@ namespace hdt
 	class SkinnedMeshWorld;
 	class BoneScaleConstraint;
 
+	// Sentinel timestep (compared with <=) that snaps bones to pose with zero velocity.
+	constexpr float RESET_PHYSICS = -10.0f;
+
 	class SkinnedMeshSystem :
 		public RE::BSIntrusiveRefCounted
 	{
@@ -33,6 +36,7 @@ namespace hdt
 		std::vector<std::shared_ptr<btCollisionShape>> m_shapeRefs;
 		SkinnedMeshWorld* m_world = nullptr;
 
+		float m_windFactor = 1.0f;  // per-system wind multiplier (obstruction-based)
 		bool block_resetting = false;
 		std::vector<RE::BSTSmartPointer<SkinnedMeshBone>>& getBones() { return m_bones; };
 

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -2,8 +2,6 @@
 #include "hdtBoneScaleConstraint.h"
 #include "hdtDispatcher.h"
 #include "hdtSkinnedMeshAlgorithm.h"
-#include "hdtSkyrimPhysicsWorld.h"
-#include "hdtSkyrimSystem.h"
 #include <algorithm>
 #include <cmath>
 #include <thread>
@@ -150,7 +148,7 @@ namespace hdt
 	int SkinnedMeshWorld::stepSimulation(btScalar remainingTimeStep, int, btScalar fixedTimeStep)
 	{
 		applyGravity();
-		if (hdt::SkyrimPhysicsWorld::get()->m_enableWind)
+		if (m_enableWind)
 			applyWind(remainingTimeStep);
 
 		while (remainingTimeStep > fixedTimeStep) {
@@ -258,15 +256,14 @@ namespace hdt
 		const btScalar gustSpeed = clampScalar(windMagnitude * kGustSpeedPerForce, kMinGustSpeed, kMaxGustSpeed);
 
 		for (auto& i : m_systems) {
-			auto system = static_cast<SkyrimSystem*>(i.get());
-			if (btFuzzyZero(system->m_windFactor))  // skip any systems that aren't affected by wind
+			if (btFuzzyZero(i->m_windFactor))  // skip any systems that aren't affected by wind
 				continue;
 			for (auto& j : i->m_bones) {
 				auto body = &j->m_rig;
 				if (body->isStaticOrKinematicObject() || btFuzzyZero(j->m_windFactor))
 					continue;
 
-				const btScalar windFactor = j->m_windFactor * system->m_windFactor;
+				const btScalar windFactor = j->m_windFactor * i->m_windFactor;
 				const btVector3 origin = body->getWorldTransform().getOrigin();
 				// Move gust phases downwind so stronger wind carries the same gust across bones faster
 				const btScalar advectedTime = m_windTime - origin.dot(windDirection) / gustSpeed - origin.dot(side) * kCrosswindTimeScale;

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "hdtSkinnedMeshSystem.h"
-#include "hdtSkyrimSystem.h"
 #include <BulletCollision/CollisionDispatch/btSimulationIslandManager.h>
 #include <BulletDynamics/Dynamics/btDiscreteDynamicsWorldMt.h>
 
@@ -23,6 +22,8 @@ namespace hdt
 
 		btVector3& getWind() { return m_windSpeed; }
 		const btVector3& getWind() const { return m_windSpeed; }
+
+		bool m_enableWind = true;
 
 	protected:
 		std::vector<float> m_timeSteps;

--- a/src/hdtSkyrimPhysicsWorld.h
+++ b/src/hdtSkyrimPhysicsWorld.h
@@ -25,8 +25,8 @@ namespace hdt
 		void addSkinnedMeshSystem(SkinnedMeshSystem* system) override;
 		void removeSkinnedMeshSystem(SkinnedMeshSystem* system) override;
 		void removeSystemByNode(void* root);
-		using SkinnedMeshWorld::updateConstraintsForBone;
 		using SkinnedMeshWorld::m_enableWind;  // re-expose through protected base inheritance
+		using SkinnedMeshWorld::updateConstraintsForBone;
 
 		void resetSystems();
 

--- a/src/hdtSkyrimPhysicsWorld.h
+++ b/src/hdtSkyrimPhysicsWorld.h
@@ -7,8 +7,6 @@
 
 namespace hdt
 {
-	constexpr float RESET_PHYSICS = -10.0f;
-
 	class SkyrimPhysicsWorld :
 		protected SkinnedMeshWorld,
 		public RE::BSTEventSink<Events::FrameEvent>,
@@ -28,6 +26,7 @@ namespace hdt
 		void removeSkinnedMeshSystem(SkinnedMeshSystem* system) override;
 		void removeSystemByNode(void* root);
 		using SkinnedMeshWorld::updateConstraintsForBone;
+		using SkinnedMeshWorld::m_enableWind;  // re-expose through protected base inheritance
 
 		void resetSystems();
 
@@ -89,7 +88,6 @@ namespace hdt
 		int m_sampleSize = 5;  // how many samples (each sample taken every second) for determining average time per activeSkeleton.
 
 		//wind settings
-		bool m_enableWind = true;
 		float m_windStrength = 2.0f;           // compare to gravity acceleration of 9.8
 		float m_distanceForNoWind = 50.0f;     // how close to wind obstruction to fully block wind
 		float m_distanceForMaxWind = 3000.0f;  // how far to wind obstruction to not block wind

--- a/src/hdtSkyrimSystem.h
+++ b/src/hdtSkyrimSystem.h
@@ -37,7 +37,6 @@ namespace hdt
 		RE::NiPointer<RE::NiNode> m_skeleton;
 		RE::NiPointer<RE::NiNode> m_oldRoot;
 		bool m_initialized = false;
-		float m_windFactor = 1.f;  // wind factor for the system (i.e., full actor/skeleton) (calculated based off obstructions)
 
 		// angular velocity damper
 		btQuaternion m_lastRootRotation;

--- a/tools/smpview/CMakeLists.txt
+++ b/tools/smpview/CMakeLists.txt
@@ -1,0 +1,44 @@
+# smpview — standalone HDT-SMP physics viewer/tuner (Phase 0 foundation).
+#
+# This is a SELF-CONTAINED CMake project, deliberately NOT add_subdirectory()'d
+# from the mod's root CMakeLists: smpcore reuses the unmodified hdtSkinnedMesh/*
+# physics sources but links only Bullet + TBB (+ Windows SDK) — no CommonLibSSE,
+# no SKSE. Keeping it separate means the tool builds without the mod's runtime
+# dependency graph.
+#
+# Configure like the mod (vcpkg toolchain supplies Bullet + TBB), e.g.:
+#   cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake
+#   cmake --build build --config Release
+cmake_minimum_required(VERSION 3.21)
+project(smpview CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Bullet CONFIG REQUIRED)
+find_package(TBB CONFIG REQUIRED)
+
+# The mod's physics core, reused verbatim. Relative to tools/smpview/.
+set(CORE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../src/hdtSkinnedMesh")
+file(GLOB SMPCORE_SOURCES CONFIGURE_DEPENDS "${CORE_DIR}/*.cpp")
+
+add_library(smpcore STATIC ${SMPCORE_SOURCES})
+
+# Same Bullet SIMD-in-API define the mod sets (root CMakeLists.txt). Without it,
+# btVector3 <-> __m128 assignments in hdtBulletHelper.h fail to compile.
+target_compile_definitions(smpcore PUBLIC BT_USE_SSE_IN_API NOMINMAX)
+target_compile_options(smpcore PUBLIC /arch:AVX2)
+
+# Swap the mod's CommonLibSSE PCH for the standalone shim — this is the seam.
+target_precompile_headers(smpcore PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/re_shim/smpcore_pch.h")
+
+target_include_directories(smpcore PUBLIC
+	"${CMAKE_CURRENT_SOURCE_DIR}/re_shim"
+	"${CMAKE_CURRENT_SOURCE_DIR}/../../src"
+	"${CORE_DIR}"
+	${BULLET_INCLUDE_DIRS})
+
+target_link_libraries(smpcore PUBLIC ${BULLET_LIBRARIES} TBB::tbb)
+
+add_executable(smpview_smoketest "${CMAKE_CURRENT_SOURCE_DIR}/src/smoketest.cpp")
+target_link_libraries(smpview_smoketest PRIVATE smpcore)

--- a/tools/smpview/CMakeLists.txt
+++ b/tools/smpview/CMakeLists.txt
@@ -1,14 +1,11 @@
 # smpview — standalone HDT-SMP physics viewer/tuner (Phase 0 foundation).
 #
-# This is a SELF-CONTAINED CMake project, deliberately NOT add_subdirectory()'d
-# from the mod's root CMakeLists: smpcore reuses the unmodified hdtSkinnedMesh/*
-# physics sources but links only Bullet + TBB (+ Windows SDK) — no CommonLibSSE,
-# no SKSE. Keeping it separate means the tool builds without the mod's runtime
-# dependency graph.
+# This is a SELF-CONTAINED CMake project, deliberately NOT add_subdirectory()'d from the mod's root CMakeLists: smpcore
+# reuses the unmodified hdtSkinnedMesh/* physics sources but links only Bullet + TBB (+ Windows SDK) — no CommonLibSSE,
+# no SKSE. Keeping it separate means the tool builds without the mod's runtime dependency graph.
 #
-# Configure like the mod (vcpkg toolchain supplies Bullet + TBB), e.g.:
-#   cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake
-#   cmake --build build --config Release
+# Configure like the mod (vcpkg toolchain supplies Bullet + TBB), e.g.: cmake -B build -S .
+# -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake cmake --build build --config Release
 cmake_minimum_required(VERSION 3.21)
 project(smpview CXX)
 
@@ -24,19 +21,16 @@ file(GLOB SMPCORE_SOURCES CONFIGURE_DEPENDS "${CORE_DIR}/*.cpp")
 
 add_library(smpcore STATIC ${SMPCORE_SOURCES})
 
-# Same Bullet SIMD-in-API define the mod sets (root CMakeLists.txt). Without it,
-# btVector3 <-> __m128 assignments in hdtBulletHelper.h fail to compile.
+# Same Bullet SIMD-in-API define the mod sets (root CMakeLists.txt). Without it, btVector3 <-> __m128 assignments in
+# hdtBulletHelper.h fail to compile.
 target_compile_definitions(smpcore PUBLIC BT_USE_SSE_IN_API NOMINMAX)
 target_compile_options(smpcore PUBLIC /arch:AVX2)
 
 # Swap the mod's CommonLibSSE PCH for the standalone shim — this is the seam.
 target_precompile_headers(smpcore PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/re_shim/smpcore_pch.h")
 
-target_include_directories(smpcore PUBLIC
-	"${CMAKE_CURRENT_SOURCE_DIR}/re_shim"
-	"${CMAKE_CURRENT_SOURCE_DIR}/../../src"
-	"${CORE_DIR}"
-	${BULLET_INCLUDE_DIRS})
+target_include_directories(smpcore PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/re_shim" "${CMAKE_CURRENT_SOURCE_DIR}/../../src"
+										  "${CORE_DIR}" ${BULLET_INCLUDE_DIRS})
 
 target_link_libraries(smpcore PUBLIC ${BULLET_LIBRARIES} TBB::tbb)
 

--- a/tools/smpview/README.md
+++ b/tools/smpview/README.md
@@ -1,0 +1,43 @@
+# smpview
+
+A standalone HDT-SMP physics viewer/tuner that reuses FSMP's **actual** `hdt::`
+solver outside Skyrim, so previews are faithful by construction (same constraint
+code) rather than an approximation. Tracks issue #391.
+
+## Status: Phase 0 (foundation)
+
+Proven: the physics core (`src/hdtSkinnedMesh/*`) compiles and links with **no
+CommonLibSSE / SKSE**, behind a ~210-line compatibility shim, and a smoke test
+constructs + steps a real `SkinnedMeshWorld` standalone.
+
+The seam is the PCH: the mod force-includes `src/PCH.h` (which pulls
+`<RE/Skyrim.h>`); `smpcore` swaps in [`re_shim/smpcore_pch.h`](re_shim/smpcore_pch.h),
+which provides only the few `RE::` utility types the core uses
+(`BSIntrusiveRefCounted`, `BSTSmartPointer`, `make_smart`, `BSFixedString`,
+`logger`). The one core→Skyrim coupling — two data members and the
+`RESET_PHYSICS` sentinel — was removed by hoisting them into the base classes
+(`SkinnedMeshWorld` / `SkinnedMeshSystem`), which also fixes a base-includes-
+derived smell in the mod itself.
+
+## Layout
+
+- `re_shim/smpcore_pch.h` — standalone PCH (CommonLibSSE-free).
+- `src/smoketest.cpp` — constructs + steps an empty `SkinnedMeshWorld`.
+- `CMakeLists.txt` — self-contained project building `smpcore` (static lib) and
+  `smpview_smoketest`. Links Bullet + TBB only.
+
+## Build
+
+Self-contained; configure with the vcpkg toolchain that supplies Bullet + TBB:
+
+```
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake
+cmake --build build --config Release
+./build/smpview_smoketest      # prints "smpcore OK: ..."
+```
+
+## Not yet implemented (later phases / follow-up issues)
+
+nifly-backed NIF/skeleton loading · GLFW/OpenGL + ImGui rendering and live
+parameter sliders · kinematic driver (gravity-settle / procedural sway / drag) ·
+SMP XML round-trip and Validator-clean export.

--- a/tools/smpview/re_shim/smpcore_pch.h
+++ b/tools/smpview/re_shim/smpcore_pch.h
@@ -63,10 +63,18 @@ namespace RE
 		BSTSmartPointer(std::nullptr_t) noexcept {}
 
 		explicit BSTSmartPointer(T* a_ptr) :
-			_ptr(a_ptr) { if (_ptr) _ptr->IncRef(); }
+			_ptr(a_ptr)
+		{
+			if (_ptr)
+				_ptr->IncRef();
+		}
 
 		BSTSmartPointer(const BSTSmartPointer& a_rhs) :
-			_ptr(a_rhs._ptr) { if (_ptr) _ptr->IncRef(); }
+			_ptr(a_rhs._ptr)
+		{
+			if (_ptr)
+				_ptr->IncRef();
+		}
 
 		BSTSmartPointer(BSTSmartPointer&& a_rhs) noexcept :
 			_ptr(a_rhs._ptr) { a_rhs._ptr = nullptr; }
@@ -74,7 +82,11 @@ namespace RE
 		// Covariant construction (store derived in a base-typed pointer).
 		template <class U>
 		BSTSmartPointer(const BSTSmartPointer<U>& a_rhs) :
-			_ptr(a_rhs.get()) { if (_ptr) _ptr->IncRef(); }
+			_ptr(a_rhs.get())
+		{
+			if (_ptr)
+				_ptr->IncRef();
+		}
 
 		~BSTSmartPointer() { release_(); }
 
@@ -209,10 +221,22 @@ namespace std
 // --- logging shim: core only uses logger::info; make all levels no-ops ------
 namespace logger
 {
-	template <class... Args> void trace(Args&&...) {}
-	template <class... Args> void debug(Args&&...) {}
-	template <class... Args> void info(Args&&...) {}
-	template <class... Args> void warn(Args&&...) {}
-	template <class... Args> void error(Args&&...) {}
-	template <class... Args> void critical(Args&&...) {}
+	template <class... Args>
+	void trace(Args&&...)
+	{}
+	template <class... Args>
+	void debug(Args&&...)
+	{}
+	template <class... Args>
+	void info(Args&&...)
+	{}
+	template <class... Args>
+	void warn(Args&&...)
+	{}
+	template <class... Args>
+	void error(Args&&...)
+	{}
+	template <class... Args>
+	void critical(Args&&...)
+	{}
 }

--- a/tools/smpview/re_shim/smpcore_pch.h
+++ b/tools/smpview/re_shim/smpcore_pch.h
@@ -1,0 +1,218 @@
+// smpcore_pch.h — standalone replacement for hdtSMP64 src/PCH.h
+//
+// Lets the hdtSkinnedMesh/* physics core compile with NO CommonLibSSE / SKSE.
+// The mod's real PCH force-includes <RE/Skyrim.h>; here we provide only the
+// handful of RE:: utility types the core actually uses: BSIntrusiveRefCounted,
+// BSTSmartPointer<T>, make_smart, BSFixedString (+std::hash), the `logger`
+// namespace, plus <windows.h>/<tbb/tbb.h>/std (all things the mod PCH supplied
+// transitively — none of them CommonLibSSE).
+//
+// Modeled on the existing standalone refcount base hdt::RefObject in
+// hdtBulletHelper.h, which already proves intrusive refcounting works here.
+#pragma once
+
+// Win32 types the core uses (ZeroMemory, UINT, ...) — the mod PCH gets these
+// transitively via <RE/Skyrim.h>; standalone we include <windows.h> directly.
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+// std umbrella the core relied on the mod PCH to provide.
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <cinttypes>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+// TBB umbrella — core uses tbb::parallel_for_each / parallel_for (mod PCH:30).
+#include <tbb/tbb.h>
+
+using namespace std::literals;
+
+// --- minimal RE:: shim ------------------------------------------------------
+namespace RE
+{
+	// Intrusive refcount base. CommonLibSSE semantics: IncRef/DecRef return the
+	// new count; the smart pointer deletes the object when DecRef() hits 0.
+	class BSIntrusiveRefCounted
+	{
+	public:
+		std::uint32_t IncRef() const noexcept { return ++_refCount; }
+		std::uint32_t DecRef() const noexcept { return --_refCount; }
+		std::uint32_t GetRefCount() const noexcept { return _refCount.load(); }
+
+	private:
+		mutable std::atomic<std::uint32_t> _refCount{ 0 };
+	};
+
+	// Intrusive smart pointer. Works with any T exposing IncRef()/DecRef()
+	// (both BSIntrusiveRefCounted-derived and hdt::RefObject-derived qualify).
+	template <class T>
+	class BSTSmartPointer
+	{
+	public:
+		BSTSmartPointer() noexcept = default;
+		BSTSmartPointer(std::nullptr_t) noexcept {}
+
+		explicit BSTSmartPointer(T* a_ptr) :
+			_ptr(a_ptr) { if (_ptr) _ptr->IncRef(); }
+
+		BSTSmartPointer(const BSTSmartPointer& a_rhs) :
+			_ptr(a_rhs._ptr) { if (_ptr) _ptr->IncRef(); }
+
+		BSTSmartPointer(BSTSmartPointer&& a_rhs) noexcept :
+			_ptr(a_rhs._ptr) { a_rhs._ptr = nullptr; }
+
+		// Covariant construction (store derived in a base-typed pointer).
+		template <class U>
+		BSTSmartPointer(const BSTSmartPointer<U>& a_rhs) :
+			_ptr(a_rhs.get()) { if (_ptr) _ptr->IncRef(); }
+
+		~BSTSmartPointer() { release_(); }
+
+		BSTSmartPointer& operator=(const BSTSmartPointer& a_rhs)
+		{
+			reset(a_rhs._ptr);
+			return *this;
+		}
+
+		BSTSmartPointer& operator=(BSTSmartPointer&& a_rhs) noexcept
+		{
+			if (this != &a_rhs) {
+				release_();
+				_ptr = a_rhs._ptr;
+				a_rhs._ptr = nullptr;
+			}
+			return *this;
+		}
+
+		template <class U>
+		BSTSmartPointer& operator=(const BSTSmartPointer<U>& a_rhs)
+		{
+			reset(a_rhs.get());
+			return *this;
+		}
+
+		void reset() noexcept { release_(); }
+
+		void reset(T* a_ptr)
+		{
+			if (a_ptr)
+				a_ptr->IncRef();  // bump new first (handles self-reset)
+			release_();
+			_ptr = a_ptr;
+		}
+
+		[[nodiscard]] T* get() const noexcept { return _ptr; }
+		T* operator->() const noexcept { return _ptr; }
+		T& operator*() const noexcept { return *_ptr; }
+		explicit operator bool() const noexcept { return _ptr != nullptr; }
+
+	private:
+		void release_() noexcept
+		{
+			if (_ptr && _ptr->DecRef() == 0)
+				delete _ptr;
+			_ptr = nullptr;
+		}
+
+		T* _ptr = nullptr;
+	};
+
+	template <class T1, class T2>
+	[[nodiscard]] constexpr bool operator==(const BSTSmartPointer<T1>& a_lhs, T2* a_rhs)
+	{
+		return a_lhs.get() == a_rhs;
+	}
+	template <class T1, class T2>
+	[[nodiscard]] constexpr bool operator!=(const BSTSmartPointer<T1>& a_lhs, T2* a_rhs)
+	{
+		return a_lhs.get() != a_rhs;
+	}
+	template <class T1>
+	[[nodiscard]] constexpr bool operator==(const BSTSmartPointer<T1>& a_lhs, std::nullptr_t)
+	{
+		return a_lhs.get() == nullptr;
+	}
+	template <class T1>
+	[[nodiscard]] constexpr bool operator!=(const BSTSmartPointer<T1>& a_lhs, std::nullptr_t)
+	{
+		return a_lhs.get() != nullptr;
+	}
+
+	template <class T, class... Args>
+	[[nodiscard]] BSTSmartPointer<T> make_smart(Args&&... a_args)
+	{
+		BSTSmartPointer<T> r;
+		r.reset(new T(std::forward<Args>(a_args)...));
+		return r;
+	}
+
+	// Interned-string stand-in. The mod's BSFixedString interns + compares by
+	// pooled pointer; for a single-threaded standalone viewer plain std::string
+	// value semantics are correct (just O(len) compare instead of O(1)).
+	class BSFixedString
+	{
+	public:
+		BSFixedString() = default;
+		BSFixedString(const char* a_s) :
+			_s(a_s ? a_s : "") {}
+		BSFixedString(const std::string& a_s) :
+			_s(a_s) {}
+
+		[[nodiscard]] const char* data() const noexcept { return _s.c_str(); }
+		[[nodiscard]] const char* c_str() const noexcept { return _s.c_str(); }
+		[[nodiscard]] bool empty() const noexcept { return _s.empty(); }
+		[[nodiscard]] const std::string& str() const noexcept { return _s; }
+
+		bool operator==(const BSFixedString& a_rhs) const { return _s == a_rhs._s; }
+		bool operator!=(const BSFixedString& a_rhs) const { return _s != a_rhs._s; }
+		bool operator==(const char* a_rhs) const { return _s == (a_rhs ? a_rhs : ""); }
+		bool operator!=(const char* a_rhs) const { return !(*this == a_rhs); }
+
+	private:
+		std::string _s;
+	};
+}
+
+namespace hdt
+{
+	template <class T>
+	[[nodiscard]] RE::BSTSmartPointer<T> make_smart(T* a_ptr)
+	{
+		RE::BSTSmartPointer<T> result;
+		result.reset(a_ptr);
+		return result;
+	}
+}
+
+namespace std
+{
+	template <>
+	struct hash<RE::BSFixedString>
+	{
+		[[nodiscard]] std::size_t operator()(const RE::BSFixedString& a_key) const noexcept
+		{
+			return std::hash<std::string>{}(a_key.str());
+		}
+	};
+}
+
+// --- logging shim: core only uses logger::info; make all levels no-ops ------
+namespace logger
+{
+	template <class... Args> void trace(Args&&...) {}
+	template <class... Args> void debug(Args&&...) {}
+	template <class... Args> void info(Args&&...) {}
+	template <class... Args> void warn(Args&&...) {}
+	template <class... Args> void error(Args&&...) {}
+	template <class... Args> void critical(Args&&...) {}
+}

--- a/tools/smpview/src/smoketest.cpp
+++ b/tools/smpview/src/smoketest.cpp
@@ -1,0 +1,27 @@
+// smpview Phase 0 smoke test.
+//
+// Proves the standalone smpcore static lib links and runs: it constructs the
+// real hdt::SkinnedMeshWorld (Bullet MT world + custom dispatcher/solver pool,
+// all from FSMP's unmodified physics core) and steps it a few frames with no
+// systems attached. No CommonLibSSE, no Skyrim runtime. If this exits 0, the
+// physics core is usable outside the game — the foundation every later smpview
+// phase (nifly load, render, tuning, XML export) builds on.
+#include "hdtSkinnedMesh/hdtSkinnedMeshWorld.h"
+
+#include <cstdio>
+
+int main()
+{
+	hdt::SkinnedMeshWorld world;
+
+	// Exercise a member hoisted into the base during decoupling (was on the
+	// Skyrim-only SkyrimPhysicsWorld): toggling it must compile and link here.
+	world.m_enableWind = false;
+
+	constexpr int kFrames = 8;
+	for (int i = 0; i < kFrames; ++i)
+		world.stepSimulation(1.0f / 60.0f);
+
+	std::printf("smpcore OK: stepped empty SkinnedMeshWorld %d frames standalone\n", kFrames);
+	return 0;
+}


### PR DESCRIPTION
Closes #391 (Phase 0 only; later phases tracked as follow-ups).

## What

Phase 0 of **smpview** — a standalone HDT-SMP physics viewer/tuner that reuses FSMP's *actual* `hdt::` solver outside the game, so previews are faithful by construction rather than an approximation. This PR only stands up the foundation: the physics core builds and links with **no CommonLibSSE/SKSE**.

Two commits:

1. **refactor** — decouple the physics core from the Skyrim layer. `hdtSkinnedMeshWorld` reached into the Skyrim layer at three points, all plain shared values in the wrong class:
   - `m_enableWind` (bool) → base `SkinnedMeshWorld` (re-exposed through `SkyrimPhysicsWorld`'s protected inheritance with a `using`-declaration, matching the existing `updateConstraintsForBone` one)
   - `m_windFactor` (float, per-system) → base `SkinnedMeshSystem`
   - `RESET_PHYSICS` (sentinel timestep) → `hdtSkinnedMeshSystem.h`

   The world file no longer downcasts to `SkyrimSystem` or includes the Skyrim headers, removing a base-includes-derived cycle. Net `+10/−11`.

2. **feat** — `tools/smpview/`: a self-contained CMake project building the `hdtSkinnedMesh/*` sources as a standalone `smpcore` static lib (Bullet + TBB only) via a shim PCH (`re_shim/smpcore_pch.h`) that replaces the mod's CommonLibSSE PCH, plus a `smpview_smoketest`. Not wired into the mod build.

## Verification

- **Standalone:** all **13/13** core TUs compile against the shim with zero CommonLibSSE; `smpcore.lib` archives, links, and the smoke test runs — constructs a real `SkinnedMeshWorld` and steps it 8 frames → exit 0.
- **Mod `/WX`:** `hdtsmp64.dll` builds clean in Release (`user-vs2022-windows-avx2`). The first build caught a real access error (`m_enableWind` behind protected inheritance); the `using`-declaration fixes it and is included in commit 1.

## Out of scope (follow-up issues)

nifly-backed NIF/skeleton loading · GLFW/OpenGL + ImGui rendering and live parameter sliders · kinematic driver (gravity-settle / procedural sway / drag) · SMP XML round-trip and Validator-clean export.

## Why draft

Foundation only — opening as draft for design feedback on the shim/decoupling approach before building the later phases on top.
