### PR TITLE
feat(#406): flag skin-redundant <bone> declarations across all consumers

### DIFF
--- a/src/Validator/Parser/hdtNIFBinaryParser.cpp
+++ b/src/Validator/Parser/hdtNIFBinaryParser.cpp
@@ -1,13 +1,36 @@
 #include "hdtNIFBinaryParser.h"
 
+#include "../../hdtStringUtils.h"
+#include "../Schema/hdtNifSchema.h"
 #include "../Utils/hdtNIFBinaryUtils.h"
 
 #include <cstring>
+#include <unordered_set>
 
 namespace hdt
 {
 	namespace nif
 	{
+		namespace
+		{
+			// True if `typeName` is, or transitively inherits from, "NiNode" per the schema —
+			// i.e. a scene-graph node that carries a NiObjectNET Name at block offset 0. Walking the
+			// inherit chain (bounded to guard against a malformed/cyclic schema) keeps the skin-bone
+			// read honest: geometry, properties and unknown types resolve to false and are skipped.
+			bool inheritsFromNiNode(const NifSchema& schema, const std::string& typeName)
+			{
+				std::string t = typeName;
+				for (int guard = 0; guard < 64 && !t.empty(); ++guard) {
+					if (t == "NiNode")
+						return true;
+					const NifTypeDef* def = schema.findType(t);
+					if (!def)
+						return false;
+					t = def->inherit;
+				}
+				return false;
+			}
+		}  // namespace
 
 		std::vector<std::string> FindXmlPathsInNif(const ParsedNif& parsed)
 		{
@@ -54,6 +77,57 @@ namespace hdt
 				}
 			}
 			return paths;
+		}
+
+		std::vector<std::string> ExtractSkinBoundBoneNames(const ParsedNif& parsed)
+		{
+			const NifSchema& schema = globalNifSchema();
+			const int32_t numBlocks = static_cast<int32_t>(parsed.blocks.size());
+			std::unordered_set<std::string> nameSet;
+
+			for (int32_t i = 0; i < numBlocks; ++i) {
+				auto tOpt = blockTypeOf(parsed, i);
+				if (!tOpt)
+					continue;
+				if (*tOpt != kTypeNiSkinInstance && *tOpt != kTypeBSDismemberSkinInstance &&
+					*tOpt != kTypeBSSkinInstance)
+					continue;
+
+				const auto& block = parsed.blocks[static_cast<size_t>(i)];
+				auto details = walkBlockRefDetails(schema, *tOpt, block.data(), block.size(), numBlocks);
+				if (!details)
+					continue;
+
+				for (const auto& ref : details->refs) {
+					// The Bones array is the skin instance's only array-valued Ref; the scalar
+					// Data / Skin Partition / Skeleton Root refs carry an empty arr1 and are not bones.
+					if (ref.arr1.empty())
+						continue;
+					if (ref.offset + 4 > block.size())
+						continue;
+					int32_t boneIdx = -1;
+					std::memcpy(&boneIdx, block.data() + ref.offset, 4);
+					if (boneIdx < 0 || boneIdx >= numBlocks)
+						continue;
+
+					auto boneTypeOpt = blockTypeOf(parsed, boneIdx);
+					if (!boneTypeOpt || !inheritsFromNiNode(schema, *boneTypeOpt))
+						continue;  // not a scene node — no reliable Name at offset 0
+
+					const auto& boneBlock = parsed.blocks[static_cast<size_t>(boneIdx)];
+					if (boneBlock.size() < 4)
+						continue;
+					uint32_t nameIdx = 0;
+					std::memcpy(&nameIdx, boneBlock.data(), 4);
+					if (nameIdx >= parsed.strings.size())
+						continue;
+					const std::string& name = parsed.strings[nameIdx];
+					if (!name.empty())
+						nameSet.insert(ToLowerAscii(name));
+				}
+			}
+
+			return std::vector<std::string>(nameSet.begin(), nameSet.end());
 		}
 
 	}  // namespace nif

--- a/src/Validator/Parser/hdtNIFBinaryParser.h
+++ b/src/Validator/Parser/hdtNIFBinaryParser.h
@@ -14,6 +14,20 @@ namespace hdt
 		// Reads directly from parsed.blocks — no raw-byte offset arithmetic needed.
 		std::vector<std::string> FindXmlPathsInNif(const ParsedNif& parsed);
 
+		// Returns every skeleton-node name this NIF is skinned to: the union of the Bones
+		// arrays of all NiSkinInstance / BSDismemberSkinInstance / BSSkin::Instance blocks.
+		// Names are case-folded (ASCII lower) and de-duplicated so callers can compare and
+		// intersect them directly.
+		//
+		// How it reads a skin instance's bones: the schema marks the Bones field as the block's
+		// only array-valued Ref (Data / Skin Partition / Skeleton Root are scalar Refs), so we
+		// take every array-element Ref, follow it to its block, and read that block's Name — the
+		// first field (a StringIndex at byte offset 0) of every NiObjectNET-derived node. A bone
+		// Ref that points to a non-node block, an unknown type, or an out-of-range string is
+		// skipped, so the result UNDER-reports (never invents) a skin binding — which is what lets
+		// the #406 caller treat "every consumer skins to X" as a zero-false-positive fact.
+		std::vector<std::string> ExtractSkinBoundBoneNames(const ParsedNif& parsed);
+
 	}  // namespace nif
 
 }  // namespace hdt

--- a/src/Validator/Utils/hdtTemplateDefaults.cpp
+++ b/src/Validator/Utils/hdtTemplateDefaults.cpp
@@ -966,6 +966,67 @@ namespace hdt
 			}
 		}
 
