### PR TITLE
fix(#466): correct false BUILD_PATTERN_TESTS CI-wiring claim; add wiring guard

### DIFF
--- a/.github/workflows/validate-build-test-flags.yml
+++ b/.github/workflows/validate-build-test-flags.yml
@@ -1,0 +1,84 @@
+name: Validate BUILD_*_TESTS CI wiring
+
+# Cheap, build-free check that every `option(BUILD_..._TESTS ...)` declared in CMakeLists.txt is either
+# turned ON in the main build workflow (.github/workflows/build.yml) or listed below as a documented
+# exception with a reason -- so a future doctest suite can't silently repeat issue #466:
+# BUILD_PATTERN_TESTS/BUILD_CONFIG_TESTS were both declared, both documented in CMakeLists.txt as a "dev/CI
+# tool" (one comment even falsely claimed "CI and local dev turn it ON"), and neither was ever actually
+# turned ON anywhere -- so `config_tests`/`xml_pattern_tests` were compiled and run by nobody, ever, while
+# only the third sibling (BUILD_VALIDATOR_TESTS) was ever wired in. This job stops a fourth suite from
+# joining them unnoticed.
+on:
+  push:
+    paths:
+      - "CMakeLists.txt"
+      - ".github/workflows/build.yml"
+      - ".github/workflows/validate-build-test-flags.yml"
+  pull_request:
+    paths:
+      - "CMakeLists.txt"
+      - ".github/workflows/build.yml"
+      - ".github/workflows/validate-build-test-flags.yml"
+  workflow_dispatch:
+
+# Least privilege: this job only reads the repo to lint text.
+permissions:
+  contents: read
+
+# Supersede in-flight runs for the same ref so a rapid series of pushes doesn't pile up.
+concurrency:
+  group: validate-build-test-flags-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Diff CMakeLists.txt's BUILD_*_TESTS options against build.yml's CMake configure step
+        shell: bash
+        run: |
+          set -uo pipefail
+          fail=0
+          cmake_file="CMakeLists.txt"
+          build_file=".github/workflows/build.yml"
+
+          # Every BUILD_*_TESTS doctest-suite toggle declared in CMakeLists.txt, e.g. BUILD_VALIDATOR_TESTS.
+          names=$(grep -oP '^\s*option\(\K(BUILD_[A-Z0-9_]*_TESTS)(?=\s)' "$cmake_file" | sort -u)
+          if [ -z "$names" ]; then
+            echo "::error file=$cmake_file::found zero BUILD_*_TESTS option() declarations -- has the naming shape changed? Update this check's pattern to match."
+            exit 1
+          fi
+
+          # Suites known NOT to be wired into CI yet, with the reason a human must resolve before removing an
+          # entry. Every name here is a documented, deliberate exception -- never a place to silently grow;
+          # adding a new suite here without ALSO wiring it into build.yml or explaining why not is exactly the
+          # regression this check exists to catch.
+          #
+          # BUILD_PATTERN_TESTS / BUILD_CONFIG_TESTS: never verified to still compile (no C++ toolchain was
+          # available to the audit that found them dead-in-CI). Wiring either into build.yml needs a real
+          # Windows/MSVC/vcpkg CI run proving the suite still builds against the currently-pinned
+          # rapidjson/pugixml/doctest versions before flipping it ON -- see issue #466.
+          exempt="BUILD_PATTERN_TESTS BUILD_CONFIG_TESTS"
+
+          for n in $names; do
+            if grep -qF -- "-D${n}=ON" "$build_file"; then
+              echo "wired: $n"
+              continue
+            fi
+            is_exempt=0
+            for e in $exempt; do
+              [ "$e" = "$n" ] && is_exempt=1 && break
+            done
+            if [ "$is_exempt" = "1" ]; then
+              echo "::notice file=$cmake_file::$n is declared but not wired into CI -- documented exception in this workflow's own 'exempt' list"
+              continue
+            fi
+            echo "::error file=$build_file::$n is declared in $cmake_file's option() list but never turned ON anywhere in $build_file -- CI compiles and runs nothing for this suite. Either add -D${n}=ON to the CMake configure step, or add it to this workflow's documented 'exempt' list with a reason."
+            fail=1
+          done
+
+          exit $fail

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,16 @@ option(BUILD_VALIDATOR_TESTS "Build the validator/XML-reader doctest suite" OFF)
 set(BUILD_TESTS OFF)
 
 # Standalone doctest suite for the SMP XML pattern expander (PLAN smp-xml-patterns, D5). OFF by default so
-# normal/packaged builds stay DLL-only; CI and local dev turn it ON to build + run the suite.
+# normal/packaged builds stay DLL-only. Unlike BUILD_VALIDATOR_TESTS, CI does NOT currently turn this ON --
+# it is a documented exception in .github/workflows/validate-build-test-flags.yml pending a real
+# Windows/MSVC/vcpkg CI run to confirm the suite still compiles (issue #466). Turn it ON locally to build
+# and run the suite in the meantime.
 option(BUILD_PATTERN_TESTS "Build the SMP XML pattern expander doctest suite" OFF)
 
 # Standalone doctest suite for the GlobalConfig JSON (de)serialization. OFF by default and never packaged; it compiles
 # src/GlobalConfig.cpp directly without the game's PCH and links only rapidjson + doctest (no CommonLibSSE/Bullet/TBB),
-# mirroring tests/patterns.
+# mirroring tests/patterns. Also NOT currently turned on by CI -- see BUILD_PATTERN_TESTS's comment above
+# and issue #466; the same documented exception applies here.
 option(BUILD_CONFIG_TESTS "Build the GlobalConfig JSON doctest suite" OFF)
 
 # default definitions


### PR DESCRIPTION
## Root cause

`CMakeLists.txt`'s `BUILD_PATTERN_TESTS` option comment claimed *"CI and local dev turn it ON to build + run the suite."* That's false: grepping every CI workflow, `CMakePresets.json`, and `.pre-commit-config.yaml` shows only `-DBUILD_VALIDATOR_TESTS=ON` (`.github/workflows/build.yml:194`) is ever set anywhere. `BUILD_PATTERN_TESTS` (`xml_pattern_tests`) and `BUILD_CONFIG_TESTS` (`config_tests`) are declared, both documented as "a dev/CI tool", and neither is ever compiled or run by anything.

## What this PR does — and deliberately does NOT do

**Fixes the documentation lie** (`CMakeLists.txt`): corrected both `BUILD_PATTERN_TESTS` and `BUILD_CONFIG_TESTS`'s comments to state their true, current CI status and point at this issue, instead of asserting coverage that doesn't exist.

**Adds enforcement**: `.github/workflows/validate-build-test-flags.yml` — a cheap, build-free job matching the existing `validate-config.yml`/`validate-package-payload.yml` pattern. It parses every `option(BUILD_..._TESTS ...)` in `CMakeLists.txt` and fails if one is neither wired `-D...=ON` in `build.yml` nor listed in the workflow's own documented `exempt` array (currently `BUILD_PATTERN_TESTS`/`BUILD_CONFIG_TESTS`, each with the same reason). This is the class-wide fix: a future fourth `BUILD_*_TESTS` suite can no longer join these two silently — it must be wired in, or explicitly exempted with a reason, in the same PR that adds it.

**Deliberately does NOT flip `BUILD_PATTERN_TESTS`/`BUILD_CONFIG_TESTS` to `ON` in `build.yml`.** The issue itself flags that both suites "may have bit-rotted in the time nothing has compiled them" and explicitly asks for a genuine CI run (not an inspection) proving they still compile against the currently-pinned `rapidjson`/`pugixml`/`doctest` versions before wiring them in. This sandbox has no C++/MSVC/vcpkg toolchain, so that can't be verified here — flipping the flag would be an unverifiable behavioral change to a CI pipeline that's expensive when red. Left open as a smaller, explicitly human-verifiable follow-up (see below); the `exempt` list documents exactly why and points back at this issue.

## Class re-verification (per the issue's own resolution guidance)

Re-swept the whole repo for every place a `BUILD_*_TESTS`-shaped flag is declared or set:
- `option(BUILD_..._TESTS ...)`: exactly 3, all in `CMakeLists.txt` (`BUILD_VALIDATOR_TESTS`, `BUILD_PATTERN_TESTS`, `BUILD_CONFIG_TESTS`) — matches the issue's own count, no further members of the class.
- `-DBUILD_..._TESTS=ON`: exactly 1, `build.yml:194` (`BUILD_VALIDATOR_TESTS`).
- No hits anywhere else (other workflows, `CMakePresets.json`, `.pre-commit-config.yaml`).

## Verification (no C++ toolchain in this sandbox — everything below is inspection + direct execution of the new guard's own shell logic, which needs none)

- Confirmed the YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`) alongside the three pre-existing workflow files.
- Extracted the new job's bash script verbatim and ran it directly against the real repo files: passes today — `wired: BUILD_VALIDATOR_TESTS`, plus a `::notice` for each of the two documented exceptions, exit 0.
- **Mutation-verified the guard** (per this fleet's "does the added test/lint actually FAIL if the fix is reverted" bar): appended a synthetic `option(BUILD_FOO_TESTS "dummy" OFF)` to a scratch copy of `CMakeLists.txt` with no matching `-D...=ON` and no exempt entry → guard fails (exit 1, correct `::error`). Then added `-DBUILD_FOO_TESTS=ON` to a scratch copy of `build.yml` → guard passes again (exit 0). Restored both files from backups afterward (no leftover artifacts in the diff).
- `bash -n` on the extracted script: clean syntax.

## Doc-sync

No other doc references the removed false claim (`README.md` has zero mentions of these build flags or testing at all; no `CONTRIBUTING.md` exists in this repo). `tests/patterns/CMakeLists.txt` and `tests/config/CMakeLists.txt`'s own comments were re-checked and don't make the false claim — only the top-level `CMakeLists.txt` comment did, now fixed.

## Adversarial review

No general-purpose subagent-spawn tool was available in this sandbox (checked via tool search — only teammate messaging exists, which needs an active team). In its place: rigorous mutation-based self-verification of the new guard (both failure and recovery paths, run against real files, not imagined), plus a structural sweep of every possible spot a flag could be hiding, before committing. Noted as friction in this run's report to the orchestrating session.

## Resolution guidance checklist
1. ✅ Re-verified the known sites + grepped for further occurrences — confirmed exactly 3 options, only 1 wired, no fourth suite exists.
2. ⚠️ Partial — root cause (the false doc claim) is fixed everywhere it appeared; the "compile config_tests/xml_pattern_tests in CI" half is deliberately left open, since it needs a real toolchain to verify safely.
3. ✅ Enforcement added: `validate-build-test-flags.yml`, a CI meta-check (no CLAUDE.md/CONTRIBUTING.md exists in this repo to add a routing note to — the workflow's own header comment and inline `exempt`-list comment serve that role).
4. ✅ Intentional exceptions noted: `BUILD_PATTERN_TESTS`/`BUILD_CONFIG_TESTS` are explicitly listed as documented, reasoned exceptions in the new workflow, not silently ignored.

Not closing #466 — this resolves the documentation-lie half plus its enforcement, but the "wire the two suites into CI" half genuinely needs a human with a real Windows/MSVC/vcpkg toolchain to verify before flipping the flags. Referencing but not closing.

Refs #466.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Saar3wzbEF4bnT61vePULX)_