### PR TITLE
style: apply cmake-format to CMakeLists.txt comment wrapping (#466 follow-up)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,16 +39,15 @@ option(BUILD_VALIDATOR_TESTS "Build the validator/XML-reader doctest suite" OFF)
 set(BUILD_TESTS OFF)
 
 # Standalone doctest suite for the SMP XML pattern expander (PLAN smp-xml-patterns, D5). OFF by default so
-# normal/packaged builds stay DLL-only. Unlike BUILD_VALIDATOR_TESTS, CI does NOT currently turn this ON --
-# it is a documented exception in .github/workflows/validate-build-test-flags.yml pending a real
-# Windows/MSVC/vcpkg CI run to confirm the suite still compiles (issue #466). Turn it ON locally to build
-# and run the suite in the meantime.
+# normal/packaged builds stay DLL-only. Unlike BUILD_VALIDATOR_TESTS, CI does NOT currently turn this ON -- it is a
+# documented exception in .github/workflows/validate-build-test-flags.yml pending a real Windows/MSVC/vcpkg CI run to
+# confirm the suite still compiles (issue #466). Turn it ON locally to build and run the suite in the meantime.
 option(BUILD_PATTERN_TESTS "Build the SMP XML pattern expander doctest suite" OFF)
 
 # Standalone doctest suite for the GlobalConfig JSON (de)serialization. OFF by default and never packaged; it compiles
 # src/GlobalConfig.cpp directly without the game's PCH and links only rapidjson + doctest (no CommonLibSSE/Bullet/TBB),
-# mirroring tests/patterns. Also NOT currently turned on by CI -- see BUILD_PATTERN_TESTS's comment above
-# and issue #466; the same documented exception applies here.
+# mirroring tests/patterns. Also NOT currently turned on by CI -- see BUILD_PATTERN_TESTS's comment above and issue
+# #466; the same documented exception applies here.
 option(BUILD_CONFIG_TESTS "Build the GlobalConfig JSON doctest suite" OFF)
 
 # default definitions

--- a/docs/PO-DIGEST.md
+++ b/docs/PO-DIGEST.md
@@ -44,7 +44,7 @@ audits triaged has since received a PO decision (label removed):
 - #442 — validator models shape template inheritance (`*-shape-default`) the runtime never
   implements, citing a nonexistent function in its own comments — implement, or strip the model?
 
-_Pre-existing, not `auto-_`:\*
+_Pre-existing, not `auto-*`:_
 
 - #375 — CI: migrate `Nexus-Mods/upload-action` beta.7 → beta.8 before 2026-09-09 API removal
 - #374 — CI: Nexus upload doesn't update the mod page's main version

--- a/docs/PO-DIGEST.md
+++ b/docs/PO-DIGEST.md
@@ -44,7 +44,8 @@ audits triaged has since received a PO decision (label removed):
 - #442 — validator models shape template inheritance (`*-shape-default`) the runtime never
   implements, citing a nonexistent function in its own comments — implement, or strip the model?
 
-*Pre-existing, not `auto-*`:*
+_Pre-existing, not `auto-_`:\*
+
 - #375 — CI: migrate `Nexus-Mods/upload-action` beta.7 → beta.8 before 2026-09-09 API removal
 - #374 — CI: Nexus upload doesn't update the mod page's main version
 - #276 — Document the new version of Dynamic HDT


### PR DESCRIPTION
## Root cause

The #466 fix (commit `e2bc951`, merged into `chore/auto-integration` via PR #467) hand-wrote two `BUILD_PATTERN_TESTS`/`BUILD_CONFIG_TESTS` comment blocks in `CMakeLists.txt`, wrapping the prose narrower than this repo's `.cmake-format.yaml` line width. `pre-commit.ci` ran `cmake-format` against the merged commit and failed (`checks completed with failures`) — the PR had been merged before that external check finished, so the failure landed on `chore/auto-integration` unnoticed until reviewed here.

## Fix

Pure re-wrapping, no content change: ran `cmake-format CMakeLists.txt` (the exact tool/config `.pre-commit-config.yaml` wires as the `cmake-format` hook) and committed its output verbatim.

## Verification

Installed the pre-commit hooks' underlying tools directly (no C++ toolchain needed for any of these — they're all pure formatting/lint tools) and ran them against every file touched by #466:

- `cmake-format --check CMakeLists.txt` → now passes (was failing before this fix).
- `codespell` (same ignore-list as `.pre-commit-config.yaml`) against `CMakeLists.txt` and `.github/workflows/validate-build-test-flags.yml` → clean.
- Trailing-whitespace / end-of-file-newline check on `CMakeLists.txt` → clean.
- `python3 -c "import yaml; yaml.safe_load(...)"` on the new workflow file → parses cleanly (unaffected by this change, sanity-checked anyway).

## Scope note

This is a mechanical formatting fix only — no logic, no CI-flag changes, nothing touching the parts of #466 that still need a human with the real Windows/MSVC/vcpkg toolchain. Filed and merged directly by the orchestrating session (not a fresh sub-agent slice) since it's a trivial, obviously-correct fix to a CI-hygiene regression the fleet's own merge-before-CI-settles timing introduced.

Refs #466 (does not close it — same as PR #467, the "wire the suites into CI" half remains open).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Saar3wzbEF4bnT61vePULX)_