### PR TITLE
chore: remove leftover enableCuda config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,6 @@ If applicable, add screenshots or videos to help explain your problem.
 ** FSMP**
 
 - Installed version
-- CUDA: No_CUDA or CUDA?
 - AVX: No_AVX, AVX, AVX2, AVX512?
 
 **SKSE**

--- a/configs/configs.json
+++ b/configs/configs.json
@@ -15,8 +15,7 @@
     "sampleSize": 1,
     "disable1stPersonViewPhysics": true,
     "skipDeadActors": false,
-    "minScreenSizePercent": 0.0,
-    "enableCuda": true
+    "minScreenSizePercent": 0.0
   },
   "solver": {
     "numIterations": 16,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -145,8 +145,7 @@ namespace hdt
 	{
 		// Write to userConfigs.json (never configs.json), so an FSMP update replacing configs.json can't wipe
 		// the user's settings. We write a clean serialization of only the fields we model, so a setting that
-		// a later FSMP version removes leaves no stale key behind. (Variant-only keys like enableCuda live in
-		// the shipped configs.json, which we never rewrite, so they are unaffected.)
+		// a later FSMP version removes leaves no stale key behind.
 		const std::string merged = serializeConfigJson(readConfig());
 
 		// Atomic write: emit to a sibling temp file, then rename over the target so a crash mid-write can

--- a/src/config.h
+++ b/src/config.h
@@ -38,8 +38,9 @@ namespace hdt
 	// the struct's built-in fallback). Parsed once and cached --- configs.json never changes while running.
 	const GlobalConfig& shippedDefaults();
 
-	// Persist the live settings to configs.json. Raw-merges over the existing file so keys this build does
-	// not model (e.g. enableCuda) survive; writes atomically (temp file + rename).
+	// Persist the live settings to userConfigs.json (never configs.json, so an FSMP update replacing
+	// configs.json can't wipe them). Writes a clean serialization of only the fields we model, so a key a
+	// later FSMP version drops leaves no stale entry behind; writes atomically (temp file + rename).
 	void saveUserSettings();
 
 	// The canonical "apply settings" sequence shared by `smp reset` and the in-game menu: reload config,

--- a/tests/config/test_globalconfig.cpp
+++ b/tests/config/test_globalconfig.cpp
@@ -99,7 +99,7 @@ TEST_CASE("string arrays drop non-string elements")
 TEST_CASE("unknown keys are ignored without affecting known ones")
 {
 	const GlobalConfig c = parseConfigJson(R"({
-		"smp": { "logLevel": 4, "enableCuda": true, "someFutureField": 123 },
+		"smp": { "logLevel": 4, "someRemovedField": true, "someFutureField": 123 },
 		"totallyUnknownSection": { "x": 1 }
 	})");
 	CHECK(c.logLevel == 4);


### PR DESCRIPTION
## Summary

FSMP no longer provides a CUDA build, but an `enableCuda` key was still lingering in the shipped `configs.json` plus a handful of doc/test/template references. `GlobalConfig` never actually parsed `enableCuda` (unknown keys are ignored — there's a test for that), so this is a **pure cleanup with no behavior change**.

## Changes

- **`configs/configs.json`** — remove `"enableCuda": true`
- **`src/config.cpp`** — drop the `enableCuda` example from the `saveUserSettings` comment (it was the only unmodeled key, so nothing remains to preserve)
- **`src/config.h`** — remove the `enableCuda` reference and fix the stale `saveUserSettings` docstring: it claimed a "raw-merge into configs.json", but the code writes a clean serialization to `userConfigs.json`
- **`tests/config/test_globalconfig.cpp`** — replace `enableCuda` with a neutral unknown-key name in the "unknown keys are ignored" test (keeps the bool-typed-unknown coverage)
- **`.github/ISSUE_TEMPLATE/bug_report.md`** — drop the `CUDA: No_CUDA or CUDA?` build-variant question

## Migration / compatibility

No migration needed: a leftover `enableCuda` in an old user `configs.json` is harmlessly ignored by the parser (fail-safe by design), and it was never written to `userConfigs.json` since it was never a modeled field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)