### PR TITLE
fix: use recursive glob '**/*.xml' in .prettierrc.yaml override (closes #198)

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,6 +1,6 @@
 tabWidth: 2
 printWidth: 120
 overrides:
-  - files: "*.xml"
+  - files: "**/*.xml"
     options:
       xmlWhitespaceSensitivity: "ignore"


### PR DESCRIPTION
## What

Changes the `.prettierrc.yaml` XML override's `files` pattern from `"*.xml"` to `"**/*.xml"`, as requested in PR #193's review discussion and tracked by #198.

## Verification (no C++/game build needed — pure config file)

I could not build/run this repo's SKSE plugin locally (needs MSVC + CommonLibSSE + the Skyrim SDK on Windows — unavailable here), but this change touches only `.prettierrc.yaml`, so I verified it directly against the actual formatting tool instead, using the exact `prettier@3.1.0` + `@prettier/plugin-xml@3.4.1` versions pinned in `.pre-commit-config.yaml`:

- `prettier.resolveConfig()` and an actual `prettier.format()` pass, run against both a root-level XML file and a nested one (mirroring `configs/configs.xml`), before and after this change.
- **Finding:** with this prettier version, the old `"*.xml"` pattern already resolves `xmlWhitespaceSensitivity: "ignore"` for nested files too — prettier applies gitignore-style basename matching to slash-less `files` patterns, so nested XML files were *not* actually excluded as #198 assumed. Output was byte-identical before/after for both files in my test.

So this isn't fixing a live formatting bug — it's a no-op today. It's still worth landing because:
1. It's exactly what was requested in the PR #193 review thread and in #198's suggested fix.
2. It makes the intent explicit rather than relying on an implicit micromatch/prettier basename-matching fallback, which is a more fragile thing to depend on across future prettier/plugin-xml version bumps.
3. It's a one-line, zero-risk change with no possible behavioral regression (confirmed identical output above).

closes #198


---
_Generated by [Claude Code](https://claude.ai/code/session_016VbsPseWcWq65r7n4C7DoK)_