+		// XML-side collector for the skin-redundant-<bone> check (issue #406). See the header
+		// for the contract. Walks top-level bone-family elements in document order, keeping the
+		// unnamed bone-default (boneTemplates[""]) current. A plain <bone> becomes a candidate
+		// when its effective FieldMap equals boneTemplates[""] at that point. An unnamed
+		// <bone-default> encountered later clears the pending candidates: it changes the default
+		// the engine would recreate skinned bones with, so any earlier candidate can no longer be
+		// proven neutral to remove. Whatever candidates survive to the end therefore satisfy both
+		// "equals the default at its position" and "no unnamed bone-default after it".
+		std::vector<InertBoneInfo> collectSkinRedundantBoneCandidates(
+			const pugi::xml_document& doc,
+			const std::string* sourceBytes)
+		{
+			std::vector<InertBoneInfo> candidates;
+			auto sysNode = findSystemNode(doc);
+			if (!sysNode)
+				return candidates;
+
+			const auto baseDefaults = makeBaseDefaults();
+			TemplateMap boneTemplates;
+			{
+				auto it = baseDefaults.find(Family::Bone);
+				boneTemplates[""] = (it != baseDefaults.end()) ? it->second : FieldMap{};
+			}
+
+			for (auto node = sysNode.first_child(); node; node = node.next_sibling()) {
+				if (node.type() != pugi::node_element)
+					continue;
+				const std::string localName = std::string(XmlLocalName(node.name()));
+				if (familyForNode(localName) != Family::Bone)
+					continue;
+
+				const bool isDefault = isDefaultNodeName(localName);  // "bone-default"
+				FieldMap effective = computeNodeEffectiveFields(node, Family::Bone, isDefault, boneTemplates);
+
+				if (isDefault) {
+					const std::string templateName = TrimAsciiWhitespace(node.attribute("name").as_string());
+					boneTemplates[templateName] = std::move(effective);
+					// An unnamed bone-default retroactively invalidates earlier candidates
+					// (condition 2): the default that would recreate them has now changed.
+					if (templateName.empty())
+						candidates.clear();
+					continue;
+				}
+
+				const char* rawName = node.attribute("name").value();
+				if (rawName[0] == '\0')
+					continue;
+				auto defaultIt = boneTemplates.find("");
+				if (defaultIt != boneTemplates.end() && effective == defaultIt->second) {
+					InertBoneInfo info;
+					info.location = BuildNodeLocationPath(node);
+					info.boneName = TrimAsciiWhitespace(rawName);
+					if (sourceBytes)
+						info.line = OffsetToLineNumber(*sourceBytes, node.offset_debug());
+					candidates.push_back(std::move(info));
+				}
+			}
+
+			return candidates;
+		}
+
 	}  // anonymous namespace
 
 	// ── Public API ────────────────────────────────────────────────────────────
@@ -1030,6 +1091,44 @@ namespace hdt
 		std::unordered_set<std::string> touched;
 		collectInertBonesInOrder(sysNode, touched, sourceBytes, out);
 		return out;
+	}
+
+	std::vector<InertBoneInfo> CollectSkinRedundantBoneCandidates(
+		const pugi::xml_document& doc,
+		const std::string* sourceBytes)
+	{
+		return collectSkinRedundantBoneCandidates(doc, sourceBytes);
+	}
+
+	std::vector<InertBoneInfo> FilterSkinRedundantBonesByConsumers(
+		const std::vector<InertBoneInfo>& candidates,
+		const std::vector<std::vector<std::string>>& consumerSkinBones)
+	{
+		// Nothing is proven with no consumer, so flag nothing.
+		if (candidates.empty() || consumerSkinBones.empty())
+			return {};
+
+		// Intersection of skin-bound bone names across ALL consumers (all case-folded).
+		// Seed from the first consumer, then drop any name missing from a later consumer.
+		std::unordered_set<std::string> common(consumerSkinBones[0].begin(), consumerSkinBones[0].end());
+		for (size_t k = 1; k < consumerSkinBones.size() && !common.empty(); ++k) {
+			std::unordered_set<std::string> next(consumerSkinBones[k].begin(), consumerSkinBones[k].end());
+			for (auto it = common.begin(); it != common.end();) {
+				if (next.find(*it) == next.end())
+					it = common.erase(it);
+				else
+					++it;
+			}
+		}
+		if (common.empty())
+			return {};
+
+		std::vector<InertBoneInfo> result;
+		for (const auto& c : candidates) {
+			if (common.find(ToLowerAscii(c.boneName)) != common.end())
+				result.push_back(c);
+		}
+		return result;
 	}
 
 }  // namespace hdt

--- a/src/Validator/Utils/hdtTemplateDefaults.h
+++ b/src/Validator/Utils/hdtTemplateDefaults.h
@@ -70,4 +70,36 @@ namespace hdt
 		const pugi::xml_document& doc,
 		const std::string* sourceBytes = nullptr);
 
+	// The XML-side half of the "skin-redundant <bone>" check (issue #406): top-level <bone>
+	// declarations that are removable AS FAR AS THE XML ALONE CAN PROVE — a mesh skinned to the
+	// node would make the engine auto-create an identical bone, so the declaration only restates
+	// it. Two conditions, both position-aware:
+	//   (1) the bone's effective FieldMap equals the unnamed bone-default in force at its own
+	//       document position (so what it declares is exactly what would be auto-created), and
+	//   (2) no unnamed <bone-default> appears AFTER it — otherwise the default the engine would
+	//       recreate the bone with (at the skinning shape's later position) could differ, so
+	//       removal would not be neutral.
+	// This returns candidates ONLY; it deliberately says nothing about whether any mesh actually
+	// skins to the node. That is a per-consumer fact — the caller must confirm EVERY NIF that
+	// references this XML is skinned to `boneName` (after renaming) before reporting removability,
+	// which is what keeps the warning a mod-level truth rather than a per-item accident.
+	// When sourceBytes is provided, line numbers are computed from offsets.
+	std::vector<InertBoneInfo> CollectSkinRedundantBoneCandidates(
+		const pugi::xml_document& doc,
+		const std::string* sourceBytes = nullptr);
+
+	// The ecosystem half of the #406 check: given the XML-intrinsic candidates for one physics
+	// file and, for each NIF that references that file, the set of node names that NIF is skinned
+	// to (case-folded, e.g. from ExtractSkinBoundBoneNames), keep only the candidates that are
+	// removable community-wide — those whose bone name (case-folded) is skinned by EVERY consumer.
+	// The reasoning: a mesh skinned to node X makes the engine auto-create an identical default
+	// bone X, so <bone X> is pure redundancy there; but if even one consumer does NOT skin to X,
+	// its <bone X> may be that bone's only creator, so removal would change behaviour. Requiring
+	// ALL consumers is what makes the warning a mod-level truth. With zero consumers nothing is
+	// proven and the result is empty. A consumer whose skin bones could not be read contributes an
+	// empty set, which drops every candidate — the check under-reports rather than over-reports.
+	std::vector<InertBoneInfo> FilterSkinRedundantBonesByConsumers(
+		const std::vector<InertBoneInfo>& candidates,
+		const std::vector<std::vector<std::string>>& consumerSkinBones);
+
 }  // namespace hdt

