### PR TITLE
fix: install hdtSMP64.xsd to hdtSkinnedMeshConfigs subfolder

### DIFF
--- a/fomod tree/fomod/ModuleConfig.xml
+++ b/fomod tree/fomod/ModuleConfig.xml
@@ -138,7 +138,7 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 								<folder source="FSMPM\Source" destination="Source" priority="1" />
 								<folder source="FSMPM\interface" destination="interface" priority="1" />
 								<file source="FSMPM\FSMPM - The FSMP MCM.esp" destination=".\FSMPM - The FSMP MCM.esp" priority="1" />
-								<file source="FSMPV\hdtSMP64.xsd" destination="SKSE\Plugins\hdtSMP64.xsd" priority="1" />
+								<file source="FSMPV\hdtSMP64.xsd" destination="SKSE\Plugins\hdtSkinnedMeshConfigs\hdtSMP64.xsd" priority="1" />
 							</files>
 							<typeDescriptor>
 								<type name="Required" />


### PR DESCRIPTION
## Summary
The FOMOD installer deployed the physics XSD to `Data/SKSE/Plugins/hdtSMP64.xsd`, but the runtime loads it from `Data/SKSE/Plugins/hdtSkinnedMeshConfigs/hdtSMP64.xsd` (`src/Validator/Config/hdtValidatorPaths.h`). The file shipped in the release ZIP but landed one directory above where `getOrLoadPhysicsSchema()` calls `load_file()`, so the schema was never found and physics XML validation was silently skipped at startup:

```
[E] [XSDValidator] Could not load physics schema from 'data/skse/plugins/hdtSkinnedMeshConfigs/hdtSMP64.xsd': File was not found; physics XML validation will be skipped.
```

## Change
One-line fix to the FOMOD `destination` in `fomod tree/fomod/ModuleConfig.xml` so the XSD installs into the `hdtSkinnedMeshConfigs` subfolder the runtime reads. XML well-formedness verified.

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)