### PR TITLE
fix: silence GCC warnings in the skinned-mesh physics core

### DIFF
--- a/src/XmlReader.cpp
+++ b/src/XmlReader.cpp
@@ -96,6 +96,8 @@ namespace hdt
 			case Inspected::EndTag:
 				--currentDepth;
 				break;
+			default:
+				break;
 			}
 		}
 	}
@@ -239,6 +241,8 @@ namespace hdt
 				break;
 			case Inspected::EndTag:
 				return ret;
+			default:
+				break;
 			}
 		}
 		return ret;

--- a/src/hdtSkinnedMesh/hdtBoneScaleConstraint.cpp
+++ b/src/hdtSkinnedMesh/hdtBoneScaleConstraint.cpp
@@ -3,7 +3,7 @@
 namespace hdt
 {
 	BoneScaleConstraint::BoneScaleConstraint(SkinnedMeshBone* a, SkinnedMeshBone* b, btTypedConstraint* constraint) :
-		m_boneA(a), m_boneB(b), m_constraint(constraint), m_scaleA(1), m_scaleB(1)
+		m_scaleA(1), m_scaleB(1), m_boneA(a), m_boneB(b), m_constraint(constraint)
 	{
 	}
 

--- a/src/hdtSkinnedMesh/hdtCollider.h
+++ b/src/hdtSkinnedMesh/hdtCollider.h
@@ -54,18 +54,18 @@ namespace hdt
 		Aabb aabbAll;
 		Aabb aabbMe;
 
-		U32 isKinematic;
+		U32 isKinematic = 0;
 
 		Collider* cbuf = nullptr;
-		Aabb* aabb;
-		U32 numCollider;
-		U32 dynCollider;
+		Aabb* aabb = nullptr;
+		U32 numCollider = 0;
+		U32 dynCollider = 0;
 
-		U32 dynChild;
+		U32 dynChild = 0;
 		vectorA16<ColliderTree> children;
 
 		vectorA16<Collider> colliders;
-		U32 key;
+		U32 key = 0;
 
 		void insertCollider(const U32* keys, size_t keyCount, const Collider& c);
 		void exportColliders(vectorA16<Collider>& exportTo);

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
@@ -242,6 +242,7 @@ namespace hdt
 		void dispatch(ColliderTree* a, ColliderTree* b, std::vector<Aabb*>& listA, std::vector<Aabb*>& listB, const Aabb& refinedBForPruningA)
 		{
 			CollisionResult result;
+			result.normOnB.setZero();
 			CollisionResult temp;
 			bool hasResult = false;
 

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshBody.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshBody.cpp
@@ -219,7 +219,7 @@ namespace hdt
 
 		UINT numUsed = 0;
 		std::vector<UINT> map(m_vertices.size());
-		for (int i = 0; i < m_vertices.size(); ++i) {
+		for (size_t i = 0; i < m_vertices.size(); ++i) {
 			if (flags[i]) {
 				m_vertices[numUsed] = m_vertices[i];
 				m_vpos[numUsed] = m_vpos[i];

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshSystem.cpp
@@ -26,7 +26,7 @@ namespace hdt
 
 	void SkinnedMeshSystem::writeTransform()
 	{
-		for (int i = 0; i < m_bones.size(); ++i) {
+		for (size_t i = 0; i < m_bones.size(); ++i) {
 			if (m_bones[i]->m_rig.isKinematicObject()) {
 				continue;
 			}

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.cpp
@@ -50,14 +50,14 @@ namespace hdt
 	SkinnedMeshWorld::~SkinnedMeshWorld()
 	{
 		for (auto system : m_systems) {
-			for (int i = 0; i < system->m_meshes.size(); ++i)
+			for (size_t i = 0; i < system->m_meshes.size(); ++i)
 				removeCollisionObject(system->m_meshes[i].get());
 
-			for (int i = 0; i < system->m_constraints.size(); ++i)
+			for (size_t i = 0; i < system->m_constraints.size(); ++i)
 				if (system->m_constraints[i]->m_constraint)
 					removeConstraint(system->m_constraints[i]->m_constraint);
 
-			for (int i = 0; i < system->m_bones.size(); ++i)
+			for (size_t i = 0; i < system->m_bones.size(); ++i)
 				removeRigidBody(&system->m_bones[i]->m_rig);
 
 			for (auto i : system->m_constraintGroups)
@@ -80,11 +80,11 @@ namespace hdt
 		}
 
 		m_systems.push_back(hdt::make_smart(system));
-		for (int i = 0; i < system->m_meshes.size(); ++i) {
+		for (size_t i = 0; i < system->m_meshes.size(); ++i) {
 			addCollisionObject(system->m_meshes[i].get(), 1, 1);
 		}
 
-		for (int i = 0; i < system->m_bones.size(); ++i) {
+		for (size_t i = 0; i < system->m_bones.size(); ++i) {
 			system->m_bones[i]->m_rig.setActivationState(DISABLE_DEACTIVATION);
 			// 0,0 mask disables the collision of this object on Bullet.
 			addRigidBody(&system->m_bones[i]->m_rig, 0, 0);
@@ -94,7 +94,7 @@ namespace hdt
 			for (auto j : i->m_constraints)
 				addConstraint(j->m_constraint, true);
 
-		for (int i = 0; i < system->m_constraints.size(); ++i)
+		for (size_t i = 0; i < system->m_constraints.size(); ++i)
 			addConstraint(system->m_constraints[i]->m_constraint, true);
 
 		// -10 allows RESET_PHYSICS down the calls. But equality with a float?...
@@ -114,12 +114,12 @@ namespace hdt
 				if (j->m_constraint)
 					removeConstraint(j->m_constraint);
 
-		for (int i = 0; i < system->m_meshes.size(); ++i)
+		for (size_t i = 0; i < system->m_meshes.size(); ++i)
 			removeCollisionObject(system->m_meshes[i].get());
-		for (int i = 0; i < system->m_constraints.size(); ++i)
+		for (size_t i = 0; i < system->m_constraints.size(); ++i)
 			if (system->m_constraints[i]->m_constraint)
 				removeConstraint(system->m_constraints[i]->m_constraint);
-		for (int i = 0; i < system->m_bones.size(); ++i)
+		for (size_t i = 0; i < system->m_bones.size(); ++i)
 			removeRigidBody(&system->m_bones[i]->m_rig);
 
 		std::swap(*idx, m_systems.back());

--- a/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
+++ b/src/hdtSkinnedMesh/hdtSkinnedMeshWorld.h
@@ -46,7 +46,7 @@ namespace hdt
 
 		void writeTransform()
 		{
-			for (int i = 0; i < m_systems.size(); ++i) m_systems[i]->writeTransform();
+			for (size_t i = 0; i < m_systems.size(); ++i) m_systems[i]->writeTransform();
 		}
 
 		void applyGravity() override;

--- a/src/hdtSkinnedMesh/hdtVertex.h
+++ b/src/hdtSkinnedMesh/hdtVertex.h
@@ -6,9 +6,9 @@ namespace hdt
 {
 	struct alignas(16) Vertex
 	{
-		Vertex()
+		Vertex() :
+			m_skinPos(0, 0, 0), m_weight{}, m_boneIdx{}
 		{
-			ZeroMemory(this, sizeof(*this));
 		}
 
 		Vertex(float x, float y, float z) :


### PR DESCRIPTION
Since Outfit Studio builds on Linux/Ubuntu with GCC, I found out about some GCC-specific warnings when integrating HDT into my source.

Making a PR so that our sources match up post-fix.

MSVC reports none of these, so the /W4 /WX Windows build stays green either way, but a GCC build of the same code reports all of them:

- Vertex(): ZeroMemory over a struct holding a btVector3, which has a non-trivial constructor (-Wclass-memaccess). The member init list covers the whole struct.
- ColliderTree: the members filled in while the tree is built were indeterminate until then, and trees are copied before that (-Wmaybe-uninitialized).
- BoneScaleConstraint: mem-init list ordered like the declarations (-Wreorder).
- dispatch(): result.normOnB defined up front, for the negation in the swapping addResult (-Wmaybe-uninitialized).
- XMLReader: the Inspected values the two switches don't act on (-Wswitch).
- size_t loop counters where the bound is a std::vector size (-Wsign-compare).

No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization of collision data and vertex attributes for more predictable behavior.
  * Ensured collision results have a defined surface normal when no collision is detected.
  * Added safer handling for unexpected XML inspection states.

* **Refactor**
  * Updated internal collection indexing for improved type safety and portability.
  * Clarified object initialization without changing visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->