--- a/src/Validator/Validators/hdtNIFPhysicsXMLExtractor.cpp
+++ b/src/Validator/Validators/hdtNIFPhysicsXMLExtractor.cpp
@@ -224,6 +224,9 @@ namespace hdt
 				if (hasMarker) {
 					result.hasPhysicsData = true;
 					result.allPhysicsXmlPaths = nif::FindXmlPathsInNif(parsed);
+					// Record which skeleton nodes this NIF skins to, for the #406 cross-consumer
+					// check. Reuses the already-parsed blocks — no extra file read or parse.
+					result.skinBoundBoneNames = nif::ExtractSkinBoundBoneNames(parsed);
 					if (!result.allPhysicsXmlPaths.empty()) {
 						result.physicsXmlPath = result.allPhysicsXmlPaths[0];
 					} else {

--- a/src/Validator/Validators/hdtNIFValidator.h
+++ b/src/Validator/Validators/hdtNIFValidator.h
@@ -20,6 +20,9 @@ namespace hdt
 		bool hasGeometry = false;
 		bool hasSkinning = false;
 		bool hasOrphanedPhysicsMarker = false;  // marker string present but no NiStringExtraData block references it
+		// Case-folded, de-duplicated node names this NIF's meshes are skinned to (union of every
+		// skin instance's Bones array). Drives the #406 cross-consumer "skin-redundant <bone>" check.
+		std::vector<std::string> skinBoundBoneNames;
 		std::vector<std::string> errors;
 	};
 

--- a/src/Validator/hdtAssetValidator.cpp
+++ b/src/Validator/hdtAssetValidator.cpp
@@ -946,6 +946,7 @@ namespace hdt
 						asset.hasOrphanedPhysicsMarker = scanRes.hasOrphanedPhysicsMarker;
 						asset.relatedTRIPaths = discoverRelatedTRIFiles(pathStr);
 						asset.allPhysicsXmlPaths = scanRes.allPhysicsXmlPaths;
+						asset.skinBoundBoneNames = std::move(scanRes.skinBoundBoneNames);
 
 						if (!scanRes.physicsXmlPath.empty()) {
 							auto [xmlPath, xmlExists] = ResolveXMLPath(scanRes.physicsXmlPath);
@@ -1302,6 +1303,89 @@ namespace hdt
 		}
 	}
 
