### PR TITLE
fix: crash when hiding SMP hair on invisible actors (wrong MagicTarget offset)

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -42,7 +42,9 @@ namespace hdt
 		if (!actor)
 			return false;
 
-		auto* effects = actor->GetActiveEffectList();
+		// AsMagicTarget() locates the MagicTarget subobject at the game-version-dependent runtime offset;
+		// the compile-time upcast (actor->GetActiveEffectList()) points into the wrong bytes and crashes.
+		auto* effects = actor->AsMagicTarget()->GetActiveEffectList();
 		if (!effects)
 			return false;
 


### PR DESCRIPTION
## What was broken

The new **"Hide SMP hair when invisible"** feature crashed the game for four users within minutes of loading a save — including two crashes on the player character. All four crash logs share the same fingerprint (a call into a garbage address, with `RAX` pointing at an `ExtraEnableStateChildren*`).

## Explain-it-like-I'm-10

Every frame, the feature asks each actor *"do you have an invisibility spell on right now?"* so it can hide the physics hair to match.

An `Actor` is like a house with several front doors. One door leads to its "magic" room, where the list of active spells lives. To knock on the right door you need to walk a certain number of steps along the porch.

FSMP is built to run on three versions of Skyrim at once (SE, AE, and VR). Because of that, the *code's* idea of where the magic door is (**78 steps** down the porch) doesn't match where the door actually is on the real game (**160 steps**, i.e. 0xA0). So the feature knocked on the wrong door — it grabbed the actor's "extra stuff" drawer, mistook it for the magic room's instructions, and tried to follow whatever random bytes were inside. That jump into nonsense is the crash. It had nothing to do with *which* actor it was — any actor would do it, which is why even the player (who can never be "half-loaded") crashed.

## The fix

Ask the actor to point us to its magic room itself, using its `AsMagicTarget()` helper — which already knows the correct number of steps for whichever game version is running — before reading the spell list:

```cpp
// before  (walks to the wrong door → crash)
auto* effects = actor->GetActiveEffectList();

// after   (asks the actor for the right door first)
auto* effects = actor->AsMagicTarget()->GetActiveEffectList();
```

One file, +3/−1 lines. A sweep confirmed this was the only place in FSMP that opened one of an actor's "side doors" by guessing the step count, so nothing else is affected.

## Testing

- Rebuilt clean (`user-vs2022-windows-avx2`, Release).
- Deployed and reload-tested the exact save that was crashing: **no more crash.** The old bug fired within seconds of gameplay, so this is a decisive result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)