### PR TITLE
feat: first person body-local space simulation via the plugin interface

### DIFF
--- a/src/PluginAPI.h
+++ b/src/PluginAPI.h
@@ -64,7 +64,7 @@ namespace hdt
 		};
 
 	public:
-		constexpr static Version INTERFACE_VERSION{ 2, 0, 0 };
+		constexpr static Version INTERFACE_VERSION{ 2, 1, 0 };
 		constexpr static Version BULLET_VERSION{ 3, 24, 0 };
 
 	public:
@@ -77,5 +77,12 @@ namespace hdt
 
 		virtual void addListener(IPostStepListener*) = 0;
 		virtual void removeListener(IPostStepListener*) = 0;
+
+		//Since 2.1.
+		//Declares that the caller drives the player's visible body with the camera (a first
+		//person body mod). While active, the player simulates in body-local space: whole-body
+		//motion injects no velocity; gravity and animation-relative motion still apply.
+		//Main thread, any time after MSG_STARTUP.
+		virtual void setPlayerBodyCameraDriven(bool) = 0;
 	};
 }

--- a/src/PluginInterfaceImpl.cpp
+++ b/src/PluginInterfaceImpl.cpp
@@ -30,6 +30,11 @@ void hdt::PluginInterfaceImpl::removeListener(IPostStepListener* l)
 	}
 }
 
+void hdt::PluginInterfaceImpl::setPlayerBodyCameraDriven(bool active)
+{
+	m_playerBodyCameraDriven = active;
+}
+
 void hdt::PluginInterfaceImpl::onPostPostLoad()
 {
 	// Send ourselves to any plugin that registered during the PostLoad event

--- a/src/PluginInterfaceImpl.h
+++ b/src/PluginInterfaceImpl.h
@@ -21,6 +21,10 @@ namespace hdt
 		virtual void addListener(IPostStepListener* l) override;
 		virtual void removeListener(IPostStepListener* l) override;
 
+		virtual void setPlayerBodyCameraDriven(bool active) override;
+
+		bool isPlayerBodyCameraDriven() const { return m_playerBodyCameraDriven; }
+
 		void onPostPostLoad();
 
 		void onPreStep(const PreStepEvent& e) { m_preStepDispatcher.SendEvent(std::addressof(e)); }
@@ -32,6 +36,8 @@ namespace hdt
 		VersionInfo m_versionInfo{ INTERFACE_VERSION, BULLET_VERSION };
 		RE::BSTEventSource<PreStepEvent> m_preStepDispatcher;
 		RE::BSTEventSource<PostStepEvent> m_postStepDispatcher;
+
+		bool m_playerBodyCameraDriven = false;
 
 		SKSE::PluginHandle m_sksePluginHandle;
 		SKSE::MessagingInterface* m_skseMessagingInterface;

--- a/src/hdtSkyrimSystem.cpp
+++ b/src/hdtSkyrimSystem.cpp
@@ -4,6 +4,7 @@
 #include "HavokUtils.h"
 #include "Patterns/hdtPatternLibrary.h"
 #include "Patterns/hdtXmlPatternExpander.h"
+#include "PluginInterfaceImpl.h"
 #include "XmlReader.h"
 #include "hdtSkyrimPhysicsWorld.h"
 
@@ -103,56 +104,126 @@ namespace hdt
 			m_initialized = true;
 		}
 