+	/// Ecosystem-level "skin-redundant <bone>" analysis (issue #406) — full-scan only.
+	///
+	/// A top-level <bone X> on a skinned node only restates what the engine already builds from
+	/// the mesh skin: when a mesh skins to node X, the runtime creates bone X from the unnamed
+	/// default template. So <bone X> is provably removable when
+	///   (1)&(2) the XML proves it equals the unnamed default in force at its own position, with no
+	///           later unnamed <bone-default> to change that default (CollectSkinRedundantBoneCandidates), and
+	///   (3) EVERY NIF that references this physics XML is skinned to X — so the engine auto-creates
+	///       an identical bone for every consumer, making the declaration redundant across the whole
+	///       ecosystem, not merely for one item (FilterSkinRedundantBonesByConsumers).
+	/// This needs the full NIF→XML population, so it runs only in the filesystem full scan; gear mode
+	/// sees a single equipped consumer and cannot prove "every consumer". Consumers whose skin bones
+	/// could not be read contribute an empty set, which drops every candidate — so the pass
+	/// under-reports rather than ever flagging a live declaration.
+	///
+	/// `excludedXmlNorms` holds normalised paths of XMLs we must NOT analyse because their consumer
+	/// set is not enumerable from NIF references alone — chiefly defaultBBPs.xml defaults, which the
+	/// runtime applies to any body of a matching shape that lacks its own physics. Such an XML could
+	/// be worn by a mesh not skinned to X yet invisible to this scan, so flagging it could be a false
+	/// positive; skipping it keeps the guarantee intact.
+	static void analyzeSkinRedundantBones(const std::vector<PhysicsAsset>& nifAssets,
+		const std::unordered_set<std::string>& excludedXmlNorms,
+		AssetValidationResult& report, std::ostream& out)
+	{
+		// Group consumers by the XML they reference (normalised), preserving first-seen order so
+		// the emitted report is deterministic across runs.
+		struct XmlConsumers
+		{
+			std::string displayPath;
+			std::vector<std::vector<std::string>> consumerSkinBones;
+		};
+		std::unordered_map<std::string, XmlConsumers> byXml;
+		std::vector<std::string> xmlOrder;
+
+		for (const auto& asset : nifAssets) {
+			if (asset.xmlPath.empty() || !asset.xmlExists)
+				continue;
+			auto norm = NormalizePathForComparison(asset.xmlPath);
+			auto it = byXml.find(norm);
+			if (it == byXml.end()) {
+				it = byXml.emplace(norm, XmlConsumers{ asset.xmlPath, {} }).first;
+				xmlOrder.push_back(norm);
+			}
+			it->second.consumerSkinBones.push_back(asset.skinBoundBoneNames);
+		}
+
+		for (const auto& norm : xmlOrder) {
+			if (excludedXmlNorms.count(norm))
+				continue;  // consumer set not enumerable (e.g. defaultBBP default) — cannot prove removability
+			const auto& entry = byXml[norm];
+
+			std::string bytes = readAllFile2(entry.displayPath.c_str());
+			if (bytes.empty())
+				continue;
+			pugi::xml_document doc;
+			if (!doc.load_buffer(bytes.data(), bytes.size()))
+				continue;
+
+			auto candidates = CollectSkinRedundantBoneCandidates(doc, &bytes);
+			if (candidates.empty())
+				continue;
+
+			auto flagged = FilterSkinRedundantBonesByConsumers(candidates, entry.consumerSkinBones);
+			if (flagged.empty())
+				continue;
+
+			out << "  [XML]  " << entry.displayPath << "\n";
+			for (const auto& bone : flagged) {
+				const std::string named = bone.boneName.empty() ? std::string() : " \"" + bone.boneName + "\"";
+				std::string msg = entry.displayPath + ":" + std::to_string(bone.line) + ": " + bone.location +
+				                  " - <bone>" + named +
+				                  " restates the skin-created default: every mesh that references this physics"
+				                  " file skins to this node, so the engine already creates an identical default"
+				                  " bone from the skin. This declaration is redundant and can be removed.";
+				report.warnings.push_back(msg);
+				report.hasWarnings = true;
+				out << "    [WARNING] " << bone.location << " (line " << bone.line << "): <bone>" << named
+					<< " restates the skin-created default (every mesh referencing this physics file skins to"
+					   " this node, so the engine already creates an identical bone); it can be removed.\n";
+			}
+		}
+	}
+
 	static std::string runValidationCore(AssetValidationResult& report, const std::string& timestamp, bool equippedOnly = false)
 	{
 		auto wallStart = std::chrono::steady_clock::now();
@@ -1345,6 +1429,12 @@ namespace hdt
 
 			// Phase 0: DefaultBBP XML validation
 			auto bbpEntries = discoverDefaultBBPXMLs();
+			// defaultBBP defaults are applied by shape, not by NIF reference, so their consumer set
+			// is not enumerable from the NIF scan; exclude them from the #406 skin-redundant analysis.
+			std::unordered_set<std::string> defaultBbpXmlNorms;
+			for (const auto& entry : bbpEntries)
+				if (!entry.xmlPath.empty())
+					defaultBbpXmlNorms.insert(NormalizePathForComparison(entry.xmlPath));
 			if (!bbpEntries.empty()) {
 				bodyStream << "== Phase 0: DefaultBBP XML Validation ==\n";
 				bodyStream << "  Found " << bbpEntries.size() << " map entries in defaultBBPs.xml.\n";
@@ -1449,6 +1539,11 @@ namespace hdt
 
 				bodyStream << "\n== Phase 3.5: NIF Structural Validation ==\n";
 				validateNIFStructure(nifAssets, report, bodyStream);
+
+				// Cross-consumer redundant-<bone> check: needs the full NIF→XML population, so
+				// it runs only here in the full scan (see analyzeSkinRedundantBones).
+				bodyStream << "\n== Phase 3.6: Skin-Redundant <bone> Analysis ==\n";
+				analyzeSkinRedundantBones(nifAssets, defaultBbpXmlNorms, report, bodyStream);
 			}
 		}
 

--- a/src/Validator/hdtAssetValidator.h
+++ b/src/Validator/hdtAssetValidator.h
@@ -22,6 +22,7 @@ namespace hdt
 		std::string xmlPath;
 		std::vector<std::string> relatedTRIPaths;
 		std::vector<std::string> allPhysicsXmlPaths;  // all "HDT Skinned Mesh Physics Object" blocks
+		std::vector<std::string> skinBoundBoneNames;  // case-folded node names this NIF is skinned to (#406)
 		bool nifExists = false;
 		bool xmlExists = false;
 		bool hasOrphanedPhysicsMarker = false;  // marker string present but no NiStringExtraData block

--- a/tests/validator/CMakeLists.txt
+++ b/tests/validator/CMakeLists.txt
@@ -1,5 +1,5 @@
-# validator_tests - doctest unit suite for the XML reader stream contract (#404) and the validator's inert-<bone>
-# (#402) and skin-redundant-<bone> (#406) warnings.
+# validator_tests - doctest unit suite for the XML reader stream contract (#404) and the validator's inert-<bone> (#402)
+# and skin-redundant-<bone> (#406) warnings.
 #
 # Built only when BUILD_VALIDATOR_TESTS is ON (a dev/CI tool, never packaged). The targets under test are
 # game-independent: XmlReader.cpp needs only the XmlInspector headers and Bullet's header-inline math types; the
@@ -16,10 +16,12 @@ find_package(doctest CONFIG REQUIRED)
 
 add_executable(
 	validator_tests
-	"${CMAKE_CURRENT_SOURCE_DIR}/main.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/test_xmlreader.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/test_xmlreader.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/test_inert_bones.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/test_skin_redundant_bones.cpp"
-	"${CMAKE_CURRENT_SOURCE_DIR}/test_skin_bone_extraction.cpp" "${SOURCE_DIR}/XmlReader.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/test_skin_bone_extraction.cpp"
+	"${SOURCE_DIR}/XmlReader.cpp"
 	"${SOURCE_DIR}/Validator/Utils/hdtTemplateDefaults.cpp"
 	"${SOURCE_DIR}/Validator/Parser/hdtNIFBinaryParser.cpp"
 	"${SOURCE_DIR}/Validator/Schema/hdtNifSchema.cpp")

