### PR TITLE
fix(#463): copy FSMP.dds in the CI package step; add payload-parity CI check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,6 +307,9 @@ jobs:
           #    requiredInstallFiles SKSE folder.
           mkdir -p "final_package/SKSE/Plugins/hdtSkinnedMeshConfigs"
           cp configs/configs.json "final_package/SKSE/Plugins/hdtSkinnedMeshConfigs/"
+          # The FSMP logo shown in the in-game menu's status header (SKSEMenuFramework::LoadTexture); mirrors
+          # src/CMakeLists.txt's own install() of the same file (issue #463).
+          cp configs/FSMP.dds "final_package/SKSE/Plugins/hdtSkinnedMeshConfigs/"
           cp -r configs/configsPresets "final_package/SKSE/Plugins/hdtSkinnedMeshConfigs/"
           cp -r configs/localization "final_package/SKSE/Plugins/hdtSkinnedMeshConfigs/"
           # The config menu's monospace font goes into the SKSE Menu Framework's font folder (Data/SKSE/Plugins/Fonts),

--- a/.github/workflows/validate-package-payload.yml
+++ b/.github/workflows/validate-package-payload.yml
@@ -1,0 +1,66 @@
+name: Validate shipped-config payload parity
+
+# Cheap, build-free check that every file src/CMakeLists.txt's shipped-config install() block declares is
+# also copied by the CI package step (.github/workflows/build.yml) --- the only path that produces the
+# released zip (it contains no `cmake --install`/`cpack` invocation of its own). The two lists drifted once
+# already (issue #463: FSMP.dds was installed by CMake but never copied into the release, so the in-game
+# menu's Home logo silently never loaded on a fresh FOMOD install) with nothing catching it. This job stops
+# the next file added to one list from silently missing the other.
+on:
+  push:
+    paths:
+      - "src/CMakeLists.txt"
+      - ".github/workflows/build.yml"
+  pull_request:
+    paths:
+      - "src/CMakeLists.txt"
+      - ".github/workflows/build.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-package-payload-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Diff CMake install() shipped-config payload against the CI package step
+        shell: bash
+        run: |
+          set -uo pipefail
+          fail=0
+          cmake_file="src/CMakeLists.txt"
+          build_file=".github/workflows/build.yml"
+
+          # The shipped-config block is delimited by its own leading comment and the COPY_OUTPUT guard that
+          # follows it (see src/CMakeLists.txt) --- everything in between is `install(FILES ...)` /
+          # `install(DIRECTORY ...)` for a file/directory the released FOMOD ships unconditionally.
+          start=$(grep -n '^# Ship the default global config' "$cmake_file" | head -1 | cut -d: -f1)
+          end=$(grep -n '^if("\${COPY_OUTPUT}")' "$cmake_file" | head -1 | cut -d: -f1)
+          if [ -z "$start" ] || [ -z "$end" ]; then
+            echo "::error file=$cmake_file::could not locate the shipped-config install() block markers --- has the comment/guard been reworded? Update this check's markers to match."
+            exit 1
+          fi
+
+          names=$(sed -n "${start},${end}p" "$cmake_file" | grep -oP '\$\{ROOT_DIR\}/[^"]+' | sed 's#.*/##' | sort -u)
+          if [ -z "$names" ]; then
+            echo "::error file=$cmake_file::found the shipped-config block but extracted zero payload names --- the install() shape may have changed; update this check."
+            exit 1
+          fi
+
+          for n in $names; do
+            if ! grep -qF -- "$n" "$build_file"; then
+              echo "::error file=$build_file::package step never copies '$n', which src/CMakeLists.txt's shipped-config install() block declares --- a released FOMOD install silently omits it (issue #463 was FSMP.dds)"
+              fail=1
+            fi
+          done
+
+          exit $fail


### PR DESCRIPTION
## Root cause

`src/CMakeLists.txt`'s shipped-config `install()` block declares 5 payload items and its own comment says they're deployed "by `cmake --install` / CPack **and by the CI package step** (`.github/workflows/build.yml`)". `build.yml`'s package step is the *only* path that actually produces the released zip (it never invokes `cmake --install`/`cpack`) — and it copied 4 of the 5, silently dropping `FSMP.dds`. `FSMPMenu.cpp`'s `LoadTexture()` call degrades silently on a missing file (`if (logo)` guard), so a fresh FOMOD install showed no Home-page logo and no error.

## Re-verification of the full class

Extracted every `${ROOT_DIR}`-relative payload basename from the `install()` block (between its own leading comment and the `COPY_OUTPUT` guard that follows it):

```
configs.json, FSMP.dds, configsPresets, localization, FSMPMono.ttf, FSMPMono.LICENSE.txt
```

Grepped `build.yml`'s package step for each — `FSMP.dds` was the lone miss. Matches the issue's own measurement exactly (4 mirrored, 1 missing, no intentional-exception marker anywhere in `.github/` or `fomod tree/`).

## Fix

Added the missing `cp configs/FSMP.dds "final_package/SKSE/Plugins/hdtSkinnedMeshConfigs/"` line to `build.yml`'s package step, with a comment mirroring the one already on `CMakeLists.txt`'s own `install()` rule for the same file.

## Enforcement

New `.github/workflows/validate-package-payload.yml` (triggers on `src/CMakeLists.txt` or `build.yml` changing): extracts every payload basename from the `install()` block's shipped-config section and fails if `build.yml`'s package step doesn't copy it — so a future file added to one list can't silently miss the other again.

I deliberately chose this standalone parity check over the issue's alternate suggestion ("drive the package step from `cmake --install`"): that would replace the whole packaging mechanism for a Windows FOMOD package, which this environment has no MSVC/CommonLibSSE/vcpkg toolchain to build or verify is behavior-preserving. The parity check is a build-free guard fully achievable and verified here today, and doesn't foreclose that larger refactor later if someone with the real toolchain wants to pursue it.

## Verification (no MSVC/CommonLibSSE/vcpkg in this environment — scoped to files verifiable by inspection alone)

- Ran the new check's exact shell logic locally against the **pre-fix** tree: correctly reports `FSMP.dds` missing (reproduces the issue).
- Ran it again against the **fixed** tree: exits 0, no missing files — mutation-sense proof.
- `python3 -c "import yaml; yaml.safe_load(...)"` on both the edited `build.yml` and the new `validate-package-payload.yml` — both parse cleanly.

## Doc-sync

`README.md` has no mention of the package contents/payload list, so nothing else needed updating.

## Adversarial self-review

(No Task/subagent tool was available in this environment to spawn a blank-context reviewer — noted under NOTABLE FRICTION in the run report — this is my own second-pass read.)

- Checked the marker-based extraction is robust to the actual current text (`# Ship the default global config` / `if("${COPY_OUTPUT}")`) and added an explicit `::error` + `exit 1` if either marker ever goes missing (e.g. the comment gets reworded), rather than silently matching nothing and reporting a vacuous pass.
- Confirmed `FSMPMono.LICENSE.txt` (a second file on the same `install(FILES ...)` line as `FSMPMono.ttf`) is correctly extracted too, not just the first quoted path per line — verified by running the extraction regex locally and inspecting its output before wiring it into the workflow.
- Confirmed the fix doesn't touch any `.cpp`/`.h` file — pure CI/YAML, matching this environment's build-free verification scope.

Closes #463


---
_Generated by [Claude Code](https://claude.ai/code/session_01ETZVSt8qrAu8qEqDUmrrP7)_