### PR TITLE
feat: default 'smp report' to errors-only; add 'smp report warnings' for the full report

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -439,8 +439,8 @@ bool SMPDebug_Execute(
 				includeWarnings = true;
 				return true;
 			}
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Unknown report mode: %s", arg);
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Usage: smp report [gear] [warnings]");
+			RE::ConsoleLog::GetSingleton()->Print("[Validator] Unknown report mode: %s", arg);
+			RE::ConsoleLog::GetSingleton()->Print("[Validator] Usage: smp report [gear] [warnings]");
 			return false;
 		};
 
@@ -448,17 +448,17 @@ bool SMPDebug_Execute(
 			return true;
 
 		if (s_validationRunning.exchange(true)) {
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Validation is already running.");
+			RE::ConsoleLog::GetSingleton()->Print("[Validator] Validation is already running.");
 			return true;
 		}
 		if (gearOnly && includeWarnings) {
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Equipped gear report (with warnings) started in background. Results will appear when complete.");
+			RE::ConsoleLog::GetSingleton()->Print("[Validator] Equipped gear report (with warnings) started in background. Results will appear when complete.");
 		} else if (gearOnly) {
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Equipped gear report (errors only) started in background. Results will appear when complete.");
+			RE::ConsoleLog::GetSingleton()->Print("[Validator] Equipped gear report (errors only) started in background. Results will appear when complete.");
 		} else if (includeWarnings) {
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Report (with warnings) started in background. Results will appear when complete.");
+			RE::ConsoleLog::GetSingleton()->Print("[Validator] Report (with warnings) started in background. Results will appear when complete.");
 		} else {
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Report (errors only) started in background. Results will appear when complete.");
+			RE::ConsoleLog::GetSingleton()->Print("[Validator] Report (errors only) started in background. Results will appear when complete.");
 		}
 		std::thread([gearOnly, includeWarnings]() {
 			try {
@@ -471,14 +471,14 @@ bool SMPDebug_Execute(
 				auto* console = RE::ConsoleLog::GetSingleton();
 				if (includeWarnings) {
 					console->Print(
-						"[HDT-SMP] %s complete in %.2fs: %d XML(s) found, %d passed, %d failed, %d warning(s)",
+						"[Validator] %s complete in %.2fs: %d XML(s) found, %d passed, %d failed, %d warning(s)",
 						validationLabel,
 						result.elapsedSeconds,
 						result.totalXMLsFound, result.xmlPassCount, result.xmlErrorCount,
 						(int)result.warnings.size());
 				} else {
 					console->Print(
-						"[HDT-SMP] %s complete in %.2fs: %d XML(s) found, %d failed (errors only)",
+						"[Validator] %s complete in %.2fs: %d XML(s) found, %d failed (errors only)",
 						validationLabel,
 						result.elapsedSeconds,
 						result.totalXMLsFound,
@@ -486,18 +486,18 @@ bool SMPDebug_Execute(
 				}
 				if (!reportPath.empty()) {
 					if (includeWarnings) {
-						console->Print("[HDT-SMP] Report written to: %s", reportPath.c_str());
+						console->Print("[Validator] Report written to: %s", reportPath.c_str());
 					} else {
-						console->Print("[HDT-SMP] Errors-only report written to: %s", reportPath.c_str());
+						console->Print("[Validator] Errors-only report written to: %s", reportPath.c_str());
 					}
 				} else {
-					console->Print("[HDT-SMP] Warning: report file could not be written");
+					console->Print("[Validator] Warning: report file could not be written");
 				}
 			} catch (const std::exception& e) {
-				RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Report failed with error: %s", e.what());
+				RE::ConsoleLog::GetSingleton()->Print("[Validator] Report failed with error: %s", e.what());
 				logger::error("[Validator] smp report threw: {}", e.what());
 			} catch (...) {
-				RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Report failed with an unknown error");
+				RE::ConsoleLog::GetSingleton()->Print("[Validator] Report failed with an unknown error");
 				logger::error("[Validator] smp report threw an unknown exception");
 			}
 			s_validationRunning.store(false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -338,10 +338,11 @@ bool SMPDebug_Execute(
 		console->Print("    Disable SMP simulation.");
 		console->Print("  smp QueryOverride");
 		console->Print("    Print current dynamic override data.");
-		console->Print("  smp report [gear] [error]");
+		console->Print("  smp report [gear] [warnings]");
 		console->Print("    Run the physics-asset validator in the background and write a report file.");
-		console->Print("    gear  = validate equipped gear only.");
-		console->Print("    error = write an errors-only report (no warnings/info).");
+		console->Print("    Default: errors only (no warnings/info).");
+		console->Print("    gear     = validate equipped gear only.");
+		console->Print("    warnings = also include warnings and info in the report.");
 		return true;
 	}
 
@@ -426,7 +427,7 @@ bool SMPDebug_Execute(
 		static std::atomic<bool> s_validationRunning{ false };
 
 		bool gearOnly = false;
-		bool errorReport = false;
+		bool includeWarnings = false;  // default: errors only (an explicit 'warnings' opts in)
 		auto parseValidateModeArg = [&](const char* arg) {
 			if (arg[0] == '\0')
 				return true;
@@ -434,12 +435,12 @@ bool SMPDebug_Execute(
 				gearOnly = true;
 				return true;
 			}
-			if (_stricmp(arg, "error") == 0) {
-				errorReport = true;
+			if (_stricmp(arg, "warnings") == 0) {
+				includeWarnings = true;
 				return true;
 			}
 			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Unknown report mode: %s", arg);
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Usage: smp report [gear] [error]");
+			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Usage: smp report [gear] [warnings]");
 			return false;
 		};
 
@@ -450,44 +451,44 @@ bool SMPDebug_Execute(
 			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Validation is already running.");
 			return true;
 		}
-		if (gearOnly && errorReport) {
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Equipped gear report (error report) started in background. Results will appear when complete.");
+		if (gearOnly && includeWarnings) {
+			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Equipped gear report (with warnings) started in background. Results will appear when complete.");
 		} else if (gearOnly) {
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Equipped gear report started in background. Results will appear when complete.");
-		} else if (errorReport) {
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Report (error report) started in background. Results will appear when complete.");
+			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Equipped gear report (errors only) started in background. Results will appear when complete.");
+		} else if (includeWarnings) {
+			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Report (with warnings) started in background. Results will appear when complete.");
 		} else {
-			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Report started in background. Results will appear when complete.");
+			RE::ConsoleLog::GetSingleton()->Print("[HDT-SMP] Report (errors only) started in background. Results will appear when complete.");
 		}
-		std::thread([gearOnly, errorReport]() {
+		std::thread([gearOnly, includeWarnings]() {
 			try {
 				const char* validationLabel = gearOnly ? "Equipped gear report" : "Report";
 				std::string reportPath;
 				auto result = hdt::ValidatePhysicsAssets(
 					reportPath,
 					gearOnly,
-					errorReport ? hdt::ValidationReportMode::ErrorsOnly : hdt::ValidationReportMode::Full);
+					includeWarnings ? hdt::ValidationReportMode::Full : hdt::ValidationReportMode::ErrorsOnly);
 				auto* console = RE::ConsoleLog::GetSingleton();
-				if (errorReport) {
-					console->Print(
-						"[HDT-SMP] %s complete in %.2fs: %d XML(s) found, %d failed (error report: errors only)",
-						validationLabel,
-						result.elapsedSeconds,
-						result.totalXMLsFound,
-						result.xmlErrorCount);
-				} else {
+				if (includeWarnings) {
 					console->Print(
 						"[HDT-SMP] %s complete in %.2fs: %d XML(s) found, %d passed, %d failed, %d warning(s)",
 						validationLabel,
 						result.elapsedSeconds,
 						result.totalXMLsFound, result.xmlPassCount, result.xmlErrorCount,
 						(int)result.warnings.size());
+				} else {
+					console->Print(
+						"[HDT-SMP] %s complete in %.2fs: %d XML(s) found, %d failed (errors only)",
+						validationLabel,
+						result.elapsedSeconds,
+						result.totalXMLsFound,
+						result.xmlErrorCount);
 				}
 				if (!reportPath.empty()) {
-					if (errorReport) {
-						console->Print("[HDT-SMP] Errors-only report written to: %s", reportPath.c_str());
-					} else {
+					if (includeWarnings) {
 						console->Print("[HDT-SMP] Report written to: %s", reportPath.c_str());
+					} else {
+						console->Print("[HDT-SMP] Errors-only report written to: %s", reportPath.c_str());
 					}
 				} else {
 					console->Print("[HDT-SMP] Warning: report file could not be written");
@@ -727,7 +728,7 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 
 		unusedCommand->functionName = "SMPDebug";
 		unusedCommand->shortName = "smp";
-		unusedCommand->helpString = "smp <help|reset|report [gear] [error]>";
+		unusedCommand->helpString = "smp <help|reset|report [gear] [warnings]>";
 		unusedCommand->referenceFunction = 0;
 		unusedCommand->numParams = 3;
 		unusedCommand->params = params;


### PR DESCRIPTION
## What

Changes the `smp report` console command so it defaults to an **errors-only** report, and adds `smp report warnings` for the full report (errors + warnings + info) that used to be the default.

| Command | Before | After |
|---|---|---|
| `smp report` | errors + warnings + info | **errors only** |
| `smp report warnings` | *(n/a)* | **errors + warnings + info** |
| `smp report gear` | equipped, errors + warnings | equipped, **errors only** |
| `smp report gear warnings` | *(n/a)* | equipped, errors + warnings |
| `smp report error` | errors only | **removed** — now rejected as an unknown mode (errors-only is the default) |

Rationale: keep the common case focused on what actually breaks physics; make the noisier warnings/info opt-in.

## How

Inverted the command's report-mode selection in `src/main.cpp` (`errorReport` opt-in-errors-only → `includeWarnings` opt-in-warnings, default off). The `ValidationReportMode` enum and report builders are untouched — only the CLI's mode selection changed. Usage is now `smp report [gear] [warnings]`; help text and background/completion messages updated.

## Note — `error` removed

The old `error` argument is gone: `smp report error` now prints "Unknown report mode" + usage. Its previous behaviour (errors only) is simply the new default, so use `smp report`.

## Docs

Wikis updated in their own repos (pushed to master):
- **hdtSMP64.wiki**: `11-…smp-report` (command table + report-reading section), `04-…Console-commands`, `10-…Changelog` (new "🔀 Changes" entry under 3.4.0).
- **FSMP-Validator.wiki**: `10-…mod-authors`, `11-…maintainers`.

## Verification

Builds clean (AVX2 Release, `/W4 /WX`), zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated `smp report` console help and usage text to reflect `report [gear] [warnings]`.
* **New Features**
  * Added support for a `warnings` option to include warnings and informational output alongside errors.
* **Bug Fixes**
  * Refined report mode handling so the default remains errors-only, with clearer status/output wording (including warnings count when enabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->