--- a/tests/validator/CMakeLists.txt
+++ b/tests/validator/CMakeLists.txt
@@ -1,9 +1,10 @@
 # validator_tests - doctest unit suite for the XML reader stream contract (#404) and the validator's inert-<bone>
-# warning (#402).
+# (#402) and skin-redundant-<bone> (#406) warnings.
 #
 # Built only when BUILD_VALIDATOR_TESTS is ON (a dev/CI tool, never packaged). The targets under test are
-# game-independent: XmlReader.cpp needs only the XmlInspector headers and Bullet's header-inline math types, and the
-# XML-redundancy analysis (hdtTemplateDefaults.cpp) is pure pugixml + STL - no CommonLibSSE, no TBB - so both compile
+# game-independent: XmlReader.cpp needs only the XmlInspector headers and Bullet's header-inline math types; the
+# XML-redundancy analysis (hdtTemplateDefaults.cpp) is pure pugixml + STL; and the #406 offline skin-bone extraction
+# (hdtNIFBinaryParser.cpp + hdtNifSchema.cpp) is pure binary/schema parsing - no CommonLibSSE, no TBB - so all compile
 # directly without the game's force-included src/PCH.h (tests supply test_pch.h instead). Mirrors tests/patterns.
 
 set(ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
@@ -16,8 +17,12 @@ find_package(doctest CONFIG REQUIRED)
 add_executable(
 	validator_tests
 	"${CMAKE_CURRENT_SOURCE_DIR}/main.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/test_xmlreader.cpp"
-	"${CMAKE_CURRENT_SOURCE_DIR}/test_inert_bones.cpp" "${SOURCE_DIR}/XmlReader.cpp"
-	"${SOURCE_DIR}/Validator/Utils/hdtTemplateDefaults.cpp")
+	"${CMAKE_CURRENT_SOURCE_DIR}/test_inert_bones.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/test_skin_redundant_bones.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/test_skin_bone_extraction.cpp" "${SOURCE_DIR}/XmlReader.cpp"
+	"${SOURCE_DIR}/Validator/Utils/hdtTemplateDefaults.cpp"
+	"${SOURCE_DIR}/Validator/Parser/hdtNIFBinaryParser.cpp"
+	"${SOURCE_DIR}/Validator/Schema/hdtNifSchema.cpp")
 
 target_compile_features(validator_tests PRIVATE cxx_std_20)
 target_include_directories(validator_tests PRIVATE "${SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" ${BULLET_INCLUDE_DIRS})

--- a/tests/validator/test_pch.h
+++ b/tests/validator/test_pch.h
@@ -12,3 +12,29 @@
 #include <mutex>      // std::lock_guard — hdtBulletHelper.h
 #include <vector>     // std::vector     — hdt::vectorA16 alias (hdtBulletHelper.h)
 #include <windows.h>  // BYTE            — XMLReader's buffer constructor
+
+// hdtNifSchema.cpp emits verbose spdlog trace lines (`logger::info("...{}", ...)`, guarded by a
+// debug flag but compiled unconditionally). In the plugin, `logger` comes from CommonLibSSE via
+// PCH.h; the headless test target has none, so stand in a no-op variadic `logger` that swallows any
+// arguments. Test-target only — the plugin build still uses the real logger through PCH.h.
+namespace logger
+{
+	template <class... Args>
+	inline void trace(Args&&...)
+	{}
+	template <class... Args>
+	inline void debug(Args&&...)
+	{}
+	template <class... Args>
+	inline void info(Args&&...)
+	{}
+	template <class... Args>
+	inline void warn(Args&&...)
+	{}
+	template <class... Args>
+	inline void error(Args&&...)
+	{}
+	template <class... Args>
+	inline void critical(Args&&...)
+	{}
+}

