### PR TITLE
fix: smp report: zero-false-positive bone checks; fix duplicate-<bone> parser leak and getOrCreateBone rename asymmetry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,11 @@ jobs:
         run: cmake --build out/build/${{ matrix.preset }} --config Release
 
       - name: Run unit tests
+        # The runner executes the compiled test binary, but GitHub's runners do not support
+        # AVX-512, so an avx512-compiled test crashes on an illegal instruction. The tests
+        # validate SIMD-independent logic, so running them on the <=avx2 variants fully covers
+        # them; skip only the avx512 run (it still builds).
+        if: matrix.preset != 'vs2022-windows-avx512'
         run: ctest --test-dir out/build/${{ matrix.preset }} -C Release --output-on-failure
 
       - name: Verify build info embedded in DLL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,8 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_MANIFEST_MODE=ON `
             -DCompiledPluginsPath="${{ github.workspace }}/out/build/${{ matrix.preset }}/plugins" `
-            -DPROJECT_BUILD_INFO="${{ needs.prepare.outputs.build_info }}"
+            -DPROJECT_BUILD_INFO="${{ needs.prepare.outputs.build_info }}" `
+            -DBUILD_VALIDATOR_TESTS=ON
 
       - name: Create the CompiledPluginsPath folder structure
         run: mkdir -p "${{ github.workspace }}/out/build/${{ matrix.preset }}/plugins/SKSE/Plugins/"
@@ -180,6 +181,9 @@ jobs:
 
       - name: Build according to the preset
         run: cmake --build out/build/${{ matrix.preset }} --config Release
+
+      - name: Run unit tests
+        run: ctest --test-dir out/build/${{ matrix.preset }} -C Release --output-on-failure
 
       - name: Verify build info embedded in DLL
         if: needs.prepare.outputs.build_info != ''

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,12 @@ option(ENABLE_SKYRIM_SE "Enable support for Skyrim SE in the dynamic runtime fea
 option(ENABLE_SKYRIM_AE "Enable support for Skyrim AE in the dynamic runtime feature." ON)
 option(ENABLE_SKYRIM_VR "Enable support for Skyrim VR in the dynamic runtime feature." ON)
 
-# Headless doctest suite for the XML reader contract and the validator's inert-<bone>
-# warning (a dev/CI tool, never packaged; no CommonLibSSE), mirroring tests/patterns.
+# Headless doctest suite for the XML reader contract and the validator's inert-<bone> warning (a dev/CI tool, never
+# packaged; no CommonLibSSE), mirroring tests/patterns.
 option(BUILD_VALIDATOR_TESTS "Build the validator/XML-reader doctest suite" OFF)
 
-# CommonLibSSE consumes a variable of this exact name to gate its own Catch2-based
-# tests; keep them off (Catch2 is not in our vcpkg manifest).
+# CommonLibSSE consumes a variable of this exact name to gate its own Catch2-based tests; keep them off (Catch2 is not
+# in our vcpkg manifest).
 set(BUILD_TESTS OFF)
 
 # default definitions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,12 @@ option(ENABLE_SKYRIM_SE "Enable support for Skyrim SE in the dynamic runtime fea
 option(ENABLE_SKYRIM_AE "Enable support for Skyrim AE in the dynamic runtime feature." ON)
 option(ENABLE_SKYRIM_VR "Enable support for Skyrim VR in the dynamic runtime feature." ON)
 
-#
+# Headless doctest suite for the XML reader contract and the validator's inert-<bone>
+# warning (a dev/CI tool, never packaged; no CommonLibSSE), mirroring tests/patterns.
+option(BUILD_VALIDATOR_TESTS "Build the validator/XML-reader doctest suite" OFF)
+
+# CommonLibSSE consumes a variable of this exact name to gate its own Catch2-based
+# tests; keep them off (Catch2 is not in our vcpkg manifest).
 set(BUILD_TESTS OFF)
 
 # default definitions
@@ -39,4 +44,10 @@ add_definitions(-DBT_USE_SSE_IN_API)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 add_subdirectory(src)
+
+if(BUILD_VALIDATOR_TESTS)
+	enable_testing()
+	add_subdirectory(tests/validator)
+endif()
+
 include(cmake/packaging.cmake)

--- a/src/NetImmerseUtils.h
+++ b/src/NetImmerseUtils.h
@@ -73,6 +73,14 @@ namespace hdt
 		return ret ? ret->AsNode() : nullptr;
 	}
 
+	// Like findNode, but vets the found object through castNiNode's vtable guard before
+	// the virtual AsNode call, so a VR NiStream stub or junk pointer cannot fault the
+	// caller. Same result as findNode for every valid object.
+	static inline RE::NiNode* findNodeSafe(RE::NiNode* obj, const RE::BSFixedString& name)
+	{
+		return obj ? castNiNode(obj->GetObjectByName(name)) : nullptr;
+	}
+
 	static inline std::string readAllFile(const char* path)
 	{
 		RE::BSResourceNiBinaryStream stream(path);

--- a/src/Validator/Utils/hdtTemplateDefaults.cpp
+++ b/src/Validator/Utils/hdtTemplateDefaults.cpp
@@ -886,6 +886,85 @@ namespace hdt
 			return aliases;
 		}
 
+		// Document-order walk behind CollectInertBoneDeclarations.
+		//
+		// A <bone> declaration is "inert" when the engine never acts on it: the physics
+		// system built from the file — every bone, constraint, and collision — is
+		// byte-for-byte the same whether the declaration is present or deleted.
+		//
+		// Why a second claim of a name is always inert: the engine creates a bone at the
+		// FIRST element naming it — a <bone> declaration, a constraint bodyA/bodyB
+		// endpoint (findBones), or a can-/no-collide-with-bone shape reference
+		// (getOrCreateBone) — and readOrUpdateBone skips any later <bone> of an
+		// already-claimed name ("Bone X already exists, skipped"). If instead the name
+		// resolves to no skeleton node, the first claim creates nothing and the later
+		// <bone> repeats the identical failed lookup. In both worlds the later
+		// declaration contributes nothing, whatever the skeleton looks like.
+		//
+		// Mechanics: `touched` carries every (case-folded) bone name an earlier element
+		// already claimed. "-default" template elements are skipped throughout — their
+		// name/bodyA/bodyB carry template class names, not skeleton nodes, and defining
+		// them creates no bone. Recursion descends only into constraint-group, mirroring
+		// the runtime reader's dispatch.
+		void collectInertBonesInOrder(pugi::xml_node parent,
+			std::unordered_set<std::string>& touched,
+			const std::string* sourceBytes,
+			std::vector<InertBoneInfo>& out)
+		{
+			const auto touch = [&touched](const char* written) {
+				if (written && written[0] != '\0')
+					touched.insert(ToLowerAscii(written));
+			};
+
+			for (auto node = parent.first_child(); node; node = node.next_sibling()) {
+				if (node.type() != pugi::node_element)
+					continue;
+				const std::string localName = std::string(XmlLocalName(node.name()));
+				if (isDefaultNodeName(localName))
+					continue;
+
+				switch (familyForNode(localName)) {
+				case Family::Bone: {
+					const char* name = node.attribute("name").value();
+					if (name[0] == '\0')
+						break;
+					std::string key = ToLowerAscii(name);
+					if (touched.count(key)) {
+						InertBoneInfo info;
+						info.location = BuildNodeLocationPath(node);
+						info.boneName = TrimAsciiWhitespace(name);
+						if (sourceBytes)
+							info.line = OffsetToLineNumber(*sourceBytes, node.offset_debug());
+						out.push_back(std::move(info));
+					} else {
+						touched.insert(std::move(key));
+					}
+					break;
+				}
+				case Family::Generic:
+				case Family::StiffSpring:
+				case Family::ConeTwist:
+					touch(node.attribute("bodyA").value());
+					touch(node.attribute("bodyB").value());
+					break;
+				case Family::PerVertex:
+				case Family::PerTriangle:
+					for (auto child = node.first_child(); child; child = child.next_sibling()) {
+						if (child.type() != pugi::node_element)
+							continue;
+						const std::string_view childName = XmlLocalName(child.name());
+						if (childName == "can-collide-with-bone" || childName == "no-collide-with-bone")
+							touch(child.text().get());
+					}
+					break;
+				default:
+					if (localName == "constraint-group")
+						collectInertBonesInOrder(node, touched, sourceBytes, out);
+					break;
+				}
+			}
+		}
+
 	}  // anonymous namespace
 
 	// ── Public API ────────────────────────────────────────────────────────────
@@ -936,6 +1015,20 @@ namespace hdt
 		const pugi::xml_document& doc)
 	{
 		return collectEquivalentDefaultTemplateAliases(doc);
+	}
+
+	std::vector<InertBoneInfo> CollectInertBoneDeclarations(
+		const pugi::xml_document& doc,
+		const std::string* sourceBytes)
+	{
+		std::vector<InertBoneInfo> out;
+		auto sysNode = findSystemNode(doc);
+		if (!sysNode)
+			return out;
+
+		std::unordered_set<std::string> touched;
+		collectInertBonesInOrder(sysNode, touched, sourceBytes, out);
+		return out;
 	}
 
 }  // namespace hdt

--- a/src/Validator/Utils/hdtTemplateDefaults.cpp
+++ b/src/Validator/Utils/hdtTemplateDefaults.cpp
@@ -924,23 +924,24 @@ namespace hdt
 					continue;
 
 				switch (familyForNode(localName)) {
-				case Family::Bone: {
-					const char* name = node.attribute("name").value();
-					if (name[0] == '\0')
+				case Family::Bone:
+					{
+						const char* name = node.attribute("name").value();
+						if (name[0] == '\0')
+							break;
+						std::string key = ToLowerAscii(name);
+						if (touched.count(key)) {
+							InertBoneInfo info;
+							info.location = BuildNodeLocationPath(node);
+							info.boneName = TrimAsciiWhitespace(name);
+							if (sourceBytes)
+								info.line = OffsetToLineNumber(*sourceBytes, node.offset_debug());
+							out.push_back(std::move(info));
+						} else {
+							touched.insert(std::move(key));
+						}
 						break;
-					std::string key = ToLowerAscii(name);
-					if (touched.count(key)) {
-						InertBoneInfo info;
-						info.location = BuildNodeLocationPath(node);
-						info.boneName = TrimAsciiWhitespace(name);
-						if (sourceBytes)
-							info.line = OffsetToLineNumber(*sourceBytes, node.offset_debug());
-						out.push_back(std::move(info));
-					} else {
-						touched.insert(std::move(key));
 					}
-					break;
-				}
 				case Family::Generic:
 				case Family::StiffSpring:
 				case Family::ConeTwist:

--- a/src/Validator/Utils/hdtTemplateDefaults.cpp
+++ b/src/Validator/Utils/hdtTemplateDefaults.cpp
@@ -886,81 +886,6 @@ namespace hdt
 			return aliases;
 		}
 
-		// Detect top-level <bone> declarations whose complete effective settings are
-		// identical to the bone the engine auto-creates on demand for an undeclared
-		// node — the unnamed bone-default, a kinematic (mass-0) body.
-		//
-		// Why these are removable: when a node is referenced by a constraint or shape
-		// but has no <bone> of its own, FSMP fabricates one from getBoneTemplate("")
-		// (the unnamed bone-default). So a <bone> that only restates that default adds
-		// nothing — a referenced node would get an identical body anyway, and an
-		// unreferenced one leaves the declaration inert — and can be deleted either way.
-		//
-		// The check reuses the same effective-template machinery as the redundant-child
-		// and template-equivalence walks: step through top-level nodes in document order,
-		// keep boneTemplates[""] current as bone-default nodes are seen, and for each
-		// plain <bone> build its full effective FieldMap (inherited template + own field
-		// tags + collision-list overrides) exactly as a bone-default's is built, then
-		// compare it to boneTemplates[""] at that point.
-		//
-		// It is conservative in both directions. Every element child either overwrites a
-		// known field key or, being unmodelled, injects its own tag-name key — so a bone
-		// carrying anything beyond the defaults (a non-default value, a collision-list
-		// override, an unexpected child) ends up with a FieldMap that differs from the
-		// default and is left alone. And with the .sch defaults absent, boneTemplates[""]
-		// holds fewer keys, so an explicit non-default field can only fail to match —
-		// the walk under-reports rather than ever flagging a non-default bone.
-		static std::vector<RedundantBoneInfo> collectRedundantBoneDeclarations(
-			const pugi::xml_document& doc,
-			const std::string* sourceBytes)
-		{
-			std::vector<RedundantBoneInfo> out;
-			auto sysNode = findSystemNode(doc);
-			if (!sysNode)
-				return out;
-
-			const auto baseDefaults = makeBaseDefaults();
-			TemplateMap boneTemplates;
-			{
-				auto it = baseDefaults.find(Family::Bone);
-				boneTemplates[""] = (it != baseDefaults.end()) ? it->second : FieldMap{};
-			}
-
-			for (auto node = sysNode.first_child(); node; node = node.next_sibling()) {
-				if (node.type() != pugi::node_element)
-					continue;
-
-				const std::string localName = std::string(XmlLocalName(node.name()));
-				// Only the bone family touches boneTemplates; everything else is irrelevant
-				// to both the inheritance state and the candidate set, so skip it.
-				if (familyForNode(localName) != Family::Bone)
-					continue;
-
-				const bool isDefault = isDefaultNodeName(localName);  // "bone-default"
-				// Same effective-map construction as the bone-default templates, so a <bone>
-				// and an equivalent bone-default normalise to the same map and compare equal.
-				FieldMap effective = computeNodeEffectiveFields(node, Family::Bone, isDefault, boneTemplates);
-
-				if (isDefault) {
-					const std::string templateName = TrimAsciiWhitespace(node.attribute("name").as_string());
-					boneTemplates[templateName] = std::move(effective);
-					continue;
-				}
-
-				auto defaultIt = boneTemplates.find("");
-				if (defaultIt != boneTemplates.end() && effective == defaultIt->second) {
-					RedundantBoneInfo info;
-					info.location = BuildNodeLocationPath(node);
-					info.boneName = TrimAsciiWhitespace(node.attribute("name").as_string());
-					if (sourceBytes)
-						info.line = OffsetToLineNumber(*sourceBytes, node.offset_debug());
-					out.push_back(std::move(info));
-				}
-			}
-
-			return out;
-		}
-
 	}  // anonymous namespace
 
 	// ── Public API ────────────────────────────────────────────────────────────
@@ -1011,13 +936,6 @@ namespace hdt
 		const pugi::xml_document& doc)
 	{
 		return collectEquivalentDefaultTemplateAliases(doc);
-	}
-
-	std::vector<RedundantBoneInfo> CollectRedundantBoneDeclarations(
-		const pugi::xml_document& doc,
-		const std::string* sourceBytes)
-	{
-		return collectRedundantBoneDeclarations(doc, sourceBytes);
 	}
 
 }  // namespace hdt

--- a/src/Validator/Utils/hdtTemplateDefaults.h
+++ b/src/Validator/Utils/hdtTemplateDefaults.h
@@ -52,10 +52,15 @@ namespace hdt
 		int line = 0;
 	};
 
-	// Find top-level <bone> declarations that only restate the auto-created default
-	// bone (the unnamed bone-default) and are therefore removable with no behavioural
-	// change. Reuses the effective-default machinery; see the .cpp for the conservative
-	// comparison. When sourceBytes is provided, line numbers are computed from offsets.
+	// Find top-level <bone> declarations whose complete effective settings match the unnamed
+	// bone-default. NOTE (issue #402): "matches the default" does NOT imply "removable" — the
+	// engine only re-fabricates an identical bone when the node is skinned by a mesh (and the
+	// default is unchanged at the shape's position) or referenced elsewhere; a present-but-
+	// unskinned-unreferenced default <bone> is a standalone kinematic collider whose removal
+	// deletes a real body. None of that is knowable from the XML alone, so smp report NO LONGER
+	// turns this into removal advice. Retained as a building block for a future gear + mesh-aware
+	// check that resolves skin binding. Reuses the effective-default machinery; see the .cpp.
+	// When sourceBytes is provided, line numbers are computed from offsets.
 	std::vector<RedundantBoneInfo> CollectRedundantBoneDeclarations(
 		const pugi::xml_document& doc,
 		const std::string* sourceBytes = nullptr);

--- a/src/Validator/Utils/hdtTemplateDefaults.h
+++ b/src/Validator/Utils/hdtTemplateDefaults.h
@@ -43,4 +43,31 @@ namespace hdt
 	std::unordered_map<std::string, std::string> CollectEquivalentDefaultTemplateAliases(
 		const pugi::xml_document& doc);
 
+	// One top-level <bone> declaration the engine never uses: by the time the parser
+	// reaches it, an earlier element in the same file has already claimed the same
+	// (case-folded) bone name, so readOrUpdateBone skips it ("Bone X already exists,
+	// skipped") — or, when the name resolves to no node, repeats the identical failed
+	// lookup. Removing such a declaration cannot change behaviour.
+	struct InertBoneInfo
+	{
+		std::string location;  // positional path, e.g. /system[1]/bone[5]
+		std::string boneName;  // value of the bone's name attribute (for the message)
+		int line = 0;
+	};
+
+	// Find top-level <bone> declarations that are inert — never acted on by the engine,
+	// so removable with zero behaviour change — because an earlier same-file element
+	// claims the same bone name first: an earlier <bone>, a constraint
+	// bodyA/bodyB endpoint, or a can-/no-collide-with-bone shape reference — the engine
+	// creates a bone at the first of these it reads, and every later <bone> of that name
+	// is skipped. The walk follows document order (recursing into constraint-group) and
+	// folds case like BSFixedString; renaming cannot break the equivalence because both
+	// occurrences go through the same rename. Only certainty is reported: creators the
+	// engine resolves through data outside this file (mesh skinning) are ignored, so the
+	// walk under-reports rather than ever flagging a live declaration.
+	// When sourceBytes is provided, line numbers are computed from offsets.
+	std::vector<InertBoneInfo> CollectInertBoneDeclarations(
+		const pugi::xml_document& doc,
+		const std::string* sourceBytes = nullptr);
+
 }  // namespace hdt

--- a/src/Validator/Utils/hdtTemplateDefaults.h
+++ b/src/Validator/Utils/hdtTemplateDefaults.h
@@ -43,26 +43,4 @@ namespace hdt
 	std::unordered_map<std::string, std::string> CollectEquivalentDefaultTemplateAliases(
 		const pugi::xml_document& doc);
 
-	// One top-level <bone> declaration found to be redundant: its complete effective
-	// settings match the bone the engine would auto-create for an undeclared node.
-	struct RedundantBoneInfo
-	{
-		std::string location;  // positional path, e.g. /system[1]/bone[5]
-		std::string boneName;  // value of the bone's name attribute (for the message)
-		int line = 0;
-	};
-
-	// Find top-level <bone> declarations whose complete effective settings match the unnamed
-	// bone-default. NOTE (issue #402): "matches the default" does NOT imply "removable" — the
-	// engine only re-fabricates an identical bone when the node is skinned by a mesh (and the
-	// default is unchanged at the shape's position) or referenced elsewhere; a present-but-
-	// unskinned-unreferenced default <bone> is a standalone kinematic collider whose removal
-	// deletes a real body. None of that is knowable from the XML alone, so smp report NO LONGER
-	// turns this into removal advice. Retained as a building block for a future gear + mesh-aware
-	// check that resolves skin binding. Reuses the effective-default machinery; see the .cpp.
-	// When sourceBytes is provided, line numbers are computed from offsets.
-	std::vector<RedundantBoneInfo> CollectRedundantBoneDeclarations(
-		const pugi::xml_document& doc,
-		const std::string* sourceBytes = nullptr);
-
 }  // namespace hdt

--- a/src/Validator/Validators/hdtNIFBoneRefValidator.cpp
+++ b/src/Validator/Validators/hdtNIFBoneRefValidator.cpp
@@ -7,18 +7,31 @@
 #include <pugixml.hpp>
 
 #include <algorithm>
+#include <cctype>
+#include <cstdint>
 #include <string>
+#include <unordered_set>
 
 namespace hdt
 {
 	namespace
 	{
+		// ASCII lower-case, mirroring the engine's case-insensitive BSFixedString name matching
+		// so a name written in a different case than the skeleton/mesh uses still compares equal.
+		std::string toLowerAscii(std::string s)
+		{
+			for (char& c : s)
+				c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+			return s;
+		}
+
 		// Mirror of SkyrimSystemCreator::getRenamedBone: a mapped name resolves to its
-		// merged-skeleton form, an unmapped name is looked up verbatim.
+		// merged-skeleton form, an unmapped name is looked up verbatim. Case-insensitive like
+		// getRenamedBone's BSFixedString lookup — `renameMap` must have lower-cased keys.
 		std::string applyRename(const std::string& name,
 			const std::unordered_map<std::string, std::string>& renameMap)
 		{
-			auto it = renameMap.find(name);
+			auto it = renameMap.find(toLowerAscii(name));
 			return it == renameMap.end() ? name : it->second;
 		}
 
@@ -34,12 +47,43 @@ namespace hdt
 		// return null and the engine would drop it — no false "absent" for a bone SMP resolves.
 		// (Limitation, see issue #402: a name that exists only as a mesh-skin bone — created by
 		// generateMeshBody from skinInstance->bones[] with no name lookup — is not in the NPC
-		// tree and is still reported; detecting it needs the equipped mesh, tracked separately.)
+		// tree; the caller suppresses those via the mesh skin-bound set (this stays skeleton-only).)
 		bool resolvesToSkeletonNode(RE::NiNode* skeletonRoot, const std::string& resolvedName)
 		{
 			if (!skeletonRoot || resolvedName.empty())
 				return false;
 			return castNiNode(skeletonRoot->GetObjectByName(RE::BSFixedString(resolvedName.c_str()))) != nullptr;
+		}
+
+		// Collect the names of every bone the equipped mesh is skinned to. The engine's
+		// generateMeshBody creates a body for each of these straight from skinInstance->bones[]
+		// (live NiNode pointers) with NO name lookup against the skeleton — so a name reachable
+		// only this way is a real body at runtime even though findObjectByName(m_skeleton) can't
+		// resolve it. Walk mirrors validateSkinningSubtree (BSTriShape covers BSDynamicTriShape).
+		void collectSkinBoundBoneNames(RE::NiAVObject* obj, std::unordered_set<std::string>& out)
+		{
+			if (!obj)
+				return;
+			if (RE::BSTriShape* triShape = castBSTriShape(obj)) {
+				auto& runtimeData = triShape->GetGeometryRuntimeData();
+				if (runtimeData.skinInstance) {
+					RE::NiSkinInstance* skinInst = runtimeData.skinInstance.get();
+					RE::NiSkinData* skinData = skinInst->skinData ? skinInst->skinData.get() : nullptr;
+					if (skinData && skinInst->bones) {
+						const std::uint32_t boneCount = skinData->GetBoneCount();
+						for (std::uint32_t i = 0; i < boneCount; ++i) {
+							auto bone = skinInst->bones[i];
+							if (bone && bone->name.size())
+								out.insert(toLowerAscii(bone->name.c_str()));
+						}
+					}
+				}
+			}
+			if (RE::NiNode* node = castNiNode(obj)) {
+				for (auto& child : node->GetChildren())
+					if (child)
+						collectSkinBoundBoneNames(child.get(), out);
+			}
 		}
 
 		// Per-resolved-name accumulator: how many times, and in what roles, the XML reaches
@@ -56,6 +100,7 @@ namespace hdt
 		// nested inside <constraint-group> and bones/shapes are siblings under <system>.
 		void collectReferences(pugi::xml_node node,
 			RE::NiNode* skeletonRoot,
+			const std::unordered_set<std::string>& skinBoundBones,
 			const std::unordered_map<std::string, std::string>& renameMap,
 			std::unordered_map<std::string, MissingAcc>& missingByResolved)
 		{
@@ -65,6 +110,16 @@ namespace hdt
 				std::string resolved = applyRename(written, renameMap);
 				if (resolvesToSkeletonNode(skeletonRoot, resolved))
 					return;  // the engine's findObjectByName would bind it — not absent
+				// A node absent from the skeleton but skinned by the mesh is still turned into a
+				// body by generateMeshBody (from skinInstance->bones[], no name lookup), so it is
+				// not "absent". We suppress it for BOTH <bone> declarations and constraint
+				// endpoints. For a constraint this can miss a real drop — the endpoint's skin body
+				// may be built after the constraint in document order, so the engine drops the
+				// constraint — but that is an accepted trade under issue #402's policy: zero false
+				// positives (never a spurious "absent" that sends an author chasing a non-problem),
+				// missed positives tolerated. Names compared lower-cased (see toLowerAscii).
+				if (skinBoundBones.count(toLowerAscii(resolved)))
+					return;
 				auto& acc = missingByResolved[resolved];
 				if (acc.referenced.empty())
 					acc.referenced = written;
@@ -95,13 +150,14 @@ namespace hdt
 						break;
 					}
 				}
-				collectReferences(child, skeletonRoot, renameMap, missingByResolved);
+				collectReferences(child, skeletonRoot, skinBoundBones, renameMap, missingByResolved);
 			}
 		}
 	}  // namespace
 
 	std::vector<MissingBoneRef> FindMissingPhysicsXmlBoneRefs(
 		RE::NiNode* skeletonRoot,
+		RE::NiAVObject* meshRoot,
 		const std::string& xmlPath,
 		const std::unordered_map<std::string, std::string>& renameMap)
 	{
@@ -112,8 +168,21 @@ namespace hdt
 		if (!doc.load_buffer(bytes.data(), bytes.size()))
 			return {};
 
+		// Bones the equipped mesh is skinned to count as present even when absent from the
+		// skeleton — the engine fabricates a body for them from the mesh skin with no name
+		// lookup. meshRoot may be null (then the set is simply empty). Stored lower-cased.
+		std::unordered_set<std::string> skinBoundBones;
+		collectSkinBoundBoneNames(meshRoot, skinBoundBones);
+
+		// Lower-case the rename keys so applyRename mirrors getRenamedBone's case-insensitive
+		// BSFixedString lookup (values keep their case; the skeleton lookup case-folds anyway).
+		std::unordered_map<std::string, std::string> renameLc;
+		renameLc.reserve(renameMap.size());
+		for (const auto& [k, v] : renameMap)
+			renameLc.emplace(toLowerAscii(k), v);
+
 		std::unordered_map<std::string, MissingAcc> missingByResolved;
-		collectReferences(doc, skeletonRoot, renameMap, missingByResolved);
+		collectReferences(doc, skeletonRoot, skinBoundBones, renameLc, missingByResolved);
 
 		std::vector<MissingBoneRef> missing;
 		missing.reserve(missingByResolved.size());

--- a/src/Validator/Validators/hdtNIFBoneRefValidator.cpp
+++ b/src/Validator/Validators/hdtNIFBoneRefValidator.cpp
@@ -37,17 +37,15 @@ namespace hdt
 
 		// Mirror of SkyrimSystemCreator::findObjectByName (the runtime bone binder): look the
 		// resolved name up the exact way the engine does — GetObjectByName over the whole NPC
-		// subtree, then require the hit to be a NiNode. We resolve live against the skeleton
-		// instead of pre-collecting a NiNode-only name set (the old approach) so the report
-		// agrees with runtime in the cases that set missed: a named NiNode hanging *below* a
-		// non-NiNode parent is still found (GetObjectByName recurses the full tree, the old
-		// NiNode-only recursion stopped at the non-node parent), the match is case-folded like
+		// subtree, then require the hit to be a NiNode. Resolving live keeps the report's notion
+		// of "present" identical to the engine's: a named NiNode below a non-NiNode parent is
+		// found (GetObjectByName recurses the full tree), matching is case-folded like
 		// BSFixedString, and VR NiStream stubs are rejected by castNiNode exactly as the engine
-		// fails to bind them. So a reference is called "absent" iff findObjectByName would also
-		// return null and the engine would drop it — no false "absent" for a bone SMP resolves.
-		// (Limitation, see issue #402: a name that exists only as a mesh-skin bone — created by
-		// generateMeshBody from skinInstance->bones[] with no name lookup — is not in the NPC
-		// tree; the caller suppresses those via the mesh skin-bound set (this stays skeleton-only).)
+		// fails to bind them. So a reference is "absent" iff findObjectByName would also return
+		// null and the engine would drop it — never a false "absent" for a bone SMP resolves.
+		// (A name that exists only as a mesh-skin bone — created by generateMeshBody from
+		// skinInstance->bones[] with no name lookup — is not in the NPC tree; the caller
+		// suppresses those via the mesh skin-bound set, so this function stays skeleton-only.)
 		bool resolvesToSkeletonNode(RE::NiNode* skeletonRoot, const std::string& resolvedName)
 		{
 			if (!skeletonRoot || resolvedName.empty())

--- a/src/Validator/Validators/hdtNIFBoneRefValidator.cpp
+++ b/src/Validator/Validators/hdtNIFBoneRefValidator.cpp
@@ -1,13 +1,13 @@
 #include "hdtNIFBoneRefValidator.h"
 
+#include "../Utils/hdtStringUtils.h"       // ToLowerAscii
 #include "../Utils/hdtTemplateDefaults.h"  // isDefaultNodeName
 #include "../Utils/hdtValidatorFamily.h"   // familyForNode
-#include "NetImmerseUtils.h"               // readAllFile2, castNiNode
+#include "NetImmerseUtils.h"               // readAllFile2, castNiNode, findNodeSafe
 
 #include <pugixml.hpp>
 
 #include <algorithm>
-#include <cctype>
 #include <cstdint>
 #include <string>
 #include <unordered_set>
@@ -16,41 +16,31 @@ namespace hdt
 {
 	namespace
 	{
-		// ASCII lower-case, mirroring the engine's case-insensitive BSFixedString name matching
-		// so a name written in a different case than the skeleton/mesh uses still compares equal.
-		std::string toLowerAscii(std::string s)
-		{
-			for (char& c : s)
-				c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-			return s;
-		}
-
 		// Mirror of SkyrimSystemCreator::getRenamedBone: a mapped name resolves to its
 		// merged-skeleton form, an unmapped name is looked up verbatim. Case-insensitive like
 		// getRenamedBone's BSFixedString lookup — `renameMap` must have lower-cased keys.
 		std::string applyRename(const std::string& name,
 			const std::unordered_map<std::string, std::string>& renameMap)
 		{
-			auto it = renameMap.find(toLowerAscii(name));
+			auto it = renameMap.find(ToLowerAscii(name));
 			return it == renameMap.end() ? name : it->second;
 		}
 
 		// Mirror of SkyrimSystemCreator::findObjectByName (the runtime bone binder): look the
 		// resolved name up the exact way the engine does — GetObjectByName over the whole NPC
-		// subtree, then require the hit to be a NiNode. Resolving live keeps the report's notion
-		// of "present" identical to the engine's: a named NiNode below a non-NiNode parent is
-		// found (GetObjectByName recurses the full tree), matching is case-folded like
-		// BSFixedString, and VR NiStream stubs are rejected by castNiNode exactly as the engine
-		// fails to bind them. So a reference is "absent" iff findObjectByName would also return
-		// null and the engine would drop it — never a false "absent" for a bone SMP resolves.
+		// subtree, then require the hit to be a NiNode (findNodeSafe). Resolving live keeps the
+		// report's notion of "present" identical to the engine's: a named NiNode below a
+		// non-NiNode parent is found, matching is case-folded like BSFixedString, and VR
+		// NiStream stubs are rejected exactly as the engine fails to bind them. So a reference
+		// is "absent" iff findObjectByName would also return null and the engine would drop it.
 		// (A name that exists only as a mesh-skin bone — created by generateMeshBody from
 		// skinInstance->bones[] with no name lookup — is not in the NPC tree; the caller
 		// suppresses those via the mesh skin-bound set, so this function stays skeleton-only.)
 		bool resolvesToSkeletonNode(RE::NiNode* skeletonRoot, const std::string& resolvedName)
 		{
-			if (!skeletonRoot || resolvedName.empty())
+			if (resolvedName.empty())
 				return false;
-			return castNiNode(skeletonRoot->GetObjectByName(RE::BSFixedString(resolvedName.c_str()))) != nullptr;
+			return findNodeSafe(skeletonRoot, RE::BSFixedString(resolvedName.c_str())) != nullptr;
 		}
 
 		// Collect the names of every bone the equipped mesh is skinned to. The engine's
@@ -72,7 +62,7 @@ namespace hdt
 						for (std::uint32_t i = 0; i < boneCount; ++i) {
 							auto bone = skinInst->bones[i];
 							if (bone && bone->name.size())
-								out.insert(toLowerAscii(bone->name.c_str()));
+								out.insert(ToLowerAscii(bone->name.c_str()));
 						}
 					}
 				}
@@ -108,15 +98,16 @@ namespace hdt
 				std::string resolved = applyRename(written, renameMap);
 				if (resolvesToSkeletonNode(skeletonRoot, resolved))
 					return;  // the engine's findObjectByName would bind it — not absent
-				// A node absent from the skeleton but skinned by the mesh is still turned into a
-				// body by generateMeshBody (from skinInstance->bones[], no name lookup), so it is
-				// not "absent". We suppress it for BOTH <bone> declarations and constraint
-				// endpoints. For a constraint this can miss a real drop — the endpoint's skin body
-				// may be built after the constraint in document order, so the engine drops the
-				// constraint — but that is an accepted trade under issue #402's policy: zero false
-				// positives (never a spurious "absent" that sends an author chasing a non-problem),
-				// missed positives tolerated. Names compared lower-cased (see toLowerAscii).
-				if (skinBoundBones.count(toLowerAscii(resolved)))
+				// Skin-bound names are never reported absent, for any reference kind.
+				//  - Why suppressed: a node skinned by the mesh gets a body from generateMeshBody
+				//    (skinInstance->bones[], no name lookup), even with no skeleton node.
+				//  - Known miss: a constraint whose endpoint's skin body is only built later in
+				//    document order is genuinely dropped by the engine, yet not reported here.
+				//  - Why accepted (issue #402): zero false positives outrank missed positives — a
+				//    spurious "absent" sends authors and users chasing a non-problem, while a miss
+				//    only leaves a real problem undiagnosed.
+				// Comparison is case-folded (ToLowerAscii), matching BSFixedString.
+				if (skinBoundBones.count(ToLowerAscii(resolved)))
 					return;
 				auto& acc = missingByResolved[resolved];
 				if (acc.referenced.empty())
@@ -177,7 +168,7 @@ namespace hdt
 		std::unordered_map<std::string, std::string> renameLc;
 		renameLc.reserve(renameMap.size());
 		for (const auto& [k, v] : renameMap)
-			renameLc.emplace(toLowerAscii(k), v);
+			renameLc.emplace(ToLowerAscii(k), v);
 
 		std::unordered_map<std::string, MissingAcc> missingByResolved;
 		collectReferences(doc, skeletonRoot, skinBoundBones, renameLc, missingByResolved);

--- a/src/Validator/Validators/hdtNIFBoneRefValidator.cpp
+++ b/src/Validator/Validators/hdtNIFBoneRefValidator.cpp
@@ -2,14 +2,12 @@
 
 #include "../Utils/hdtTemplateDefaults.h"  // isDefaultNodeName
 #include "../Utils/hdtValidatorFamily.h"   // familyForNode
-#include "NetImmerseUtils.h"               // readAllFile2
-#include "hdtNIFValidator.h"               // CollectNamedSkeletonNodes
+#include "NetImmerseUtils.h"               // readAllFile2, castNiNode
 
 #include <pugixml.hpp>
 
 #include <algorithm>
 #include <string>
-#include <unordered_set>
 
 namespace hdt
 {
@@ -22,6 +20,26 @@ namespace hdt
 		{
 			auto it = renameMap.find(name);
 			return it == renameMap.end() ? name : it->second;
+		}
+
+		// Mirror of SkyrimSystemCreator::findObjectByName (the runtime bone binder): look the
+		// resolved name up the exact way the engine does — GetObjectByName over the whole NPC
+		// subtree, then require the hit to be a NiNode. We resolve live against the skeleton
+		// instead of pre-collecting a NiNode-only name set (the old approach) so the report
+		// agrees with runtime in the cases that set missed: a named NiNode hanging *below* a
+		// non-NiNode parent is still found (GetObjectByName recurses the full tree, the old
+		// NiNode-only recursion stopped at the non-node parent), the match is case-folded like
+		// BSFixedString, and VR NiStream stubs are rejected by castNiNode exactly as the engine
+		// fails to bind them. So a reference is called "absent" iff findObjectByName would also
+		// return null and the engine would drop it — no false "absent" for a bone SMP resolves.
+		// (Limitation, see issue #402: a name that exists only as a mesh-skin bone — created by
+		// generateMeshBody from skinInstance->bones[] with no name lookup — is not in the NPC
+		// tree and is still reported; detecting it needs the equipped mesh, tracked separately.)
+		bool resolvesToSkeletonNode(RE::NiNode* skeletonRoot, const std::string& resolvedName)
+		{
+			if (!skeletonRoot || resolvedName.empty())
+				return false;
+			return castNiNode(skeletonRoot->GetObjectByName(RE::BSFixedString(resolvedName.c_str()))) != nullptr;
 		}
 
 		// Per-resolved-name accumulator: how many times, and in what roles, the XML reaches
@@ -37,7 +55,7 @@ namespace hdt
 		// Recursion (rather than first-level children) is needed because constraints may be
 		// nested inside <constraint-group> and bones/shapes are siblings under <system>.
 		void collectReferences(pugi::xml_node node,
-			const std::unordered_set<std::string>& nodeSet,
+			RE::NiNode* skeletonRoot,
 			const std::unordered_map<std::string, std::string>& renameMap,
 			std::unordered_map<std::string, MissingAcc>& missingByResolved)
 		{
@@ -45,8 +63,8 @@ namespace hdt
 				if (!written || written[0] == '\0')
 					return;
 				std::string resolved = applyRename(written, renameMap);
-				if (nodeSet.count(resolved))
-					return;  // resolves fine — SMP would find it
+				if (resolvesToSkeletonNode(skeletonRoot, resolved))
+					return;  // the engine's findObjectByName would bind it — not absent
 				auto& acc = missingByResolved[resolved];
 				if (acc.referenced.empty())
 					acc.referenced = written;
@@ -77,7 +95,7 @@ namespace hdt
 						break;
 					}
 				}
-				collectReferences(child, nodeSet, renameMap, missingByResolved);
+				collectReferences(child, skeletonRoot, renameMap, missingByResolved);
 			}
 		}
 	}  // namespace
@@ -94,12 +112,8 @@ namespace hdt
 		if (!doc.load_buffer(bytes.data(), bytes.size()))
 			return {};
 
-		std::vector<std::string> nodeNames;
-		CollectNamedSkeletonNodes(skeletonRoot, nodeNames);
-		std::unordered_set<std::string> nodeSet(nodeNames.begin(), nodeNames.end());
-
 		std::unordered_map<std::string, MissingAcc> missingByResolved;
-		collectReferences(doc, nodeSet, renameMap, missingByResolved);
+		collectReferences(doc, skeletonRoot, renameMap, missingByResolved);
 
 		std::vector<MissingBoneRef> missing;
 		missing.reserve(missingByResolved.size());

--- a/src/Validator/Validators/hdtNIFBoneRefValidator.h
+++ b/src/Validator/Validators/hdtNIFBoneRefValidator.h
@@ -26,12 +26,15 @@ namespace hdt
 	// `skeletonRoot` — the NPC node SMP resolves bones against at load time, which already
 	// contains the equipped item's merged + renamed nodes.
 	//
-	// Algorithm: (1) read+parse the XML; (2) collect the skeleton's node-name set via
-	// CollectNamedSkeletonNodes; (3) walk every element, gathering each <bone>'s `name`
-	// and each generic-/stiffspring-/conetwist-constraint's `bodyA`/`bodyB`; (4) push each
-	// reference through `renameMap` (mirroring SkyrimSystemCreator::getRenamedBone) and
-	// keep the ones whose resolved name is not in the set, merged per resolved name and
-	// sorted by it.
+	// Algorithm: (1) read+parse the XML; (2) walk every element, gathering each <bone>'s
+	// `name` and each generic-/stiffspring-/conetwist-constraint's `bodyA`/`bodyB`; (3) push
+	// each reference through `renameMap` (mirroring SkyrimSystemCreator::getRenamedBone) and
+	// resolve it live against `skeletonRoot` the exact way the engine's findObjectByName does
+	// — GetObjectByName over the whole subtree, then AsNode — keeping the ones that do NOT
+	// bind to a NiNode, merged per resolved name and sorted by it. Resolving live (rather than
+	// diffing against a pre-collected NiNode-only name set) is what makes the report agree with
+	// runtime: it finds a NiNode below a non-NiNode parent, folds case, and rejects VR stubs
+	// exactly as the engine does — see issue #402.
 	//
 	// A returned entry means SMP would also fail the lookup and therefore silently skip
 	// the bone / drop the constraint. The "-default" template element variants are ignored

--- a/src/Validator/Validators/hdtNIFBoneRefValidator.h
+++ b/src/Validator/Validators/hdtNIFBoneRefValidator.h
@@ -32,10 +32,9 @@ namespace hdt
 	// each reference through `renameMap` (mirroring SkyrimSystemCreator::getRenamedBone) and
 	// resolve it live against `skeletonRoot` the exact way the engine's findObjectByName does
 	// — GetObjectByName over the whole subtree, then AsNode — keeping the ones that do NOT
-	// bind to a NiNode, merged per resolved name and sorted by it. Resolving live (rather than
-	// diffing against a pre-collected NiNode-only name set) is what makes the report agree with
-	// runtime: it finds a NiNode below a non-NiNode parent, folds case, and rejects VR stubs
-	// exactly as the engine does — see issue #402.
+	// bind to a NiNode, merged per resolved name and sorted by it. Live resolution keeps
+	// "present" identical to the engine's: a NiNode below a non-NiNode parent is found, the
+	// match is case-folded, and VR stubs are rejected exactly as the engine rejects them.
 	//
 	// `meshRoot` is the equipped item's 3D (armor/headpart). A reference naming a node absent
 	// from the skeleton but skinned by that mesh is NOT reported: the engine creates a body for

--- a/src/Validator/Validators/hdtNIFBoneRefValidator.h
+++ b/src/Validator/Validators/hdtNIFBoneRefValidator.h
@@ -7,6 +7,7 @@
 namespace RE
 {
 	class NiNode;
+	class NiAVObject;
 }
 
 namespace hdt
@@ -36,6 +37,16 @@ namespace hdt
 	// runtime: it finds a NiNode below a non-NiNode parent, folds case, and rejects VR stubs
 	// exactly as the engine does — see issue #402.
 	//
+	// `meshRoot` is the equipped item's 3D (armor/headpart). A reference naming a node absent
+	// from the skeleton but skinned by that mesh is NOT reported: the engine creates a body for
+	// it from skinInstance->bones[] without any name lookup. This escape covers BOTH <bone>
+	// declarations and constraint endpoints. For a constraint it can miss a real drop (the
+	// endpoint's skin body may be built after the constraint in document order), which is an
+	// accepted trade under issue #402's policy — zero false positives, missed positives
+	// tolerated — since a spurious "absent" wastes authors' and users' time. All name matching
+	// (skeleton, skin set, rename) is case-insensitive, mirroring the engine's BSFixedString
+	// comparisons. `meshRoot` may be null (no skin escape then). See issue #402.
+	//
 	// A returned entry means SMP would also fail the lookup and therefore silently skip
 	// the bone / drop the constraint. The "-default" template element variants are ignored
 	// because their `name`/`bodyA`/`bodyB` carry template class names, not node references.
@@ -43,6 +54,7 @@ namespace hdt
 	// schema validator, which runs over the same equipped XMLs. `renameMap` may be empty.
 	std::vector<MissingBoneRef> FindMissingPhysicsXmlBoneRefs(
 		RE::NiNode* skeletonRoot,
+		RE::NiAVObject* meshRoot,
 		const std::string& xmlPath,
 		const std::unordered_map<std::string, std::string>& renameMap);
 }

--- a/src/Validator/hdtAssetValidator.cpp
+++ b/src/Validator/hdtAssetValidator.cpp
@@ -162,12 +162,7 @@ namespace hdt
 
 	using XMLValidationPair = std::pair<XSDValidationResult, SCHValidationResult>;
 
-	// Per-element tags that restate an inherited default. NOTE: the whole-<bone> "only
-	// restates the default, can be removed" warning was removed (issue #402). Whether such a
-	// bone is actually removable depends on mesh-skin binding / standalone-collider status / a
-	// position-dependent unnamed <bone-default> — none of which is knowable from the XML alone —
-	// so the warning advised deleting load-bearing bones and broke mods. CollectRedundantBone
-	// Declarations is kept for a future gear + mesh-aware reimplementation.
+	// Per-element tags that restate an inherited default.
 	struct XmlRedundancyInfo
 	{
 		std::vector<TemplateRedundantChildInfo> redundantChildren;
@@ -549,9 +544,9 @@ namespace hdt
 		std::vector<std::string>& out)
 	{
 		// Single pass: enumerate all entries, collect NIFs and recurse into dirs.
-		// Previously used two passes (*.nif + FindExSearchLimitToDirectories) but
-		// FindExSearchLimitToDirectories is advisory and ignored by NTFS — Pass 2
-		// enumerated all files anyway, doubling the I/O cost on animation mods.
+		// A two-pass split (*.nif, then FindExSearchLimitToDirectories) would not be
+		// cheaper: the directories-only filter is advisory and ignored by NTFS, so each
+		// pass enumerates every file anyway, doubling the I/O cost on animation mods.
 		// One pass with FIND_FIRST_EX_LARGE_FETCH is faster overall.
 		const std::wstring dirW = dir.wstring();
 		WIN32_FIND_DATAW fd;

--- a/src/Validator/hdtAssetValidator.cpp
+++ b/src/Validator/hdtAssetValidator.cpp
@@ -162,10 +162,13 @@ namespace hdt
 
 	using XMLValidationPair = std::pair<XSDValidationResult, SCHValidationResult>;
 
-	// Per-element tags that restate an inherited default.
+	// The two flavours of per-file XML redundancy: element tags that restate an
+	// inherited default, and top-level <bone> declarations the engine skips because
+	// an earlier same-file element already claims the name (first use creates the bone).
 	struct XmlRedundancyInfo
 	{
 		std::vector<TemplateRedundantChildInfo> redundantChildren;
+		std::vector<InertBoneInfo> inertBones;
 	};
 
 	// Load xmlPath from disk once and collect both redundancy flavours from the parsed
@@ -187,6 +190,7 @@ namespace hdt
 			return result;
 
 		result.redundantChildren = CollectTemplateRedundantChildrenInfo(doc, &bytes);
+		result.inertBones = CollectInertBoneDeclarations(doc, &bytes);
 		return result;
 	}
 
@@ -298,6 +302,24 @@ namespace hdt
 				continue;
 
 			emitTemplateRedundantWarning(info);
+		}
+
+		// Top-level <bone> declarations the engine skips because an earlier element in this
+		// file already claims the name — the first use creates the bone ("Bone X already
+		// exists, skipped"), so these declarations are inert and provably removable.
+		for (const auto& bone : redundancyInfo.inertBones) {
+			const std::string named = bone.boneName.empty() ? std::string() : " \"" + bone.boneName + "\"";
+			std::string msg = xmlPath + ":" + std::to_string(bone.line) + ": " + bone.location +
+			                  " - <bone>" + named +
+			                  " is never used: an earlier <bone> or bone reference in this file already"
+			                  " claims this name (the first use creates the bone), so the engine skips"
+			                  " this declaration. It can be removed.";
+			report.warnings.push_back(msg);
+			report.hasWarnings = true;
+			out << "    [WARNING] " << bone.location << " (line " << bone.line << "): <bone>" << named
+				<< " is never used: an earlier <bone> or bone reference in this file already claims"
+				   " this name (the first use creates the bone), so the engine skips this declaration;"
+				   " it can be removed.\n";
 		}
 	}
 

--- a/src/Validator/hdtAssetValidator.cpp
+++ b/src/Validator/hdtAssetValidator.cpp
@@ -584,11 +584,14 @@ namespace hdt
 
 	/// Cross-references an equipped item's physics XML node references against the live
 	/// actor skeleton and appends one violation line per node the skeleton does not
-	/// provide. Each line names the affected element role and the runtime consequence so
-	/// an author can see why their physics detaches. Emits nothing when the skeleton root
-	/// is null (the caller already reported that) or the XML is missing/malformed (the
-	/// schema-validation pass over these same equipped XMLs is what reports XML validity).
-	static void appendMissingBoneRefViolations(RE::NiNode* skeletonRoot, const std::string& xmlPath,
+	/// provide. `meshRoot` is the equipped item's 3D: a <bone> naming a node absent from the
+	/// skeleton but skinned by that mesh is not reported (the engine creates a body for it
+	/// from the mesh skin, no name lookup). Each line names the affected element role and the
+	/// runtime consequence so an author can see why their physics detaches. Emits nothing when
+	/// the skeleton root is null (the caller already reported that) or the XML is
+	/// missing/malformed (the schema-validation pass over these same equipped XMLs reports it).
+	static void appendMissingBoneRefViolations(RE::NiNode* skeletonRoot, RE::NiAVObject* meshRoot,
+		const std::string& xmlPath,
 		const std::unordered_map<RE::BSFixedString, RE::BSFixedString>& renameMap,
 		const std::string& skeletonName, std::vector<std::string>& out)
 	{
@@ -600,7 +603,7 @@ namespace hdt
 		for (const auto& kv : renameMap)
 			rename.emplace(kv.first.c_str(), kv.second.c_str());
 
-		for (const auto& m : FindMissingPhysicsXmlBoneRefs(skeletonRoot, xmlPath, rename)) {
+		for (const auto& m : FindMissingPhysicsXmlBoneRefs(skeletonRoot, meshRoot, xmlPath, rename)) {
 			std::string effect;
 			if (m.usedAsBone && m.constraintRefs > 0)
 				effect = "its <bone> body is skipped and " + std::to_string(m.constraintRefs) +
@@ -677,7 +680,7 @@ namespace hdt
 							if (!nifDiskPath.empty())
 								outNifScanViolations->push_back(nifDiskPath + ": equipped armor node is not a NiNode (physics XML: " + asset.xmlPath + ")");
 						}
-						appendMissingBoneRefViolations(skeleton.npc.get(), xmlPath, armor.renameMap, skeleton.name(), *outNifScanViolations);
+						appendMissingBoneRefViolations(skeleton.npc.get(), armor.armorWorn.get(), xmlPath, armor.renameMap, skeleton.name(), *outNifScanViolations);
 					}
 					result.push_back(std::move(asset));
 				}
@@ -712,7 +715,7 @@ namespace hdt
 							if (!nifDiskPath.empty())
 								outNifScanViolations->push_back(nifDiskPath + ": equipped headpart node is not a NiNode (physics XML: " + asset.xmlPath + ")");
 						}
-						appendMissingBoneRefViolations(skeleton.npc.get(), xmlPath, skeleton.head.renameMap, skeleton.name(), *outNifScanViolations);
+						appendMissingBoneRefViolations(skeleton.npc.get(), headPart.headPart.get(), xmlPath, skeleton.head.renameMap, skeleton.name(), *outNifScanViolations);
 					}
 					result.push_back(std::move(asset));
 				}

--- a/src/Validator/hdtAssetValidator.cpp
+++ b/src/Validator/hdtAssetValidator.cpp
@@ -162,13 +162,15 @@ namespace hdt
 
 	using XMLValidationPair = std::pair<XSDValidationResult, SCHValidationResult>;
 
-	// The two flavours of template redundancy reported for one XML file: per-element
-	// tags that restate an inherited default, and whole <bone> declarations that only
-	// restate the auto-created default bone.
+	// Per-element tags that restate an inherited default. NOTE: the whole-<bone> "only
+	// restates the default, can be removed" warning was removed (issue #402). Whether such a
+	// bone is actually removable depends on mesh-skin binding / standalone-collider status / a
+	// position-dependent unnamed <bone-default> — none of which is knowable from the XML alone —
+	// so the warning advised deleting load-bearing bones and broke mods. CollectRedundantBone
+	// Declarations is kept for a future gear + mesh-aware reimplementation.
 	struct XmlRedundancyInfo
 	{
 		std::vector<TemplateRedundantChildInfo> redundantChildren;
-		std::vector<RedundantBoneInfo> redundantBones;
 	};
 
 	// Load xmlPath from disk once and collect both redundancy flavours from the parsed
@@ -190,7 +192,6 @@ namespace hdt
 			return result;
 
 		result.redundantChildren = CollectTemplateRedundantChildrenInfo(doc, &bytes);
-		result.redundantBones = CollectRedundantBoneDeclarations(doc, &bytes);
 		return result;
 	}
 
@@ -302,22 +303,6 @@ namespace hdt
 				continue;
 
 			emitTemplateRedundantWarning(info);
-		}
-
-		// Whole <bone> declarations that only restate the auto-created default bone:
-		// the engine would fabricate an identical body on demand, so the declaration
-		// is removable. See CollectRedundantBoneDeclarations for the comparison.
-		for (const auto& bone : redundancyInfo.redundantBones) {
-			const std::string named = bone.boneName.empty() ? std::string() : " \"" + bone.boneName + "\"";
-			std::string msg = xmlPath + ":" + std::to_string(bone.line) + ": " + bone.location +
-			                  " - <bone>" + named +
-			                  " only restates the default bone settings; the engine creates an"
-			                  " identical bone on demand, so this declaration is unnecessary and can be removed.";
-			report.warnings.push_back(msg);
-			report.hasWarnings = true;
-			out << "    [WARNING] " << bone.location << " (line " << bone.line << "): <bone>" << named
-				<< " only restates the default bone settings; the engine creates an identical bone on"
-				   " demand, so this declaration can be removed.\n";
 		}
 	}
 

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -183,7 +183,11 @@ namespace hdt
 		}
 
 		logger::warn("Bone {} used before being created, trying to create it with current default values", name.c_str());
-		return createBoneFromNodeName(name);
+		// Create from the renamed name too: the lookup above used it, and under a rename
+		// map (skeleton merge / DynamicHDT) the raw name's node typically no longer
+		// exists — creating from the raw name would drop the reference or split the
+		// bone into two identities. Constraint readers already create from renamed names.
+		return createBoneFromNodeName(getRenamedBone(name));
 	}
 
 	RE::BSFixedString SkyrimSystemCreator::getRenamedBone(const RE::BSFixedString& name)

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -640,6 +640,7 @@ namespace hdt
 		RE::BSFixedString name = getRenamedBone(m_reader->getAttribute("name"));
 		if (findBoneFromIndex(name)) {
 			logger::warn("Bone {} already exists, skipped", name.c_str());
+			m_reader->skipCurrentElement();
 			return;
 		}
 

--- a/src/hdtStringUtils.h
+++ b/src/hdtStringUtils.h
@@ -43,6 +43,16 @@ namespace hdt
 		return s.substr(start, end - start + 1);
 	}
 
+	// ASCII lower-case copy. Name comparisons folded with this mirror the engine's
+	// case-insensitive BSFixedString matching, so validator-side lookups agree with
+	// runtime lookups regardless of how an author cased a name.
+	inline std::string ToLowerAscii(std::string s)
+	{
+		std::transform(s.begin(), s.end(), s.begin(),
+			[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+		return s;
+	}
+
 	// Build a sorted, comma-separated string from a set of strings.
 	inline std::string JoinSortedSet(const std::unordered_set<std::string>& values)
 	{

--- a/tests/validator/CMakeLists.txt
+++ b/tests/validator/CMakeLists.txt
@@ -1,0 +1,39 @@
+# validator_tests - doctest unit suite for the XML reader stream contract (#404) and the
+# validator's inert-<bone> warning (#402).
+#
+# Built only when BUILD_VALIDATOR_TESTS is ON (a dev/CI tool, never packaged). The targets under
+# test are game-independent: XmlReader.cpp needs only the XmlInspector headers and Bullet's
+# header-inline math types, and the XML-redundancy analysis (hdtTemplateDefaults.cpp) is pure
+# pugixml + STL - no CommonLibSSE, no TBB - so both compile directly without the game's
+# force-included src/PCH.h (tests supply test_pch.h instead). Mirrors tests/patterns.
+
+set(ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+set(SOURCE_DIR "${ROOT_DIR}/src")
+
+find_package(Bullet CONFIG REQUIRED)
+find_package(pugixml CONFIG REQUIRED)
+find_package(doctest CONFIG REQUIRED)
+
+add_executable(
+	validator_tests
+	"${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/test_xmlreader.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/test_inert_bones.cpp"
+	"${SOURCE_DIR}/XmlReader.cpp"
+	"${SOURCE_DIR}/Validator/Utils/hdtTemplateDefaults.cpp")
+
+target_compile_features(validator_tests PRIVATE cxx_std_20)
+target_include_directories(validator_tests PRIVATE "${SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" ${BULLET_INCLUDE_DIRS})
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+	target_compile_options(validator_tests PRIVATE "/EHsc" "/permissive-" "/bigobj" "/utf-8")
+endif()
+
+# XmlReader.cpp relies on headers the plugin's PCH normally provides; give the standalone
+# compile the same minimal platform/std surface.
+target_precompile_headers(validator_tests PRIVATE test_pch.h)
+
+target_link_libraries(validator_tests PRIVATE pugixml::pugixml doctest::doctest ${BULLET_LIBRARIES})
+
+# CTest entry: running the exe with no args runs the whole doctest suite and exits non-zero on failure.
+add_test(NAME validator_tests COMMAND validator_tests)

--- a/tests/validator/CMakeLists.txt
+++ b/tests/validator/CMakeLists.txt
@@ -1,11 +1,10 @@
-# validator_tests - doctest unit suite for the XML reader stream contract (#404) and the
-# validator's inert-<bone> warning (#402).
+# validator_tests - doctest unit suite for the XML reader stream contract (#404) and the validator's inert-<bone>
+# warning (#402).
 #
-# Built only when BUILD_VALIDATOR_TESTS is ON (a dev/CI tool, never packaged). The targets under
-# test are game-independent: XmlReader.cpp needs only the XmlInspector headers and Bullet's
-# header-inline math types, and the XML-redundancy analysis (hdtTemplateDefaults.cpp) is pure
-# pugixml + STL - no CommonLibSSE, no TBB - so both compile directly without the game's
-# force-included src/PCH.h (tests supply test_pch.h instead). Mirrors tests/patterns.
+# Built only when BUILD_VALIDATOR_TESTS is ON (a dev/CI tool, never packaged). The targets under test are
+# game-independent: XmlReader.cpp needs only the XmlInspector headers and Bullet's header-inline math types, and the
+# XML-redundancy analysis (hdtTemplateDefaults.cpp) is pure pugixml + STL - no CommonLibSSE, no TBB - so both compile
+# directly without the game's force-included src/PCH.h (tests supply test_pch.h instead). Mirrors tests/patterns.
 
 set(ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 set(SOURCE_DIR "${ROOT_DIR}/src")
@@ -16,10 +15,8 @@ find_package(doctest CONFIG REQUIRED)
 
 add_executable(
 	validator_tests
-	"${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
-	"${CMAKE_CURRENT_SOURCE_DIR}/test_xmlreader.cpp"
-	"${CMAKE_CURRENT_SOURCE_DIR}/test_inert_bones.cpp"
-	"${SOURCE_DIR}/XmlReader.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/main.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/test_xmlreader.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/test_inert_bones.cpp" "${SOURCE_DIR}/XmlReader.cpp"
 	"${SOURCE_DIR}/Validator/Utils/hdtTemplateDefaults.cpp")
 
 target_compile_features(validator_tests PRIVATE cxx_std_20)
@@ -29,8 +26,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	target_compile_options(validator_tests PRIVATE "/EHsc" "/permissive-" "/bigobj" "/utf-8")
 endif()
 
-# XmlReader.cpp relies on headers the plugin's PCH normally provides; give the standalone
-# compile the same minimal platform/std surface.
+# XmlReader.cpp relies on headers the plugin's PCH normally provides; give the standalone compile the same minimal
+# platform/std surface.
 target_precompile_headers(validator_tests PRIVATE test_pch.h)
 
 target_link_libraries(validator_tests PRIVATE pugixml::pugixml doctest::doctest ${BULLET_LIBRARIES})

--- a/tests/validator/main.cpp
+++ b/tests/validator/main.cpp
@@ -1,0 +1,5 @@
+// Test runner for the validator/XML-reader suites. Running the executable with no arguments runs
+// the whole doctest suite and exits non-zero on any failure (so CTest / CI can gate on it). The
+// targets under test are pure XmlInspector/Bullet-math + pugixml + STL — no CommonLibSSE, no game.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>

--- a/tests/validator/test_inert_bones.cpp
+++ b/tests/validator/test_inert_bones.cpp
@@ -1,0 +1,172 @@
+// CollectInertBoneDeclarations tests -- the zero-false-positive inert-<bone> warning. These
+// exercise hdtTemplateDefaults.cpp and pugixml only -- no Bullet / CommonLibSSE.
+//
+// The predicate under test: a top-level <bone> is flagged iff an EARLIER element in the same
+// file already claims the same case-folded bone name (an earlier <bone>, a constraint
+// bodyA/bodyB -- also inside constraint-group -- or a can-/no-collide-with-bone shape
+// reference). Every "not flagged" case here is a false-positive guard; every "flagged" case is
+// a claim the engine provably skips ("Bone X already exists, skipped").
+
+#include "Validator/Utils/hdtTemplateDefaults.h"
+
+#include <doctest/doctest.h>
+#include <pugixml.hpp>
+
+#include <string>
+#include <vector>
+
+namespace
+{
+	std::vector<hdt::InertBoneInfo> collect(const std::string& xml, bool withSource = false)
+	{
+		pugi::xml_document doc;
+		if (!doc.load_buffer(xml.data(), xml.size()))
+			return {};
+		return hdt::CollectInertBoneDeclarations(doc, withSource ? &xml : nullptr);
+	}
+}
+
+TEST_CASE("a duplicate <bone> flags the second declaration only")
+{
+	auto hits = collect(
+		"<system>"
+		"<bone name=\"NPC L Breast\"/>"
+		"<bone name=\"NPC L Breast\"/>"
+		"</system>");
+	REQUIRE(hits.size() == 1);
+	CHECK(hits[0].boneName == "NPC L Breast");
+	CHECK(hits[0].location == "/system[1]/bone[2]");
+}
+
+TEST_CASE("duplicate detection is case-folded like BSFixedString")
+{
+	auto hits = collect(
+		"<system>"
+		"<bone name=\"NPC L Breast\"/>"
+		"<bone name=\"npc l breast\"/>"
+		"</system>");
+	CHECK(hits.size() == 1);
+}
+
+TEST_CASE("three declarations of one name flag two")
+{
+	auto hits = collect(
+		"<system>"
+		"<bone name=\"X\"/><bone name=\"X\"/><bone name=\"X\"/>"
+		"</system>");
+	CHECK(hits.size() == 2);
+}
+
+TEST_CASE("a constraint bodyA before the <bone> claims the name")
+{
+	auto hits = collect(
+		"<system>"
+		"<generic-constraint bodyA=\"X\" bodyB=\"Y\"/>"
+		"<bone name=\"X\"/>"
+		"</system>");
+	CHECK(hits.size() == 1);
+}
+
+TEST_CASE("a constraint bodyB before the <bone> claims the name")
+{
+	auto hits = collect(
+		"<system>"
+		"<stiffspring-constraint bodyA=\"A\" bodyB=\"X\"/>"
+		"<bone name=\"X\"/>"
+		"</system>");
+	CHECK(hits.size() == 1);
+}
+
+TEST_CASE("a constraint nested in constraint-group claims too")
+{
+	auto hits = collect(
+		"<system>"
+		"<constraint-group><conetwist-constraint bodyA=\"X\" bodyB=\"Y\"/></constraint-group>"
+		"<bone name=\"X\"/>"
+		"</system>");
+	CHECK(hits.size() == 1);
+}
+
+TEST_CASE("can-collide-with-bone in a per-vertex-shape claims")
+{
+	auto hits = collect(
+		"<system>"
+		"<per-vertex-shape name=\"MyMesh\"><can-collide-with-bone>X</can-collide-with-bone></per-vertex-shape>"
+		"<bone name=\"X\"/>"
+		"</system>");
+	CHECK(hits.size() == 1);
+}
+
+TEST_CASE("no-collide-with-bone in a per-triangle-shape claims")
+{
+	auto hits = collect(
+		"<system>"
+		"<per-triangle-shape name=\"MyMesh\"><no-collide-with-bone>X</no-collide-with-bone></per-triangle-shape>"
+		"<bone name=\"X\"/>"
+		"</system>");
+	CHECK(hits.size() == 1);
+}
+
+TEST_CASE("a <bone> before the elements referencing it is the live declaration, not flagged")
+{
+	auto hits = collect(
+		"<system>"
+		"<bone name=\"X\"/>"
+		"<generic-constraint bodyA=\"X\" bodyB=\"Y\"/>"
+		"<per-vertex-shape name=\"M\"><can-collide-with-bone>X</can-collide-with-bone></per-vertex-shape>"
+		"</system>");
+	CHECK(hits.empty());
+}
+
+TEST_CASE("-default template elements do not claim")
+{
+	// Their name/bodyA/bodyB carry template class names, not skeleton nodes, and
+	// defining them creates no bone.
+	auto hits = collect(
+		"<system>"
+		"<bone-default name=\"X\"/>"
+		"<generic-constraint-default bodyA=\"X\" bodyB=\"X\"/>"
+		"<per-vertex-shape-default name=\"X\"><can-collide-with-bone>X</can-collide-with-bone></per-vertex-shape-default>"
+		"<bone name=\"X\"/>"
+		"</system>");
+	CHECK(hits.empty());
+}
+
+TEST_CASE("weight-threshold does not claim")
+{
+	// Its bone attribute only matches already-skinned bones at runtime -- it never
+	// creates one.
+	auto hits = collect(
+		"<system>"
+		"<per-vertex-shape name=\"M\"><weight-threshold bone=\"X\">0.1</weight-threshold></per-vertex-shape>"
+		"<bone name=\"X\"/>"
+		"</system>");
+	CHECK(hits.empty());
+}
+
+TEST_CASE("empty or missing name attributes are ignored")
+{
+	auto hits = collect(
+		"<system>"
+		"<bone name=\"\"/><bone name=\"\"/><bone/><bone/>"
+		"</system>");
+	CHECK(hits.empty());
+}
+
+TEST_CASE("a document without a <system> root yields nothing")
+{
+	auto hits = collect("<notsystem><bone name=\"X\"/><bone name=\"X\"/></notsystem>");
+	CHECK(hits.empty());
+}
+
+TEST_CASE("line numbers are computed from the source bytes")
+{
+	const std::string xml =
+		"<system>\n"
+		"<bone name=\"X\"/>\n"
+		"<bone name=\"X\"/>\n"
+		"</system>\n";
+	auto hits = collect(xml, true);
+	REQUIRE(hits.size() == 1);
+	CHECK(hits[0].line == 3);
+}

--- a/tests/validator/test_pch.h
+++ b/tests/validator/test_pch.h
@@ -5,10 +5,10 @@
 // (XmlReader.h → hdtBulletHelper.h, hdtTemplateDefaults.cpp) implicitly depend on.
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
-#include <windows.h>  // BYTE            — XMLReader's buffer constructor
 #include <algorithm>  // std::clamp      — hdtBulletHelper.h
 #include <atomic>     // std::atomic     — hdt::SpinLock (hdtBulletHelper.h)
 #include <bit>        // std::bit_floor  — hdtBulletHelper.h
 #include <cstdint>    // std::uint*_t    — hdtBulletHelper.h
 #include <mutex>      // std::lock_guard — hdtBulletHelper.h
 #include <vector>     // std::vector     — hdt::vectorA16 alias (hdtBulletHelper.h)
+#include <windows.h>  // BYTE            — XMLReader's buffer constructor

--- a/tests/validator/test_pch.h
+++ b/tests/validator/test_pch.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// The main plugin gets these headers transitively through PCH.h. The test target has
+// no PCH of its own, so we supply the minimum subset the shared source files
+// (XmlReader.h → hdtBulletHelper.h, hdtTemplateDefaults.cpp) implicitly depend on.
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>  // BYTE            — XMLReader's buffer constructor
+#include <algorithm>  // std::clamp      — hdtBulletHelper.h
+#include <atomic>     // std::atomic     — hdt::SpinLock (hdtBulletHelper.h)
+#include <bit>        // std::bit_floor  — hdtBulletHelper.h
+#include <cstdint>    // std::uint*_t    — hdtBulletHelper.h
+#include <mutex>      // std::lock_guard — hdtBulletHelper.h
+#include <vector>     // std::vector     — hdt::vectorA16 alias (hdtBulletHelper.h)

--- a/tests/validator/test_xmlreader.cpp
+++ b/tests/validator/test_xmlreader.cpp
@@ -1,0 +1,188 @@
+// XMLReader stream-contract tests. These pin the reader semantics the physics-XML parser relies
+// on -- in particular the mechanism behind the duplicate-<bone> fix (#404): reading attributes
+// does not consume an element, an empty element <x/> is delivered as a StartTag followed by a
+// synthetic EndTag, and skipCurrentElement() consumes an element's whole subtree INCLUDING its
+// EndTag. A dispatch loop that breaks on EndTag (like createOrUpdateSystem's <system> loop)
+// therefore only survives an unwanted element if the element is explicitly skipped -- which is
+// exactly what readOrUpdateBone's duplicate path must do.
+
+#include "test_pch.h"
+
+#include "XmlReader.h"
+
+#include <doctest/doctest.h>
+
+#include <set>
+#include <string>
+
+namespace
+{
+	// The reader parses in place from a byte range; the caller keeps `xml` alive.
+	hdt::XMLReader makeReader(const std::string& xml)
+	{
+		return hdt::XMLReader((BYTE*)xml.data(), xml.size());
+	}
+}
+
+TEST_CASE("skipCurrentElement consumes children and the element's EndTag")
+{
+	const std::string xml =
+		"<system><bone name=\"a\"><mass>1.0</mass><inertia x=\"1\" y=\"1\" z=\"1\"/></bone>"
+		"<probe/></system>";
+	auto reader = makeReader(xml);
+
+	reader.nextStartElement();
+	CHECK(reader.GetName() == "system");
+	reader.nextStartElement();
+	CHECK(reader.GetName() == "bone");
+	CHECK(reader.getAttribute("name") == "a");
+
+	reader.skipCurrentElement();
+	reader.nextStartElement();
+	CHECK(reader.GetName() == "probe");
+}
+
+TEST_CASE("attribute reads do not consume the element")
+{
+	// readOrUpdateBone reads name/template attributes before deciding what to do with
+	// the element; the children must still be there afterwards.
+	const std::string xml = "<system><bone name=\"a\"><mass>2.5</mass></bone></system>";
+	auto reader = makeReader(xml);
+
+	reader.nextStartElement();
+	reader.nextStartElement();
+	CHECK(reader.getAttribute("name") == "a");
+	CHECK(reader.hasAttribute("name"));
+	CHECK(reader.getAttribute("template", "fallback") == "fallback");
+
+	reader.nextStartElement();
+	CHECK(reader.GetName() == "mass");
+}
+
+TEST_CASE("an empty element delivers a synthetic EndTag right after its StartTag")
+{
+	// The immediate next token after <bone/>'s StartTag is its EndTag -- so a dispatch
+	// loop that breaks on EndTag (mistaking it for its enclosing element's close) dies
+	// right here unless the element is skipped. This is the truncation mechanism of #404.
+	const std::string xml = "<system><bone name=\"X\"/><probe/></system>";
+	auto reader = makeReader(xml);
+
+	reader.nextStartElement();
+	reader.nextStartElement();
+	CHECK(reader.GetName() == "bone");
+	CHECK(reader.GetInspected() == Xml::Inspected::StartTag);
+
+	reader.Inspect();
+	CHECK(reader.GetInspected() == Xml::Inspected::EndTag);
+	CHECK(reader.GetName() == "bone");
+}
+
+TEST_CASE("skipCurrentElement works on an empty element")
+{
+	// The fixed duplicate path calls it unconditionally: the synthetic EndTag is
+	// consumed and the next sibling follows.
+	const std::string xml = "<system><bone name=\"X\"/><probe/></system>";
+	auto reader = makeReader(xml);
+
+	reader.nextStartElement();
+	reader.nextStartElement();
+	CHECK(reader.GetName() == "bone");
+
+	reader.skipCurrentElement();
+	reader.nextStartElement();
+	CHECK(reader.GetName() == "probe");
+}
+
+TEST_CASE("a dispatch loop survives a duplicate <bone> when the duplicate is skipped")
+{
+	// End-to-end contract for the #404 fix, driven exactly like createOrUpdateSystem's
+	// <system> loop: StartTags dispatch, the first EndTag breaks. With every <bone>
+	// element skipped once handled -- including the duplicate -- the loop must still
+	// reach the constraint that follows it.
+	const std::string xml =
+		"<system>"
+		"<bone name=\"X\"/>"
+		"<bone name=\"X\"><shape type=\"sphere\"/></bone>"
+		"<generic-constraint bodyA=\"X\" bodyB=\"Y\"/>"
+		"</system>";
+	auto reader = makeReader(xml);
+	reader.nextStartElement();
+	CHECK(reader.GetName() == "system");
+
+	std::set<std::string> seenBones;
+	bool constraintReached = false;
+	bool leakedShape = false;
+	bool done = false;
+	while (!done && reader.Inspect()) {
+		switch (reader.GetInspected()) {
+		case Xml::Inspected::StartTag:
+			if (reader.GetName() == "bone") {
+				seenBones.insert(reader.getAttribute("name"));
+				reader.skipCurrentElement();  // both paths consume, as fixed by #404
+			} else if (reader.GetName() == "generic-constraint") {
+				constraintReached = true;
+				reader.skipCurrentElement();
+			} else if (reader.GetName() == "shape") {
+				leakedShape = true;  // would mean the duplicate's child escaped
+				reader.skipCurrentElement();
+			}
+			break;
+		case Xml::Inspected::EndTag:
+			done = true;  // </system> -- or a leaked EndTag, which the checks catch
+			break;
+		default:
+			break;
+		}
+	}
+
+	CHECK(constraintReached);
+	CHECK(!leakedShape);
+	CHECK(seenBones.size() == 1);
+}
+
+TEST_CASE("a dispatch loop truncates on a duplicate <bone> that is not skipped")
+{
+	// The same loop WITHOUT skipping the duplicate (the pre-#404 behaviour) demonstrates
+	// the failure: the duplicate's <shape> child leaks to the dispatcher and the loop
+	// breaks on the duplicate's EndTag before ever reaching the constraint. If this test
+	// starts failing, the reader's consumption semantics changed and #404 needs a re-look.
+	const std::string xml =
+		"<system>"
+		"<bone name=\"X\"/>"
+		"<bone name=\"X\"><shape type=\"sphere\"/></bone>"
+		"<generic-constraint bodyA=\"X\" bodyB=\"Y\"/>"
+		"</system>";
+	auto reader = makeReader(xml);
+	reader.nextStartElement();
+
+	std::set<std::string> seenBones;
+	bool constraintReached = false;
+	bool leakedShape = false;
+	bool done = false;
+	while (!done && reader.Inspect()) {
+		switch (reader.GetInspected()) {
+		case Xml::Inspected::StartTag:
+			if (reader.GetName() == "bone") {
+				const std::string name = reader.getAttribute("name");
+				if (seenBones.insert(name).second)
+					reader.skipCurrentElement();
+				// duplicate: fall through WITHOUT consuming -- the old behaviour
+			} else if (reader.GetName() == "generic-constraint") {
+				constraintReached = true;
+				reader.skipCurrentElement();
+			} else if (reader.GetName() == "shape") {
+				leakedShape = true;
+				reader.skipCurrentElement();
+			}
+			break;
+		case Xml::Inspected::EndTag:
+			done = true;
+			break;
+		default:
+			break;
+		}
+	}
+
+	CHECK(leakedShape);
+	CHECK(!constraintReached);
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,6 +17,7 @@
     },
     "xbyak",
     "tbb",
-    "pugixml"
+    "pugixml",
+    "doctest"
   ]
 }


### PR DESCRIPTION
Closes #402, closes #404, closes #405. Follow-up tracked in #406.

A user deleted `<bone>` declarations that `smp report` called removable, and their mod broke. The investigation (#402) traced both report checks against the runtime's actual bone-creation model, adversarially verified the corrected design, and along the way uncovered two engine parser bugs. Policy applied throughout: **zero false positives; missed positives tolerated** — a spurious finding sends authors and users chasing non-problems.

## 1. `smp report gear` absent-node check (#363-era) — false positives eliminated

- **Engine-faithful lookup**: references are resolved live via `GetObjectByName` + NiNode check (`findNodeSafe`), exactly like the runtime's `findObjectByName` — instead of diffing against a pre-collected NiNode-only name set. Fixes false "absent" for a NiNode below a non-NiNode parent and for VR-stub edge cases.
- **Mesh-skin bones count as present**: `generateMeshBody` creates bones from `skinInstance->bones[]` with no name lookup, so skin-bound names are never reported absent — for `<bone>` declarations *and* constraint endpoints (the latter can miss a real drop when the skinning shape comes later in document order; accepted trade under the zero-FP policy).
- **Case-insensitive matching** throughout (skeleton, skin set, rename map), mirroring `BSFixedString`.

## 2. Redundant-`<bone>` warning (#364-era) — removed as unsound

"Only restates the default settings → can be removed" is unprovable from the XML alone: a default-equal `<bone>` on a present-but-unskinned-unreferenced node is a **standalone kinematic collider** (this is what broke the user's mod), and even skinned nodes aren't safe when an unnamed `<bone-default>` between declaration and shape changes the position-dependent default. The warning and its now-unused collector are deleted (no-deprecated-code policy). The provable gear-mode subset is specced in #406.

## 3. New warning: inert `<bone>` declarations — zero false positives by construction

A top-level `<bone>` is flagged only when an **earlier element in the same file already claims the same case-folded name** (earlier `<bone>`, constraint `bodyA`/`bodyB` incl. `constraint-group`, or `can`/`no-collide-with-bone`). The engine creates the bone at the first claim and skips later declarations ("Bone X already exists, skipped"); with an unresolvable name, first claim and later declaration fail identically. Either way the flagged declaration is provably removable, whatever the skeleton looks like. Out-of-file creators (mesh skinning) are ignored — the walk under-reports, never mis-flags.

## 4. Engine fixes found by adversarially verifying that warning

- **#404 — duplicate `<bone>` was not actually skipped**: `readOrUpdateBone`'s duplicate path logged "skipped" but never consumed the element. Its children leaked to the top-level dispatcher (a `<shape>` child aborts the whole physics system on a missing `name` attribute) and its EndTag ended the `<system>` loop, **silently truncating the rest of the file**. Fixed with `skipCurrentElement()`.
- **#405 — `getOrCreateBone` rename asymmetry**: looked up under `getRenamedBone(name)` but created from the raw name; under skeleton-merge/DynamicHDT rename maps, `can/no-collide-with-bone` references were silently dropped or created a wrong-identity bone. Creation now uses the renamed name, matching the constraint readers.

## 5. Refactor

`ToLowerAscii` moved to `src/hdtStringUtils.h` (shared, mirrors `BSFixedString` case-folding); `findNodeSafe` (vtable-guarded `findNode`) added to `NetImmerseUtils.h`; the bone-ref validator uses both instead of local copies.

## 6. Tests — first unit tests in the repo, running in CI

`tests/validator/` doctest suite following the `tests/patterns`/`tests/config` convention (`BUILD_VALIDATOR_TESTS`, doctest via vcpkg, `cxx_std_20`, documented `test_pch.h`): **20 test cases / 37 assertions, all passing.**

- `test_xmlreader.cpp` pins the stream contract behind #404 — including a dispatch loop driven like `createOrUpdateSystem`'s that survives a skipped duplicate, and one that reproduces the truncation + `<shape>` leak without the skip.
- `test_inert_bones.cpp` covers every claiming path of the new warning plus all false-positive guards (declaration-before-references, `-default` templates, `weight-threshold`, empty names, case-folding, line numbers).

CI now configures with `-DBUILD_VALIDATOR_TESTS=ON` and runs `ctest` after every preset build. (`BUILD_TESTS` stays force-OFF: that name belongs to CommonLibSSE's Catch2 tests, absent from our vcpkg manifest — previously an undocumented bare `set()`, now commented.)

## Verification

- AVX2 Release builds clean (`/W4 /WX`, zero warnings); unit tests green.
- The runtime model behind every claim was source-traced and adversarially verified (multi-agent review; the refutation of the first "inert" predicate is what surfaced #404/#405).
- **Outstanding before merge**: an in-game smoke test is recommended for the two engine fixes — especially #405 (equip a DynamicHDT-renamed item, verify `can-collide-with-bone` behaviour). Note: these *can* be tested headless too — the project's benchmark suite already shims `RE::` (`ShimPCH.h`), so `SkyrimSystemCreator`'s bone-resolution path could be split into a testable seam and driven with a fake renamed skeleton; that refactor is not included here (tracked separately) but is a real option, not an impossibility.

## Docs

Wiki updated alongside this PR: the removed warning's row replaced by the inert-declaration warning, absent-node row refreshed, changelog entries under 3.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an automated unit test step to the Windows build process, with failure output shown for easier troubleshooting.
  * One Windows build configuration is skipped during tests due to a known crash issue.

* **Chores**
  * Updated Windows build settings to include additional build information and enable validator-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->