### PR TITLE
fix: GlobalConfig.cpp's min-fps/windStrength clamps match the FSMPMenu.cpp slider bounds

### DIFF
--- a/src/GlobalConfig.cpp
+++ b/src/GlobalConfig.cpp
@@ -120,12 +120,18 @@ namespace hdt
 		// --- solver ---
 		c.numIterations = clampv(read(solver, "numIterations", c.numIterations), 4, 128);
 		c.erp = clampv(read(solver, "erp", c.erp), 0.01f, 1.0f);
-		c.minFps = clampv(read(solver, "min-fps", c.minFps), 1, 300);
+		// Floor matches the menu slider (FSMPMenu.cpp) and its own tooltip: "Never set below 60 or
+		// the physics engine misbehaves." A hand-edited/externally generated userConfigs.json used to
+		// be able to persist a value as low as 1, which the menu can neither represent nor correct (#439).
+		c.minFps = clampv(read(solver, "min-fps", c.minFps), 60, 300);
 		c.maxSubSteps = clampv(read(solver, "maxSubSteps", c.maxSubSteps), 1, 60);
 
 		// --- wind ---
 		c.windEnabled = read(wind, "enabled", c.windEnabled);
-		c.windStrength = clampv(read(wind, "windStrength", c.windStrength), 0.0f, 1000.0f);
+		// Ceiling matches the menu slider's max (FSMPMenu.cpp), which cannot represent or correct a
+		// value above 100 — a hand-edited/externally generated userConfigs.json used to be able to
+		// persist up to 1000, silently reading as pinned at the slider end (#439).
+		c.windStrength = clampv(read(wind, "windStrength", c.windStrength), 0.0f, 100.0f);
 		c.distanceForNoWind = clampv(read(wind, "distanceForNoWind", c.distanceForNoWind), 0.0f, 10000.0f);
 		c.distanceForMaxWind = clampv(read(wind, "distanceForMaxWind", c.distanceForMaxWind), 0.0f, 10000.0f);
 

--- a/tests/config/test_globalconfig.cpp
+++ b/tests/config/test_globalconfig.cpp
@@ -69,9 +69,9 @@ TEST_CASE("out-of-range numbers are clamped, not rejected")
 	CHECK(c.minScreenSizePercent == doctest::Approx(0.0f));                    // [0,100]
 	CHECK(c.numIterations == 4);                                               // [4,128]
 	CHECK(c.erp == doctest::Approx(1.0f));                                     // [0.01,1.0]
-	CHECK(c.minFps == 300);                                                    // [1,300]
+	CHECK(c.minFps == 300);                                                    // [60,300]
 	CHECK(c.maxSubSteps == 1);                                                 // [1,60]
-	CHECK(c.windStrength == doctest::Approx(0.0f));                            // [0,1000]
+	CHECK(c.windStrength == doctest::Approx(0.0f));                            // [0,100]
 	CHECK(c.distanceForMaxWind == doctest::Approx(10000.0f));                  // [0,10000]
 	CHECK(c.rotationSpeedLimit == doctest::Approx(100.0f));                    // [0,100]
 	CHECK(c.unclampedResetAngle == doctest::Approx(0.0f));                     // [0,360]
@@ -79,6 +79,21 @@ TEST_CASE("out-of-range numbers are clamped, not rejected")
 	CHECK(c.maximumActiveSkeletons == 200);                                    // [0,200]
 	CHECK(c.outputFontScale == doctest::Approx(GlobalConfig::maxFontScale));   // [0.6,2.0]
 	CHECK(c.overlayFontScale == doctest::Approx(GlobalConfig::minFontScale));  // [0.6,2.0]
+}
+
+TEST_CASE("min-fps and windStrength clamps match the FSMPMenu.cpp slider bounds, not the old wider parser range (#439)")
+{
+	// A hand-edited/externally generated userConfigs.json used to be able to persist min-fps as low
+	// as 1 (the code's own tooltip says "Never set below 60 or the physics engine misbehaves") and
+	// windStrength as high as 1000 (the menu slider tops out at 100 and cannot represent or correct
+	// it). The parser's clamp must agree with the only UI for the same fields.
+	const GlobalConfig c = parseConfigJson(R"({
+		"solver": { "min-fps": 5 },
+		"wind": { "windStrength": 500.0 }
+	})");
+
+	CHECK(c.minFps == 60);                          // floor now matches the menu (was 1)
+	CHECK(c.windStrength == doctest::Approx(100.0f));  // ceiling now matches the menu (was 1000)
 }
 
 TEST_CASE("wrong-typed fields fall back to defaults")