--- a/tests/validator/test_skin_bone_extraction.cpp
+++ b/tests/validator/test_skin_bone_extraction.cpp
@@ -1,0 +1,174 @@
+// ExtractSkinBoundBoneNames tests (issue #406, offline-NIF half).
+//
+// Given a parsed NIF, ExtractSkinBoundBoneNames returns the case-folded, de-duplicated set of
+// skeleton-node names every skin instance is skinned to (the union of the Bones arrays). These
+// tests hand-build a ParsedNif so they exercise the exact offset math and the schema-driven
+// Bones-vs-scalar-ref selection without needing a real .nif on disk. The zero-false-positive
+// contract is what they guard: only true bone bindings are reported, and only from node blocks.
+
+#include "Validator/Parser/hdtNIFBinaryParser.h"
+
+#include <doctest/doctest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace
+{
+	void putI32(std::vector<uint8_t>& b, int32_t v)
+	{
+		uint8_t tmp[4];
+		std::memcpy(tmp, &v, 4);
+		b.insert(b.end(), tmp, tmp + 4);
+	}
+
+	// A skin-instance block laid out exactly as the SSE schema expects, so walkBlockRefDetails
+	// parses it: three scalar refs (Data, Skin Partition, Skeleton Root), Num Bones, then the
+	// Bones ref array. `skeletonRoot` is exposed so a test can point it at a node and prove that
+	// scalar ref is NOT mistaken for a bone.
+	std::vector<uint8_t> skinInstanceBlock(const std::vector<int32_t>& boneRefs, int32_t skeletonRoot = -1)
+	{
+		std::vector<uint8_t> b;
+		putI32(b, -1);                                     // Data
+		putI32(b, -1);                                     // Skin Partition
+		putI32(b, skeletonRoot);                           // Skeleton Root
+		putI32(b, static_cast<int32_t>(boneRefs.size()));  // Num Bones
+		for (int32_t r : boneRefs)
+			putI32(b, r);
+		return b;
+	}
+
+	// A scene node only needs its Name (a StringIndex at block offset 0) for the extractor.
+	std::vector<uint8_t> nodeBlock(uint32_t nameIdx)
+	{
+		std::vector<uint8_t> b;
+		putI32(b, static_cast<int32_t>(nameIdx));
+		return b;
+	}
+
+	bool has(const std::vector<std::string>& v, const std::string& s)
+	{
+		return std::find(v.begin(), v.end(), s) != v.end();
+	}
+}
+
+TEST_CASE("bones of a NiSkinInstance are returned, case-folded")
+{
+	hdt::ParsedNif p;
+	p.blockTypes = { "NiSkinInstance", "NiNode" };
+	p.blockTypeIndex = { 0, 1, 1 };
+	p.strings = { "NPC Spine", "NPC Head" };
+	p.blocks = { skinInstanceBlock({ 1, 2 }), nodeBlock(0), nodeBlock(1) };
+
+	auto names = hdt::nif::ExtractSkinBoundBoneNames(p);
+	CHECK(names.size() == 2);
+	CHECK(has(names, "npc spine"));
+	CHECK(has(names, "npc head"));
+}
+
+TEST_CASE("BSDismemberSkinInstance bones are read the same way")
+{
+	hdt::ParsedNif p;
+	p.blockTypes = { "BSDismemberSkinInstance", "NiNode" };
+	p.blockTypeIndex = { 0, 1 };
+	p.strings = { "NPC L Breast01" };
+	// BSDismemberSkinInstance adds Num Partitions + Partitions AFTER Bones; the extractor reads
+	// the Bones array from the NiSkinInstance base, so those trailing uints are irrelevant here.
+	p.blocks = { skinInstanceBlock({ 1 }), nodeBlock(0) };
+
+	auto names = hdt::nif::ExtractSkinBoundBoneNames(p);
+	REQUIRE(names.size() == 1);
+	CHECK(names[0] == "npc l breast01");
+}
+
+TEST_CASE("the scalar Skeleton Root ref is not treated as a bone")
+{
+	hdt::ParsedNif p;
+	p.blockTypes = { "NiSkinInstance", "NiNode" };
+	p.blockTypeIndex = { 0, 1, 1 };
+	p.strings = { "NPC Spine", "NPC Root" };
+	// Skeleton Root -> block 2 ("NPC Root"), Bones -> [block 1 ("NPC Spine")].
+	p.blocks = { skinInstanceBlock({ 1 }, /*skeletonRoot=*/2), nodeBlock(0), nodeBlock(1) };
+
+	auto names = hdt::nif::ExtractSkinBoundBoneNames(p);
+	REQUIRE(names.size() == 1);
+	CHECK(has(names, "npc spine"));
+	CHECK(!has(names, "npc root"));  // scalar ref, not a bone
+}
+
+TEST_CASE("a bone ref to a non-node block is skipped")
+{
+	hdt::ParsedNif p;
+	p.blockTypes = { "NiSkinInstance", "NiNode", "BSTriShape" };
+	p.blockTypeIndex = { 0, 1, 2 };
+	p.strings = { "NPC Spine", "SomeMesh" };
+	// Bones -> [block 1 (NiNode "NPC Spine"), block 2 (BSTriShape — not a scene node)].
+	p.blocks = { skinInstanceBlock({ 1, 2 }), nodeBlock(0), nodeBlock(1) };
+
+	auto names = hdt::nif::ExtractSkinBoundBoneNames(p);
+	REQUIRE(names.size() == 1);
+	CHECK(has(names, "npc spine"));
+	CHECK(!has(names, "somemesh"));  // BSTriShape does not inherit NiNode
+}
+
+TEST_CASE("an out-of-range bone ref is skipped without crashing")
+{
+	hdt::ParsedNif p;
+	p.blockTypes = { "NiSkinInstance", "NiNode" };
+	p.blockTypeIndex = { 0, 1 };
+	p.strings = { "NPC Spine" };
+	// Bones -> [block 1 (valid), block 99 (out of range)].
+	p.blocks = { skinInstanceBlock({ 1, 99 }), nodeBlock(0) };
+
+	auto names = hdt::nif::ExtractSkinBoundBoneNames(p);
+	REQUIRE(names.size() == 1);
+	CHECK(names[0] == "npc spine");
+}
+
+TEST_CASE("an empty bone name is ignored")
+{
+	hdt::ParsedNif p;
+	p.blockTypes = { "NiSkinInstance", "NiNode" };
+	p.blockTypeIndex = { 0, 1, 1 };
+	p.strings = { "", "NPC Spine" };
+	p.blocks = { skinInstanceBlock({ 1, 2 }), nodeBlock(0), nodeBlock(1) };
+
+	auto names = hdt::nif::ExtractSkinBoundBoneNames(p);
+	REQUIRE(names.size() == 1);
+	CHECK(names[0] == "npc spine");
+}
+
+TEST_CASE("bones are unioned across skin instances and de-duplicated")
+{
+	hdt::ParsedNif p;
+	p.blockTypes = { "NiSkinInstance", "NiNode" };
+	// Two skin instances (blocks 0 and 1), three nodes (blocks 2,3,4).
+	p.blockTypeIndex = { 0, 0, 1, 1, 1 };
+	p.strings = { "NPC Spine", "NPC Head" };
+	p.blocks = {
+		skinInstanceBlock({ 2, 3 }),  // Spine, Head
+		skinInstanceBlock({ 2, 4 }),  // Spine (dup), Head-again
+		nodeBlock(0),                 // "NPC Spine"
+		nodeBlock(1),                 // "NPC Head"
+		nodeBlock(1),                 // "NPC Head" (same name, different node)
+	};
+
+	auto names = hdt::nif::ExtractSkinBoundBoneNames(p);
+	CHECK(names.size() == 2);
+	CHECK(has(names, "npc spine"));
+	CHECK(has(names, "npc head"));
+}
+
+TEST_CASE("a NIF with no skin instance yields no bones")
+{
+	hdt::ParsedNif p;
+	p.blockTypes = { "NiNode" };
+	p.blockTypeIndex = { 0 };
+	p.strings = { "NPC Spine" };
+	p.blocks = { nodeBlock(0) };
+
+	CHECK(hdt::nif::ExtractSkinBoundBoneNames(p).empty());
+}

