### PR TITLE
chore: merge dev into master for 4.0.1

### DIFF
--- a/src/ActorManager.cpp
+++ b/src/ActorManager.cpp
@@ -42,7 +42,9 @@ namespace hdt
 		if (!actor)
 			return false;
 
-		auto* effects = actor->GetActiveEffectList();
+		// AsMagicTarget() locates the MagicTarget subobject at the game-version-dependent runtime offset;
+		// the compile-time upcast (actor->GetActiveEffectList()) points into the wrong bytes and crashes.
+		auto* effects = actor->AsMagicTarget()->GetActiveEffectList();
 		if (!effects)
 			return false;
 


### PR DESCRIPTION
Release **4.0.1** — a single-fix patch over 4.0.0.

## Included change

**fix: crash when hiding SMP hair on invisible actors** (#421)

The 4.0.0 "Hide SMP hair when invisible" feature read each actor's active-effect list through a compile-time upcast to `MagicTarget`, whose subobject offset in this SE/AE/VR multi-runtime build does not match the live game's. On the real runtime that pointed at the actor's extra-data area instead of its magic target, so the call jumped to a garbage address and crashed — on any actor, including the player. Reported by four users within minutes of gameplay.

Fixed by locating the subobject via `actor->AsMagicTarget()` (which selects the right offset per game version) before reading the effect list. One file, +3/−1 lines. Field-confirmed crash-free on a save that reproduced it every time.

## Scope

`origin/master..origin/dev` was otherwise empty, so this release contains only the fix above.

## Release step

Per the established pattern, after merging bump the version on master with `chore: bump FSMP to version 4.0.1` (CMakeLists `VERSION 4.0.0` → `4.0.1`); `dev` keeps its placeholder version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)