### PR TITLE
fix(#456): add missing smp.skipDeadActors/minScreenSizePercent to all 5 presets

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -54,4 +54,28 @@ jobs:
             fi
           done
 
+          # 3. Every configs.json `smp` key must exist in every configsPresets/*.json file (issue #456).
+          #    scanPresets()/parseConfigJson() (src/UI/FSMPMenu.cpp, src/GlobalConfig.cpp) parse a preset into
+          #    a GlobalConfig struct pre-filled with its own field defaults, so a key a preset omits is not
+          #    "leave unchanged" --- applying that preset silently resets the field to the struct default,
+          #    and the menu's "(loaded)" highlight can then never match a user who changed it. commit
+          #    803595f fixed one such straggler (hideSMPHairWhenInvisible); this check stops the next one from
+          #    going unnoticed the same way.
+          #    `backupNodeByName` is a deliberate, documented exception (GlobalConfig.h: "has no menu
+          #    control; it is preserved purely so a round-trip never drops it") --- presets never own it,
+          #    physicsOnly()/PresetsBody() (src/UI/FSMPMenu.cpp) explicitly clear/preserve it on both sides of
+          #    the comparison and the apply, exactly like `validation.mods-dir` and the top-level UI fields
+          #    (locale, font scales), which live outside the `smp` block entirely and so aren't in this key
+          #    set at all.
+          smp_exceptions='["backupNodeByName"]'
+          config_smp_keys=$(jq -c --argjson ex "$smp_exceptions" '(.smp | keys) - $ex' configs/configs.json)
+          for f in configs/configsPresets/*.json; do
+            missing=$(jq -n --argjson want "$config_smp_keys" --slurpfile p "$f" '$want - ($p[0].smp | keys) | .[]' -r)
+            if [ -n "$missing" ]; then
+              echo "::error file=$f::missing smp key(s) present in configs/configs.json (applying this preset silently resets them to the struct default):"
+              echo "$missing"
+              fail=1
+            fi
+          done
+
           exit $fail

--- a/configs/configsPresets/Debug.json
+++ b/configs/configsPresets/Debug.json
@@ -13,7 +13,9 @@
     "maximumActiveSkeletons": 20,
     "budgetMs": 5.0,
     "sampleSize": 1,
-    "disable1stPersonViewPhysics": false
+    "disable1stPersonViewPhysics": false,
+    "skipDeadActors": false,
+    "minScreenSizePercent": 0.0
   },
   "solver": {
     "numIterations": 20,

--- a/configs/configsPresets/Default.json
+++ b/configs/configsPresets/Default.json
@@ -13,7 +13,9 @@
     "maximumActiveSkeletons": 5,
     "budgetMs": 3.0,
     "sampleSize": 1,
-    "disable1stPersonViewPhysics": true
+    "disable1stPersonViewPhysics": true,
+    "skipDeadActors": false,
+    "minScreenSizePercent": 0.0
   },
   "solver": {
     "numIterations": 16,

--- a/configs/configsPresets/Performance.json
+++ b/configs/configsPresets/Performance.json
@@ -13,7 +13,9 @@
     "maximumActiveSkeletons": 5,
     "budgetMs": 2.8,
     "sampleSize": 1,
-    "disable1stPersonViewPhysics": true
+    "disable1stPersonViewPhysics": true,
+    "skipDeadActors": false,
+    "minScreenSizePercent": 0.0
   },
   "solver": {
     "numIterations": 8,

--- a/configs/configsPresets/Quality.json
+++ b/configs/configsPresets/Quality.json
@@ -13,7 +13,9 @@
     "maximumActiveSkeletons": 60,
     "budgetMs": 5.0,
     "sampleSize": 1,
-    "disable1stPersonViewPhysics": false
+    "disable1stPersonViewPhysics": false,
+    "skipDeadActors": false,
+    "minScreenSizePercent": 0.0
   },
   "solver": {
     "numIterations": 32,

--- a/configs/configsPresets/Reasonable.json
+++ b/configs/configsPresets/Reasonable.json
@@ -13,7 +13,9 @@
     "maximumActiveSkeletons": 10,
     "budgetMs": 4.0,
     "sampleSize": 1,
-    "disable1stPersonViewPhysics": false
+    "disable1stPersonViewPhysics": false,
+    "skipDeadActors": false,
+    "minScreenSizePercent": 0.0
   },
   "solver": {
     "numIterations": 16,


### PR DESCRIPTION
## Root cause

`configs/configs.json` ships two `smp` keys, `skipDeadActors` and `minScreenSizePercent`, that none of the five `configs/configsPresets/*.json` files carried. Presets parse into a `GlobalConfig` struct pre-filled with its own field defaults (`scanPresets()`/`hdt::parseConfigJson()` in `src/UI/FSMPMenu.cpp` / `src/GlobalConfig.cpp`), so an absent key is not "leave unchanged" — applying any preset silently reset both fields to the struct default with no trace in the preset file, and the menu's "(loaded)" highlight comparison (`PresetsBody()`) had no way to account for them.

## Re-verification of the full class

Re-ran the grep the issue describes — the full `smp` key set of `configs.json` against every preset (`jq -r '.smp | keys[]'`):

```
configs.json smp keys:      autoAdjustMaxSkeletons, backupNodeByName, budgetMs, clampRotations,
                             disable1stPersonViewPhysics, disableSMPHairWhenWigEquipped,
                             hideSMPHairWhenInvisible, logLevel, maximumActiveSkeletons,
                             minCullingDistance, minScreenSizePercent, rotationSpeedLimit,
                             sampleSize, skipDeadActors, unclampedResetAngle, unclampedResets, useRealTime
each preset's smp keys:     same set minus {backupNodeByName, skipDeadActors, minScreenSizePercent}
```

So the two keys named in the issue are the **complete** class — no further occurrence of the same shape. `solver`/`wind` sections already match key-for-key across all 6 files, so this is scoped to `smp` only.

`backupNodeByName` is a **deliberate, documented exception**, not a third class member: `GlobalConfig.h` states "has no menu control; it is preserved purely so a round-trip never drops it", and `physicsOnly()`/`PresetsBody()` in `FSMPMenu.cpp` explicitly clear/preserve it on both sides of the comparison and the apply — exactly like `validation.mods-dir` and the top-level UI fields (`locale`, font scales), which live outside the `smp` block entirely (and outside this key set) for the same reason: they're user/machine identity, not a preset-owned physics tunable.

## Fix

1. Added both keys to all 5 presets, matching the struct/shipped-config default value (`false` / `0.0`) **uniformly across all five files** — mirroring commit `803595f`'s precedent for `hideSMPHairWhenInvisible` (same shape: add the key with the existing effective default, don't invent new per-preset tuning).

   This is deliberately a **config-completeness fix, not a change to preset-apply semantics**: I considered assigning differentiated "deliberate per-preset values" (e.g. `skipDeadActors: true` for the Performance preset) per the issue's alternate suggestion, but chose the conservative, precedent-matching option instead — picking an actual performance-tuned value is a game-design judgment call this environment can't build/playtest to validate, and it isn't necessary to close the reported bug: `skipDeadActors`/`minScreenSizePercent` now behave exactly like every other physics-tunable field in a preset (uniformly present, version-tracked, applied wholesale by every preset click) instead of being an invisible, undocumented omission. No preset's effective behavior changes as a result of this PR (every preset's live value for these two fields was already the struct default before this change too) — what changes is that the omission can no longer silently reappear or drift for a *future* new field, per the enforcement below.

2. **Enforcement** — `.github/workflows/validate-config.yml` (the existing build-free, `configs/**`-triggered JSON-lint job) gains a step 3: it computes `configs.json`'s `smp` key set minus the documented `backupNodeByName` exception, and fails the job if any `configsPresets/*.json` file is missing one of those keys. A one-line comment above the check names the mechanism (struct-default pre-fill on parse) and the documented exception, so a future preset addition/edit can't silently repeat this drift.

## Verification (this environment has no MSVC/CommonLibSSE/vcpkg toolchain — this is a pure JSON+CI-script change, fully verifiable here)

- `jq empty` on all 6 touched JSON files — valid JSON.
- Ran the **exact** step-3 shell logic locally against the fixed tree: `fail=0`, reports no missing keys.
- Reproduced the **original bug** by running the same logic against the pre-fix `Default.json` (via `git show chore/auto-integration:...`): correctly reports `minScreenSizePercent` and `skipDeadActors` as missing — proving the new check is mutation-sense (it would have caught this exact issue, and reverting the fix makes it fail again).
- `python3 -c "import yaml; yaml.safe_load(...)"` — the edited workflow YAML parses cleanly.

## Doc-sync

No README/docs mention these keys or the preset key list, so nothing else needed updating. There is no repo-level `CLAUDE.md` in this repo to add a routing note to; the routing note instead lives inline as a comment in `validate-config.yml` at the new check itself, matching this repo's existing convention of explaining a check in the workflow file rather than a separate doc.

## Adversarial self-review

(No Task/subagent tool was available in this environment to spawn a truly blank-context reviewer — this section is my own second-pass adversarial read of the diff, noted under NOTABLE FRICTION in the run report.)

- Checked whether the new CI step could pass vacuously on a malformed preset: if a preset's JSON is invalid, step 1 already flags it (`fail=1`) independently of step 3, so the job still fails overall even though step 3's `jq` call against that specific file might otherwise no-op silently. Same risk shape as the pre-existing step 2 (localization keys) — not a regression.
- Confirmed `solver`/`wind` key parity is untouched/already correct, so the fix's scope (the `smp` block only) matches the issue exactly.
- Confirmed the "(loaded)" indicator concern: for the overwhelming majority of users (who never touched these two fields), it already worked correctly before and after; the residual case (a user who set `skipDeadActors=true` and clicks a preset) is inherent to *every* non-preserved preset field today (e.g. `budgetMs`, `maximumActiveSkeletons` already behave this way) — not something this PR needs to change, and not something a JSON-only patch could change without touching the C++ apply logic.

Closes #456


---
_Generated by [Claude Code](https://claude.ai/code/session_01ETZVSt8qrAu8qEqDUmrrP7)_