--- a/tests/validator/test_skin_redundant_bones.cpp
+++ b/tests/validator/test_skin_redundant_bones.cpp
@@ -1,0 +1,200 @@
+// CollectSkinRedundantBoneCandidates tests (issue #406, XML-intrinsic half).
+//
+// The candidate collector returns top-level <bone> declarations that are removable AS FAR AS
+// THE XML PROVES: effective FieldMap == the unnamed default at the bone's position, and no
+// unnamed <bone-default> appears after it. Whether a mesh actually skins to the node is a
+// per-consumer fact applied elsewhere; these tests pin only the XML-side conditions.
+
+#include "Validator/Utils/hdtTemplateDefaults.h"
+
+#include <doctest/doctest.h>
+#include <pugixml.hpp>
+
+#include <string>
+#include <vector>
+
+namespace
+{
+	std::vector<hdt::InertBoneInfo> candidates(const std::string& xml, bool withSource = false)
+	{
+		pugi::xml_document doc;
+		if (!doc.load_buffer(xml.data(), xml.size()))
+			return {};
+		return hdt::CollectSkinRedundantBoneCandidates(doc, withSource ? &xml : nullptr);
+	}
+
+	bool hasBone(const std::vector<hdt::InertBoneInfo>& v, const std::string& name)
+	{
+		for (const auto& b : v)
+			if (b.boneName == name)
+				return true;
+		return false;
+	}
+}
+
+TEST_CASE("an empty <bone> equals the default and is a candidate")
+{
+	auto c = candidates("<system><bone name=\"A\"/></system>");
+	REQUIRE(c.size() == 1);
+	CHECK(c[0].boneName == "A");
+	CHECK(c[0].location == "/system[1]/bone[1]");
+}
+
+TEST_CASE("a <bone> carrying a non-default value is not a candidate")
+{
+	// A non-default field (or any unmodelled child) makes the effective map differ.
+	CHECK(candidates("<system><bone name=\"A\"><mass>99</mass></bone></system>").empty());
+	CHECK(candidates("<system><bone name=\"A\"><some-tag/></bone></system>").empty());
+}
+
+TEST_CASE("an unnamed <bone-default> after a candidate clears it (position guard)")
+{
+	// A: before the unnamed bone-default -> the default the engine would recreate it with
+	// could differ, so it must NOT be flagged. B: after it -> flagged.
+	auto c = candidates(
+		"<system>"
+		"<bone name=\"A\"/>"
+		"<bone-default/>"
+		"<bone name=\"B\"/>"
+		"</system>");
+	CHECK(!hasBone(c, "A"));
+	CHECK(hasBone(c, "B"));
+	CHECK(c.size() == 1);
+}
+
+TEST_CASE("a NAMED bone-default does not clear candidates")
+{
+	// Named bone-defaults change boneTemplates["x"], not the unnamed default, so they are
+	// irrelevant to the position guard.
+	auto c = candidates(
+		"<system>"
+		"<bone name=\"A\"/>"
+		"<bone-default name=\"x\"/>"
+		"<bone name=\"B\"/>"
+		"</system>");
+	CHECK(hasBone(c, "A"));
+	CHECK(hasBone(c, "B"));
+	CHECK(c.size() == 2);
+}
+
+TEST_CASE("a <bone> equal to the updated unnamed default (declared after it) is a candidate")
+{
+	// The unnamed bone-default sets mass=1; a later <bone> restating mass=1 equals the default
+	// in force at its position, with no further bone-default after it.
+	auto c = candidates(
+		"<system>"
+		"<bone-default><mass>1</mass></bone-default>"
+		"<bone name=\"A\"><mass>1</mass></bone>"
+		"</system>");
+	REQUIRE(c.size() == 1);
+	CHECK(c[0].boneName == "A");
+}
+
+TEST_CASE("a <bone> that does NOT match the updated default is not a candidate")
+{
+	auto c = candidates(
+		"<system>"
+		"<bone-default><mass>1</mass></bone-default>"
+		"<bone name=\"A\"><mass>2</mass></bone>"
+		"</system>");
+	CHECK(c.empty());
+}
+
+TEST_CASE("empty or missing name attributes are ignored")
+{
+	CHECK(candidates("<system><bone name=\"\"/><bone/></system>").empty());
+}
+
+TEST_CASE("a document without a <system> root yields nothing")
+{
+	CHECK(candidates("<notsystem><bone name=\"A\"/></notsystem>").empty());
+}
+
+TEST_CASE("multiple default bones are all candidates")
+{
+	auto c = candidates("<system><bone name=\"A\"/><bone name=\"B\"/></system>");
+	CHECK(c.size() == 2);
+	CHECK(hasBone(c, "A"));
+	CHECK(hasBone(c, "B"));
+}
+
+TEST_CASE("line numbers are computed from source bytes")
+{
+	const std::string xml =
+		"<system>\n"
+		"<bone name=\"A\"/>\n"
+		"</system>\n";
+	auto c = candidates(xml, /*withSource=*/true);
+	REQUIRE(c.size() == 1);
+	CHECK(c[0].line == 2);
+}
+
+// ── Cross-consumer filter (FilterSkinRedundantBonesByConsumers) ──────────────────
+//
+// The ecosystem half: a candidate survives only when its (case-folded) bone name is skinned
+// by EVERY NIF that references the XML. These pin the zero-false-positive guarantees.
+
+namespace
+{
+	hdt::InertBoneInfo cand(const std::string& name)
+	{
+		hdt::InertBoneInfo b;
+		b.boneName = name;
+		b.location = "/system[1]/bone[1]";
+		b.line = 1;
+		return b;
+	}
+
+	std::vector<std::string> flaggedNames(
+		const std::vector<hdt::InertBoneInfo>& candidates,
+		const std::vector<std::vector<std::string>>& consumers)
+	{
+		std::vector<std::string> out;
+		for (const auto& b : hdt::FilterSkinRedundantBonesByConsumers(candidates, consumers))
+			out.push_back(b.boneName);
+		return out;
+	}
+}
+
+TEST_CASE("a bone skinned by every consumer is flagged")
+{
+	auto out = flaggedNames({ cand("NPC Spine") }, { { "npc spine" }, { "npc spine", "npc head" } });
+	REQUIRE(out.size() == 1);
+	CHECK(out[0] == "NPC Spine");
+}
+
+TEST_CASE("a bone missing from even one consumer is not flagged")
+{
+	auto out = flaggedNames({ cand("NPC Spine") }, { { "npc spine" }, { "npc head" } });
+	CHECK(out.empty());
+}
+
+TEST_CASE("with no consumers nothing is proven, so nothing is flagged")
+{
+	CHECK(flaggedNames({ cand("NPC Spine") }, {}).empty());
+}
+
+TEST_CASE("a consumer whose skin bones could not be read (empty set) drops every candidate")
+{
+	// The empty set represents a NIF we failed to read skinning from: it must veto, never pass.
+	auto out = flaggedNames({ cand("NPC Spine") }, { { "npc spine" }, {} });
+	CHECK(out.empty());
+}
+
+TEST_CASE("consumer bone names match candidates case-insensitively")
+{
+	// Candidate keeps author casing; consumer sets are already folded. The compare folds the candidate.
+	auto out = flaggedNames({ cand("NPC L Breast01") }, { { "npc l breast01" } });
+	REQUIRE(out.size() == 1);
+	CHECK(out[0] == "NPC L Breast01");
+}
+
+TEST_CASE("only the candidates common to all consumers survive")
+{
+	auto out = flaggedNames(
+		{ cand("A"), cand("B"), cand("C") },
+		{ { "a", "b", "c" }, { "a", "c" } });  // B missing from consumer 2
+	REQUIRE(out.size() == 2);
+	CHECK(out[0] == "A");
+	CHECK(out[1] == "C");
+}


