### PR TITLE
feat: optional legacy MCM stub in the installer for mid-game updates from 3.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
       # Publish any branch under ci/ (e.g. ci/skse-menu-framework) to build all AVX variants and a
       # prerelease, without editing this file. The "/" lives only in the branch name; the versioning
       # step below sanitizes it to "-" in the version string.
+      # Creating a ci/ branch from commits that already exist on another branch does NOT start a
+      # run: that push has an empty changed-file list, so the paths filter below matches nothing.
+      # Push one commit touching a listed path to start the build.
       - "ci/**"
     paths:
       - "**.cpp"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,6 +266,20 @@ jobs:
           cp temp-validator/LICENSE validator_files/
           cp temp-validator/skse/plugins/hdtSkinnedMeshConfigs/hdtSMP64.xsd validator_files/
 
+      - name: Fetch the FSMP MCM stub
+        # The splash-only branch is the only FSMP-MCM branch this CI uses: it holds the
+        # save-preserving stub of the retired MCM, offered as an optional FOMOD install
+        # for players updating mid-playthrough from FSMP 3.x (see issue #423).
+        run: |
+          echo "Cloning FSMP-MCM (splash-only branch)..."
+          git clone --depth 1 --branch splash-only https://github.com/DaymareOn/FSMP-MCM.git temp-mcm
+          mkdir -p mcm_files/Scripts mcm_files/Source/Scripts mcm_files/interface/FSMP
+          cp "temp-mcm/FSMPM - The FSMP MCM.esp" mcm_files/
+          cp temp-mcm/LICENSE mcm_files/
+          cp temp-mcm/Scripts/*.pex mcm_files/Scripts/
+          cp temp-mcm/Source/Scripts/*.psc mcm_files/Source/Scripts/
+          cp temp-mcm/interface/FSMP/Logo.dds mcm_files/interface/FSMP/
+
       - name: Organize and 7zip
         run: |
           # 1. Create a clean structure for the final ZIP
@@ -281,6 +295,10 @@ jobs:
 
           # 4. Copy the Validator to the root level of the package
           cp -r validator_files/* final_package/FSMPV/
+
+          # 4b. Copy the legacy MCM stub; the FOMOD installs it only when the player asks for it
+          mkdir -p final_package/FSMPM
+          cp -r mcm_files/* final_package/FSMPM/
 
           # 5. Ship the default global config + in-game presets. They install unconditionally via the FOMOD
           #    requiredInstallFiles SKSE folder.

--- a/fomod tree/fomod/ModuleConfig.xml
+++ b/fomod tree/fomod/ModuleConfig.xml
@@ -119,28 +119,30 @@ A: Advanced_Vector_Extensions are extensions to the instruction sets for micropr
 			</optionalFileGroups>
 		</installStep>
 		<installStep name="Legacy MCM">
+			<!-- Shown only when the old MCM esp is already in the load order: fresh installs never
+			     see this step, while players updating from FSMP 3.x get the save-preserving stub. -->
+			<visible operator="Or">
+				<fileDependency file="FSMPM - The FSMP MCM.esp" state="Active" />
+				<fileDependency file="FSMPM - The FSMP MCM.esp" state="Inactive" />
+			</visible>
 			<optionalFileGroups order="Explicit">
-				<group name="Updating mid-playthrough from FSMP 3.x?" type="SelectExactlyOne">
+				<group name="Old FSMP MCM detected: keep its esp for your save-games?" type="SelectExactlyOne">
 					<plugins order="Explicit">
-						<plugin name="No legacy MCM (recommended)">
-							<description>Choose this for a new installation or a new playthrough.
+						<plugin name="Keep the legacy MCM (recommended)">
+							<description>"FSMPM - The FSMP MCM.esp" is in your load order, so you probably have save-games made with FSMP 3.x. FSMP 4 replaced the old SkyUI MCM with the new SKSE Menu Framework menu, and the esp was removed from the installer. Skyrim destroys a save-game when an esp it references is removed.
 
-The FSMP configuration menu is now provided through the SKSE Menu Framework; the old MCM esp is not installed.</description>
+This option installs a stub of the old MCM, so your saves keep their esp. The stub's menu only shows a splash page pointing you to the new menu.</description>
 							<conditionFlags>
-								<flag name="LEGACYMCM">Off</flag>
+								<flag name="LEGACYMCM">On</flag>
 							</conditionFlags>
 							<typeDescriptor>
 								<type name="Recommended" />
 							</typeDescriptor>
 						</plugin>
-						<plugin name="Keep the legacy MCM (updating mid-game from FSMP 3.x)">
-							<description>FSMP 4 replaced the old SkyUI MCM with the new SKSE Menu Framework menu, and "FSMPM - The FSMP MCM.esp" was removed from the installer. Skyrim destroys a save-game when an esp it references is removed.
-
-Choose this option if you are updating mid-playthrough from FSMP 3.x and want to continue your current save-game: it installs a stub of the old MCM, so your save keeps its esp. The stub's menu only shows a splash page pointing you to the new menu.
-
-Do not choose this for a fresh install or a new playthrough.</description>
+						<plugin name="No legacy MCM">
+							<description>Choose this only if you are starting a new playthrough: save-games made with FSMP 3.x will not survive without "FSMPM - The FSMP MCM.esp".</description>
 							<conditionFlags>
-								<flag name="LEGACYMCM">On</flag>
+								<flag name="LEGACYMCM">Off</flag>
 							</conditionFlags>
 							<typeDescriptor>
 								<type name="Optional" />

--- a/fomod tree/fomod/ModuleConfig.xml
+++ b/fomod tree/fomod/ModuleConfig.xml
@@ -118,6 +118,38 @@ A: Advanced_Vector_Extensions are extensions to the instruction sets for micropr
 				</group>
 			</optionalFileGroups>
 		</installStep>
+		<installStep name="Legacy MCM">
+			<optionalFileGroups order="Explicit">
+				<group name="Updating mid-playthrough from FSMP 3.x?" type="SelectExactlyOne">
+					<plugins order="Explicit">
+						<plugin name="No legacy MCM (recommended)">
+							<description>Choose this for a new installation or a new playthrough.
+
+The FSMP configuration menu is now provided through the SKSE Menu Framework; the old MCM esp is not installed.</description>
+							<conditionFlags>
+								<flag name="LEGACYMCM">Off</flag>
+							</conditionFlags>
+							<typeDescriptor>
+								<type name="Recommended" />
+							</typeDescriptor>
+						</plugin>
+						<plugin name="Keep the legacy MCM (updating mid-game from FSMP 3.x)">
+							<description>FSMP 4 replaced the old SkyUI MCM with the new SKSE Menu Framework menu, and "FSMPM - The FSMP MCM.esp" was removed from the installer. Skyrim destroys a save-game when an esp it references is removed.
+
+Choose this option if you are updating mid-playthrough from FSMP 3.x and want to continue your current save-game: it installs a stub of the old MCM, so your save keeps its esp. The stub's menu only shows a splash page pointing you to the new menu.
+
+Do not choose this for a fresh install or a new playthrough.</description>
+							<conditionFlags>
+								<flag name="LEGACYMCM">On</flag>
+							</conditionFlags>
+							<typeDescriptor>
+								<type name="Optional" />
+							</typeDescriptor>
+						</plugin>
+					</plugins>
+				</group>
+			</optionalFileGroups>
+		</installStep>
 		<installStep name="Thanks">
 			<optionalFileGroups order="Explicit">
 				<group name="" type="SelectAll">
@@ -176,6 +208,17 @@ Finally, credits and thanks to hydrogensaysHDT, aers, ousnius, Karonar1, alandts
 				</dependencies>
 				<files>
 					<folder source="raw-vs2022-windows-avx512\SKSE" destination="SKSE" priority="0" />
+				</files>
+			</pattern>
+			<pattern>
+				<dependencies>
+					<flagDependency flag="LEGACYMCM" value="On" />
+				</dependencies>
+				<files>
+					<folder source="FSMPM\Scripts" destination="Scripts" priority="1" />
+					<folder source="FSMPM\Source" destination="Source" priority="1" />
+					<folder source="FSMPM\interface" destination="interface" priority="1" />
+					<file source="FSMPM\FSMPM - The FSMP MCM.esp" destination="FSMPM - The FSMP MCM.esp" priority="1" />
 				</files>
 			</pattern>
 		</patterns>


### PR DESCRIPTION
Implements #423.

## What
People updating mid-game from FSMP 3.4.0 to 4.x lose "FSMPM - The FSMP MCM.esp", and Skyrim destroys a save-game when an esp it references is removed.

- The FOMOD gains a "Legacy MCM" step, visible **only** when the old esp is already in the player's load order (`fileDependency` check, active or inactive). Fresh installs never see it.
- When shown, "Keep the legacy MCM" is preselected: it installs a stub of the old MCM from the FSMP-MCM `splash-only` branch (DaymareOn/FSMP-MCM#18), whose menu is a single splash page with the FSMP logo and the title-bar pointer "Use the SKSE Menu Framework menu".
- The packaging CI job fetches FSMP-MCM pinned to `--branch splash-only` — from now on the only FSMP-MCM branch this CI uses.

## Verification
- ModuleConfig.xml validated against ModConfig5.0.xsd (downloaded from qconsulting.ca): passes.
- The CI fetch commands were dry-run against the pushed `splash-only` branch: the resulting `FSMPM/` tree matches the FOMOD source paths exactly.
- The stub itself was tested in game via a local mod folder (splash + title text render; the old nine MCM pages disappear on saves updating from the full MCM).

Note for the release: the wiki changelog entry is tracked in the #423 checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)