+		timeStep = dampRootRotation(timeStep);
+
 		if (timeStep <= RESET_PHYSICS) {
 			if (!this->block_resetting) {
 				updateTransformUpDown(m_skeleton.get(), true);
 			}
 
 			m_lastRootRotation = convertNi(m_skeleton->world.rotate);
-		} else if (m_skeleton->parent == RE::PlayerCharacter::GetSingleton()->Get3D2()) {
-			if (SkyrimPhysicsWorld::get()->m_resetPc > 0) {
-				timeStep = RESET_PHYSICS;
-				updateTransformUpDown(m_skeleton.get(), true);
-				m_lastRootRotation = convertNi(m_skeleton->world.rotate);
-			} else if (!RE::PlayerCamera::GetSingleton()->GetRuntimeData2().isWeapSheathed || RE::PlayerCamera::GetSingleton()->currentState->id == RE::CameraState::kFirstPerson)  // isWeaponSheathed or potentially isCameraFree || cameraState is first person
-			{
-				m_lastRootRotation = convertNi(m_skeleton->world.rotate);
-			} else {
-				btQuaternion newRot = convertNi(m_skeleton->world.rotate);
-				btVector3 rotAxis;
-				float rotAngle;
-				btTransformUtil::calculateDiffAxisAngleQuaternion(m_lastRootRotation, newRot, rotAxis, rotAngle);
+		}
 
-				if (SkyrimPhysicsWorld::get()->m_clampRotations) {
-					float limit = SkyrimPhysicsWorld::get()->m_rotationSpeedLimit * timeStep;
+		m_oldRoot = hdt::make_nismart(newRoot);
+		return timeStep;
+	}
 
-					if (rotAngle < -limit || rotAngle > limit) {
-						rotAngle = btClamped(rotAngle, -limit, limit);
-						btQuaternion clampedRot(rotAxis, rotAngle);
-						m_lastRootRotation = clampedRot * m_lastRootRotation;
-						m_skeleton->world.rotate = convertBt(m_lastRootRotation);
+	float SkyrimSystem::dampRootRotation(float timeStep)
+	{
+		if (timeStep <= RESET_PHYSICS || m_skeleton->parent != RE::PlayerCharacter::GetSingleton()->Get3D2()) {
+			return timeStep;
+		}
 
-						const auto& children = m_skeleton->GetChildren();
-						for (uint16_t i = 0; i < children.size(); ++i) {
-							auto node = castNiNode(children[i].get());
-							if (node) {
-								updateTransformUpDown(node, true);
-							}
+		if (SkyrimPhysicsWorld::get()->m_resetPc > 0) {
+			timeStep = RESET_PHYSICS;
+		} else if (!RE::PlayerCamera::GetSingleton()->GetRuntimeData2().isWeapSheathed || RE::PlayerCamera::GetSingleton()->currentState->id == RE::CameraState::kFirstPerson)  // isWeaponSheathed or potentially isCameraFree || cameraState is first person
+		{
+			m_lastRootRotation = convertNi(m_skeleton->world.rotate);
+		} else {
+			btQuaternion newRot = convertNi(m_skeleton->world.rotate);
+			btVector3 rotAxis;
+			float rotAngle;
+			btTransformUtil::calculateDiffAxisAngleQuaternion(m_lastRootRotation, newRot, rotAxis, rotAngle);
+
+			if (SkyrimPhysicsWorld::get()->m_clampRotations) {
+				float limit = SkyrimPhysicsWorld::get()->m_rotationSpeedLimit * timeStep;
+
+				if (rotAngle < -limit || rotAngle > limit) {
+					rotAngle = btClamped(rotAngle, -limit, limit);
+					btQuaternion clampedRot(rotAxis, rotAngle);
+					m_lastRootRotation = clampedRot * m_lastRootRotation;
+					m_skeleton->world.rotate = convertBt(m_lastRootRotation);
+
+					const auto& children = m_skeleton->GetChildren();
+					for (uint16_t i = 0; i < children.size(); ++i) {
+						auto node = castNiNode(children[i].get());
+						if (node) {
+							updateTransformUpDown(node, true);
 						}
 					}
-				} else if (SkyrimPhysicsWorld::get()->m_unclampedResets) {
-					float limit = SkyrimPhysicsWorld::get()->m_unclampedResetAngle * timeStep;
+				}
+			} else if (SkyrimPhysicsWorld::get()->m_unclampedResets) {
+				float limit = SkyrimPhysicsWorld::get()->m_unclampedResetAngle * timeStep;
 
-					if (rotAngle < -limit || rotAngle > limit) {
-						timeStep = RESET_PHYSICS;
-						updateTransformUpDown(m_skeleton.get(), true);
-						m_lastRootRotation = convertNi(m_skeleton->world.rotate);
-					}
+				if (rotAngle < -limit || rotAngle > limit) {
+					timeStep = RESET_PHYSICS;
 				}
 			}
 		}
 
-		m_oldRoot = hdt::make_nismart(newRoot);
+		return timeStep;
+	}
+
+	PlayerSkyrimSystem::PlayerSkyrimSystem(RE::NiNode* skeleton) :
+		SkyrimSystem(skeleton)
+	{
+	}
+
+	float PlayerSkyrimSystem::dampRootRotation(float timeStep)
+	{
+		if (!g_pluginInterface.isPlayerBodyCameraDriven()) {
+			if (m_localSpaceActive) {
+				// Don't turn the snap back to the native pose into velocity.
+				m_localSpaceActive = false;
+				m_localSpaceRef = nullptr;
+				return RESET_PHYSICS;
+			}
+			return SkyrimSystem::dampRootRotation(timeStep);
+		}
+
+		if (!m_localSpaceActive || timeStep <= RESET_PHYSICS) {
+			// Snap on engage/reset instead of cancelling a partial delta.
+			m_localSpaceActive = true;
+			m_localSpaceRef = nullptr;  // re-resolve in case the skeleton was rebuilt
+			timeStep = RESET_PHYSICS;
+		}
+
+		if (!m_localSpaceRef) {
+			auto ref = findNode(m_skeleton.get(), "NPC Root [Root]");
+			m_localSpaceRef = hdt::make_nismart(ref ? ref : m_skeleton.get());
+		}
+
+		const btQuaternion rotation = convertNi(m_localSpaceRef->world.rotate);
+		const btVector3 position = convertNi(m_localSpaceRef->world.translate);
+
+		if (timeStep > RESET_PHYSICS) {
+			// Move every rigid body along with the reference bone's frame delta: only
+			// animation-relative bone motion reaches the solver.
+			const btQuaternion deltaRotation = rotation * m_localSpaceRotation.inverse();
+			const btVector3 deltaPosition = position - m_localSpacePosition;
+
+			if (deltaRotation.getAngleShortestPath() > 1e-6f || deltaPosition.length2() > 1e-8f) {
+				const btMatrix3x3 basis(deltaRotation);
+				btTransform delta;
+				delta.setBasis(basis);
+				// Rotate about the reference bone, not the world origin.
+				delta.setOrigin(m_localSpacePosition - basis * m_localSpacePosition + deltaPosition);
+
+				for (auto& bone : m_bones) {
+					auto& rig = bone->m_rig;
+					rig.setWorldTransform(delta * rig.getWorldTransform());
+					rig.setInterpolationWorldTransform(delta * rig.getInterpolationWorldTransform());
+					rig.setLinearVelocity(basis * rig.getLinearVelocity());
+					rig.setAngularVelocity(basis * rig.getAngularVelocity());
+					rig.setInterpolationLinearVelocity(basis * rig.getInterpolationLinearVelocity());
+					rig.setInterpolationAngularVelocity(basis * rig.getInterpolationAngularVelocity());
+					rig.updateInertiaTensor();
+				}
+			}
+		}
+
+		m_localSpaceRotation = rotation;
+		m_localSpacePosition = position;
 		return timeStep;
 	}
 
@@ -253,7 +324,13 @@ namespace hdt
 
 		auto meshNameMap = file->second;
 
-		m_mesh = RE::make_smart<SkyrimSystem>(skeleton);
+		constexpr uint32_t playerFormID = 0x14;
+		const bool isPlayer = skeleton->GetUserData() && skeleton->GetUserData()->formID == playerFormID;
+		if (isPlayer) {
+			m_mesh = RE::make_smart<PlayerSkyrimSystem>(skeleton);
+		} else {
+			m_mesh = RE::make_smart<SkyrimSystem>(skeleton);
+		}
 		m_boneIndex.clear();
 
 		// This forces the skeleton into a neutral reference pose, which avoids building invalid shape data

--- a/src/hdtSkyrimSystem.h
+++ b/src/hdtSkyrimSystem.h
@@ -41,6 +41,28 @@ namespace hdt
 
 		// angular velocity damper
 		btQuaternion m_lastRootRotation;
+
+	protected:
+		// PC root rotation damper (m_resetPc / clampRotations / unclampedResets).
+		virtual float dampRootRotation(float timeStep);
+	};
+
+	// Player skeleton: while a mod declares the body camera-driven
+	// (PluginInterface::setPlayerBodyCameraDriven), the damper is replaced by body-local space
+	// simulation - whole-body motion is cancelled out of the rigid bodies and injects no velocity.
+	class PlayerSkyrimSystem final : public SkyrimSystem
+	{
+	public:
+		PlayerSkyrimSystem(RE::NiNode* skeleton);
+
+	protected:
+		float dampRootRotation(float timeStep) override;
+
+	private:
+		RE::NiPointer<RE::NiNode> m_localSpaceRef;
+		btQuaternion m_localSpaceRotation;
+		btVector3 m_localSpacePosition;
+		bool m_localSpaceActive = false;
 	};
 
 	class XMLReader;


### PR DESCRIPTION
## Problem

Mods that show the player's body in first person (Improved Camera, similar setups) glue the whole skeleton to the camera every frame. `SkyrimBone::readTransform` converts each kinematic bone's per-frame world delta into velocity, and the first-person branch of the root damper deliberately skips the rotation clamp — so mouse turns and per-frame body-anchor corrections inject large kinematic velocities into hair/cloth/body physics. The visible result is FP physics whipping around with the camera.

## Solution

Body-local space simulation for the PC (the approach engines use for character cloth), **declared by the driving mod through the plugin interface** — no config keys, no detection heuristics:

- `PluginInterface` 2.0 → 2.1 (additive vtable slot, per the semver contract in PluginAPI.h): `setPlayerBodyCameraDriven(bool)`. The driving mod calls it on its anchor-regime transitions after receiving `MSG_STARTUP`. Improved Camera will ship this call; I maintain that side and it's implemented against this branch.
- While declared, the player's systems pre-transform every rigid body by the reference bone's (`NPC Root [Root]`) frame delta — world + interpolation transforms, velocities rotated, pivoted at the reference bone — so whole-body motion contributes zero velocity to the solve. Gravity stays in world space; animation-relative bone motion still excites physics normally.
- Engaging, disengaging, or any reset flowing through snaps cleanly via `RESET_PHYSICS` (also removes the previously-unhandled impulse when the body first re-anchors).

## Implementation shape

Per review feedback: no chunks patched into `prepareForRead`. The PC root rotation damper (`m_resetPc` / `clampRotations` / `unclampedResets` block) is extracted verbatim into a protected virtual `dampRootRotation`, and a new `PlayerSkyrimSystem` subclass — instantiated by `SkyrimSystemCreator` for the player skeleton — overrides it with the local-space step while the mod's declaration is active (the damper is redundant then: root motion no longer reaches the solver). Undeclared, behavior is byte-for-byte the old damper, and NPC systems are untouched.

One deliberate behavioral nuance from the extraction: the damper's internal reset branches now return `RESET_PHYSICS` and let `prepareForRead`'s existing reset path do the tree refresh, which means they now respect `block_resetting` like every other reset does.

Inert for everyone until a mod declares itself: no shipped-config changes, no new keys, nothing user-facing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved player root rotation damping for smoother motion and more reliable reset behavior.
  - Added local-space simulation for player skeletons when enabled.
  - Introduced a new plugin API toggle for first-person camera-driven body behavior.
  - Updated the plugin interface version to support the new setting.
- **Bug Fixes**
  - Fixed inconsistent root rotation clamping/reset logic tied to player view/body conditions.
  - Corrected local-space activation/snap behavior and reference tracking to reduce drift during transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->