### PR TITLE
fix(#427): drain the physics task queue on FrameEvent to avoid a step-vs-setup race

### DIFF
--- a/src/hdtSkyrimPhysicsWorld.cpp
+++ b/src/hdtSkyrimPhysicsWorld.cpp
@@ -344,6 +344,14 @@ namespace hdt
 			startTime = ticks.QuadPart;
 		}
 
+		// Normally each frame's background step is already drained by the intervening FrameSync, so this
+		// is a no-op. But if two frame events ever fire before a frame-sync event (observed once in the
+		// wild, likely a mod-induced event-order anomaly), the previous step could still be running when
+		// we start writing bone transforms below in readTransform -- a data race that corrupts the step's
+		// memory. Wait for the queue to drain here, BEFORE taking m_lock, so the still-running step (which
+		// takes m_lock itself) can finish rather than deadlocking against us.
+		m_tasks.wait();
+
 		std::lock_guard<decltype(m_lock)> l(m_lock);
 
 		float interval = (m_useRealTime ? RE::BSTimer::GetSingleton()->realTimeDelta : RE::BSTimer::GetSingleton()->delta);


### PR DESCRIPTION
Fixes #427.

## The hazard

`ProcessEvent(FrameEvent)` already holds `m_lock` across the whole `doUpdate` call, so `readTransform` is **not** unlocked in the normal path (an earlier draft of this fix wrongly assumed it was).

The real hazard is an **event-order anomaly**: if two frame events fire before a frame-sync event — observed once in the wild, likely a mod-induced ordering quirk — the previous frame's background step (`doUpdate2ndStep`) may still be running when the next frame starts writing bone transforms in `readTransform`. The lock alone does **not** cover a step that is *queued but not yet started*, because the step holds no lock until it actually runs. So `readTransform` can write transforms while the step later reads them, corrupting the step's memory. It surfaced as a crash in the collision merge under the experimental world collision, whose long steps widen the window, but the anomaly is not specific to world collision.

## The fix

Drain the queue with `m_tasks.wait()` at the top of `ProcessEvent(FrameEvent)`, **before** taking `m_lock` so a still-running step (which needs `m_lock`) can finish rather than deadlocking against us. Normally the intervening `FrameSyncEvent` has already drained the queue, so this is a no-op with no measurable cost — it only does anything in the anomalous double-frame-event case.

One file, +8 lines. Built clean (`user-vs2022-windows-avx2`, RelWithDebInfo).

Credit: the drain-the-queue approach was suggested by the maintainer, replacing an earlier lock-based draft that would have deadlocked (re-locking the non-recursive `m_lock` already held by the FrameEvent handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved physics update stability by preventing a rare race condition during frame processing.
  * Reduced the risk of crashes or inconsistent bone/rigid body transforms when characters are being updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->