### PR DESCRIPTION
Closes #406.

## What

`smp report` (full scan) now flags top-level `<bone X>` declarations that only **restate the default bone FSMP already auto-creates from the mesh skin** — so they can be deleted with zero behaviour change. When a mesh skins to node `X`, `generateMeshBody` builds bone `X` from the unnamed default template (`getBoneTemplate("")`); an empty/default `<bone X>` on top of that adds nothing.

This is an **ecosystem-level** truth, not a per-item accident: a declaration is flagged only when it is provably removable for **every** consumer of the physics file.

## The zero-false-positive predicate

A `<bone X>` is reported removable iff **all** hold:

1. its effective FieldMap equals the unnamed `bone-default` in force **at its own document position**, and
2. no later unnamed `<bone-default>` can change that default (so the skin-shape, wherever it sits, recreates the same bone), and
3. **every** NIF that references this physics XML is skinned to node `X`.

Conservative on every axis, so it only ever **under-reports**:
- Skin bindings are read from each skin instance's `Bones` array only (schema-identified via `arr1`), resolved to `NiNode`-derived blocks only; anything unreadable (unknown type, non-node, out-of-range ref) is skipped rather than guessed.
- A consumer whose skin bones can't be read contributes an empty set, which drops every candidate.
- XMLs shared through `defaultBBPs.xml` are **excluded** — their consumers are applied by body shape, not by NIF reference, so they can't be enumerated from the scan.
- Full-scan only: `gear` mode sees one equipped consumer and can't prove "every consumer", so it doesn't run there (documented in the report and wiki).

## Change scopes

| Area | Change |
| --- | --- |
| **Parser** | `ExtractSkinBoundBoneNames(ParsedNif)` — offline union of every skin instance's skinned node names (`NiSkinInstance` / `BSDismemberSkinInstance` / `BSSkin::Instance`), case-folded. |
| **Utils** | `CollectSkinRedundantBoneCandidates` (XML conditions 1 & 2) and `FilterSkinRedundantBonesByConsumers` (condition 3) — both pure/headless. |
| **NIF scan** | `NIFScanResult` / `PhysicsAsset` carry per-NIF `skinBoundBoneNames`; populated from the already-parsed NIF (no extra read/parse). |
| **Pipeline** | `analyzeSkinRedundantBones` aggregates consumers per XML and emits **Phase 3.6** in the full scan, excluding defaultBBP XMLs. |
| **Tests** | +14 doctest cases: offline skin-bone extraction (hand-built `ParsedNif`, incl. scalar-ref/non-node/out-of-range/empty-name/union edge cases) and the cross-consumer filter. `test_pch.h` gains a no-op `logger` shim so `hdtNifSchema.cpp` compiles headless. |
| **Docs** (wiki, separate repo) | `smp report` warning table + Phase 3.6 in the check listing and Dev ‐ Validator Analysis; Changelog **3.5.0** entry. |

## Testing

- `validator_tests`: **44/44 cases, 87/87 assertions** pass (Debug + Release).
- Full plugin **Release** build clean (`hdtsmp64.dll`).

## Notes for review

- **Versioning:** `v3.4.0` is already tagged/released, so per the "features force a minor bump" rule the changelog entry opens a new **3.5.0** section. Flagging in case you intended the in-flight fixes (#402–#407) to ship as a 3.4.1 patch first — the wiki changelog currently has no 3.4.x-post-release entries at all.
- Wiki edits live in `hdtSMP64.wiki` and are committed/pushed separately from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection of skin-bound bone names from NIF files, improving validation and analysis of skinned meshes.
  * Added analysis for redundant `<bone>` declarations in XML, including filtering by the bones actually used by linked NIFs.

* **Bug Fixes**
  * Better handles mixed bone types, missing references, empty names, and out-of-range entries without over-reporting bindings.
  * Redundant bone checks now avoid false positives in default-driven XML configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->