--- a/tests/config/test_globalconfig.cpp
+++ b/tests/config/test_globalconfig.cpp
@@ -92,7 +92,7 @@ TEST_CASE("min-fps and windStrength clamps match the FSMPMenu.cpp slider bounds,
 		"wind": { "windStrength": 500.0 }
 	})");
 
-	CHECK(c.minFps == 60);                          // floor now matches the menu (was 1)
+	CHECK(c.minFps == 60);                             // floor now matches the menu (was 1)
 	CHECK(c.windStrength == doctest::Approx(100.0f));  // ceiling now matches the menu (was 1000)
 }
 


### PR DESCRIPTION
## Root cause

`GlobalConfig.cpp`'s JSON parser clamp and `FSMPMenu.cpp`'s ImGui slider are parallel range definitions for the same two fields, and they disagreed on both:

- **min-fps**: parser accepted down to 1; the menu floors at 60 and its own tooltip says "Never set below 60 or the physics engine misbehaves."
- **windStrength**: parser accepted up to 1000; the menu caps at 100 and cannot represent or correct anything above that.

A hand-edited or externally generated `userConfigs.json` could persist a min-fps the code itself documents as breaking physics, or a windStrength the only UI for the setting reads as pinned at the slider end.

## Fix

Tighten `GlobalConfig.cpp`'s clamp to `[60,300]` for min-fps and `[0,100]` for windStrength, matching the menu. `FSMPMenu.cpp` itself is untouched — it's already correct, and it's ImGui/CommonLibSSE code I have no way to compile or verify in this Linux cloud environment (see verification note below).

## Tests

Added a case to `tests/config/test_globalconfig.cpp` asserting min-fps=5 clamps to 60 and windStrength=500 clamps to 100 (previously both would have passed through un-clamped to their old, wider bounds). Updated the existing "out-of-range numbers are clamped" test's inline range comments to match.

**Mutation-verified**: reverted min-fps's clamp to `(1, 300)`, reran — the new test failed exactly as expected (`CHECK( c.minFps == 60 ) — values: CHECK( 5 == 60 )`). Restored from a file copy (never `git checkout`) and confirmed green again.

## Verification note (this repo's full build cannot run here)

This repo's full SKSE plugin needs MSVC + CommonLibSSE + vcpkg + the Skyrim SDK on Windows, unavailable in this cloud environment, and has no CI path that would verify it either. `GlobalConfig.cpp` is the one file in the repo that's deliberately dependency-free for exactly this reason (see its own top-of-file comment and `tests/config/CMakeLists.txt`'s `BUILD_CONFIG_TESTS` target: *"GlobalConfig is pure rapidjson + STL... no CommonLibSSE, Bullet, or TBB"*). Its CMake target still transitively requires the full vcpkg-configured build via the top-level `CMakeLists.txt` (`CompiledPluginsPath`/vcpkg toolchain checks fail immediately outside that setup), so I compiled the actual target sources directly with g++, bypassing only the CMake generation step, not the C++ code itself:

```
apt-get install -y rapidjson-dev doctest-dev   # both available via apt
g++ -std=c++20 -Isrc -o config_tests \
  tests/config/main.cpp tests/config/test_globalconfig.cpp src/GlobalConfig.cpp
./config_tests
# [doctest] test cases: 11 | 11 passed | 0 failed | 0 skipped
# [doctest] assertions: 41 | 41 passed | 0 failed
```

This exercises the exact same three source files CMake's `config_tests` target does (see `tests/config/CMakeLists.txt`), so it's a real compile + real test run of the changed code, not a skip. `FSMPMenu.cpp` was deliberately left unmodified because it has no equivalent standalone-buildable path here.

closes #439

---
_Generated by [Claude Code](https://claude.ai/code/session_01LREr7umdSMDTezbLV39oc1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration values for minimum FPS are now limited to 60–300.
  * Wind strength is now limited to 0–100, matching the available settings controls.
  * Out-of-range values in imported configuration files are automatically adjusted to valid limits.

* **Tests**
  * Added coverage confirming configuration limits match the in-app controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->